### PR TITLE
refactor: Used DSL instead of default Material Builder for all Material Registries

### DIFF
--- a/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
@@ -92,6 +92,16 @@ fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier)
 }
 
 fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier,
+                               blastEUtOverride: Int, blastDurationOverride: Int): Material.Builder
+{
+    blast { b ->
+        b.temp(temperature, gasTier)
+            .blastStats(blastEUtOverride, blastDurationOverride)
+    }
+    return this
+}
+
+fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier,
                                blastEUtOverride: Int, blastDurationOverride: Int,
                                freezeEUtOverride: Int, freezeDurationOverride: Int): Material.Builder
 {

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
@@ -1,7 +1,11 @@
 package gregtechlite.gtlitecore.api.extension
 
 import gregtech.api.unification.material.Material
+import gregtech.api.unification.material.properties.BlastProperty
+import gregtech.api.unification.material.properties.MaterialToolProperty
 import kotlin.math.pow
+
+// region Functional Utilities
 
 /**
  * Get average RGB color without components of materials.
@@ -57,3 +61,58 @@ fun Material.Builder.colorAverage(vararg inputs: Material): Material.Builder
     color(result)
     return this
 }
+
+// endregion
+
+// region DSL Contexts
+
+fun Material.Builder.toolProp(harvestSpeed: Float, attackDamage: Float, durability: Int, harvestLevel: Int,
+                              builder: MaterialToolProperty.Builder.() -> Unit): Material.Builder
+{
+    toolStats(MaterialToolProperty.Builder.of(harvestSpeed, attackDamage, durability, harvestLevel).apply(builder).build())
+    return this
+}
+
+// endregion
+
+// region Simplifactions
+
+fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier,
+                               blastEUtOverride: Int, blastDurationOverride: Int,
+                               freezeEUtOverride: Int, freezeDurationOverride: Int): Material.Builder
+{
+    blast { b ->
+        b.temp(temperature, gasTier)
+            .blastStats(blastEUtOverride, blastDurationOverride)
+            .vacuumStats(freezeEUtOverride, freezeDurationOverride)
+    }
+    return this
+}
+
+fun Material.Builder.cableProp(vol: Long, amp: Int, loss: Int, isSuperconductor: Boolean = false): Material.Builder
+{
+    cableProperties(vol, amp, loss, isSuperconductor)
+    return this
+}
+
+fun Material.Builder.itemPipeProp(priority: Int, transferRate: Float): Material.Builder
+{
+    itemPipeProperties(priority, transferRate)
+    return this
+}
+
+fun Material.Builder.fluidPipeProp(maxTemperature: Int, transferRate: Int,
+                                   gasProof: Boolean = false, acidProof: Boolean = false,
+                                   cryoProof: Boolean = false, plasmaProof: Boolean = false): Material.Builder
+{
+    fluidPipeProperties(maxTemperature, transferRate, gasProof, acidProof, cryoProof, plasmaProof)
+    return this
+}
+
+fun Material.Builder.rotorProp(speed: Float, damage: Float, durability: Int): Material.Builder
+{
+    rotorStats(speed, damage, durability)
+    return this
+}
+
+// endregion

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
@@ -1,5 +1,6 @@
 package gregtechlite.gtlitecore.api.extension
 
+import gregtech.api.fluids.FluidBuilder
 import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.properties.BlastProperty
 import gregtech.api.unification.material.properties.MaterialToolProperty
@@ -65,6 +66,24 @@ fun Material.Builder.colorAverage(vararg inputs: Material): Material.Builder
 // endregion
 
 // region DSL Contexts
+
+fun Material.Builder.liquid(builder: FluidBuilder.() -> Unit): Material.Builder
+{
+    liquid(FluidBuilder().apply(builder))
+    return this
+}
+
+fun Material.Builder.gas(builder: FluidBuilder.() -> Unit): Material.Builder
+{
+    gas(FluidBuilder().apply(builder))
+    return this
+}
+
+fun Material.Builder.plasma(builder: FluidBuilder.() -> Unit): Material.Builder
+{
+    plasma(FluidBuilder().apply(builder))
+    return this
+}
 
 fun Material.Builder.toolProp(harvestSpeed: Float, attackDamage: Float, durability: Int, harvestLevel: Int): Material.Builder
 {

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialBuilderExt.kt
@@ -66,6 +66,12 @@ fun Material.Builder.colorAverage(vararg inputs: Material): Material.Builder
 
 // region DSL Contexts
 
+fun Material.Builder.toolProp(harvestSpeed: Float, attackDamage: Float, durability: Int, harvestLevel: Int): Material.Builder
+{
+    toolStats(MaterialToolProperty.Builder.of(harvestSpeed, attackDamage, durability, harvestLevel).build())
+    return this
+}
+
 fun Material.Builder.toolProp(harvestSpeed: Float, attackDamage: Float, durability: Int, harvestLevel: Int,
                               builder: MaterialToolProperty.Builder.() -> Unit): Material.Builder
 {
@@ -76,6 +82,14 @@ fun Material.Builder.toolProp(harvestSpeed: Float, attackDamage: Float, durabili
 // endregion
 
 // region Simplifactions
+
+fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier): Material.Builder
+{
+    blast { b ->
+        b.temp(temperature, gasTier)
+    }
+    return this
+}
 
 fun Material.Builder.blastProp(temperature: Int, gasTier: BlastProperty.GasTier,
                                blastEUtOverride: Int, blastDurationOverride: Int,

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialExt.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/extension/MaterialExt.kt
@@ -1,6 +1,57 @@
 package gregtechlite.gtlitecore.api.extension
 
+import gregtech.api.fluids.FluidBuilder
+import gregtech.api.fluids.store.FluidStorageKeys
 import gregtech.api.unification.material.Material
+import gregtech.api.unification.material.properties.DustProperty
+import gregtech.api.unification.material.properties.FluidProperty
+import gregtech.api.unification.material.properties.IngotProperty
+import gregtech.api.unification.material.properties.PropertyKey
 import net.minecraftforge.fluids.FluidStack
 
+// region Regular Convert Methods
+
 fun Material.getFluid(amount: Double): FluidStack = FluidStack(fluid, amount.toInt())
+
+// endregion
+
+// region Short Circuit Properties Setters
+
+fun Material.addIngot()
+{
+    setProperty(PropertyKey.INGOT, IngotProperty())
+}
+
+fun Material.addDust()
+{
+    setProperty(PropertyKey.DUST, DustProperty())
+}
+
+fun Material.addLiquid()
+{
+    setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.LIQUID, FluidBuilder()))
+}
+
+fun Material.addGas()
+{
+    setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.GAS, FluidBuilder()))
+}
+
+fun Material.addPlasma()
+{
+    getProperty(PropertyKey.FLUID).enqueueRegistration(FluidStorageKeys.PLASMA, FluidBuilder())
+}
+
+fun Material.addLiquidAndPlasma()
+{
+    setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.LIQUID, FluidBuilder()))
+    getProperty(PropertyKey.FLUID).enqueueRegistration(FluidStorageKeys.PLASMA, FluidBuilder())
+}
+
+fun Material.addGasAndPlasma()
+{
+    setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.GAS, FluidBuilder()))
+    getProperty(PropertyKey.FLUID).enqueueRegistration(FluidStorageKeys.PLASMA, FluidBuilder())
+}
+
+// endregion

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
@@ -11,7 +11,6 @@ import gregtech.api.GTValues.UXV
 import gregtech.api.GTValues.V
 import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.ZPM
-import gregtech.api.fluids.FluidBuilder
 import gregtech.api.unification.Elements.Fl
 import gregtech.api.unification.Elements.Hs
 import gregtech.api.unification.Elements.Og
@@ -44,6 +43,8 @@ import gregtechlite.gtlitecore.api.extension.blastProp
 import gregtechlite.gtlitecore.api.extension.cableProp
 import gregtechlite.gtlitecore.api.extension.fluidPipeProp
 import gregtechlite.gtlitecore.api.extension.itemPipeProp
+import gregtechlite.gtlitecore.api.extension.liquid
+import gregtechlite.gtlitecore.api.extension.plasma
 import gregtechlite.gtlitecore.api.extension.rotorProp
 import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Adamantium
@@ -251,7 +252,10 @@ object GTLiteElementMaterials
         Plutonium244 = addMaterial(9, "plutonium_244")
         {
             ingot()
-            liquid(FluidBuilder().temperature(913))
+            liquid()
+            {
+                temperature(913)
+            }
             color(0xD82D2D).iconSet(METALLIC)
             element(Pu244)
             flags(STD_METAL, GENERATE_FOIL)
@@ -261,7 +265,10 @@ object GTLiteElementMaterials
         DegenerateRhenium = addMaterial(10, "degenerate_rhenium")
         {
             dust()
-            plasma(FluidBuilder().temperature(1_000_000))
+            plasma()
+            {
+                temperature(1_000_000)
+            }
             iconSet(DEGENERATE)
             element(Rh)
             flags(STD_METAL, NO_UNIFICATION)
@@ -272,7 +279,10 @@ object GTLiteElementMaterials
         Magnetium = addMaterial(11, "magnetium")
         {
             ingot()
-            liquid(FluidBuilder().temperature(2_560_000))
+            liquid()
+            {
+                temperature(2_560_000)
+            }
             iconSet(MAGNETIUM) // Foreground Color: 0xF2F226, Background Color: 0x21A7A7
             element(M)
             flags(EXT2_METAL, NO_UNIFICATION, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
@@ -287,7 +297,10 @@ object GTLiteElementMaterials
         Rhugnor = addMaterial(12, "rhugnor")
         {
             ingot()
-            liquid(FluidBuilder().temperature(9025))
+            liquid()
+            {
+                temperature(9025)
+            }
             color(0xBE00FF).iconSet(METALLIC)
             flags(EXT2_METAL, GENERATE_RING, GENERATE_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
                   GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR)
@@ -308,7 +321,10 @@ object GTLiteElementMaterials
         Hypogen = addMaterial(13, "hypogen")
         {
             ingot()
-            liquid(FluidBuilder().temperature(11530))
+            liquid()
+            {
+                temperature(11530)
+            }
             color(0xDC784B).iconSet(ENRICHED) // Opacity Changing: 5-35 (per 5)
             element(Hy)
             flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROTOR,

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
@@ -105,7 +105,7 @@ object GTLiteElementMaterials
     fun init()
     {
         // 1 Adamantium
-        Adamantium = matCreator(1, "adamantium")
+        Adamantium = addMaterial(1, "adamantium")
         {
             ingot()
             liquid().plasma()
@@ -128,7 +128,7 @@ object GTLiteElementMaterials
         }
 
         // 2 Vibranium
-        Vibranium = matCreator(2, "vibranium")
+        Vibranium = addMaterial(2, "vibranium")
         {
             ingot()
             liquid().plasma()
@@ -151,7 +151,7 @@ object GTLiteElementMaterials
         }
 
         // 3 Taranium
-        Taranium = matCreator(3, "taranium")
+        Taranium = addMaterial(3, "taranium")
         {
             ingot()
             liquid()
@@ -165,7 +165,7 @@ object GTLiteElementMaterials
         }
 
         // 4 Metastable Flerovium
-        MetastableFlerovium = matCreator(4, "metastable_flerovium")
+        MetastableFlerovium = addMaterial(4, "metastable_flerovium")
         {
             ingot()
             liquid().plasma()
@@ -179,7 +179,7 @@ object GTLiteElementMaterials
         }
 
         // 5 Metastable Oganesson
-        MetastableOganesson = matCreator(5, "metastable_oganesson")
+        MetastableOganesson = addMaterial(5, "metastable_oganesson")
         {
             ingot()
             liquid().plasma()
@@ -201,7 +201,7 @@ object GTLiteElementMaterials
         }
 
         // 6 Metastable Hassium
-        MetastableHassium = matCreator(6, "metastable_hassium")
+        MetastableHassium = addMaterial(6, "metastable_hassium")
         {
             ingot()
             liquid().plasma()
@@ -217,7 +217,7 @@ object GTLiteElementMaterials
 
 
         // 7 Cosmic Neutronium
-        CosmicNeutronium = matCreator(7, "cosmic_neutronium")
+        CosmicNeutronium = addMaterial(7, "cosmic_neutronium")
         {
             ingot()
             liquid()
@@ -232,7 +232,7 @@ object GTLiteElementMaterials
         }
 
         // 8 Infinity
-        Infinity = matCreator(8, "infinity")
+        Infinity = addMaterial(8, "infinity")
         {
             ingot()
             liquid()
@@ -248,7 +248,7 @@ object GTLiteElementMaterials
         }
 
         // 9 Plutonium-244
-        Plutonium244 = matCreator(9, "plutonium_244")
+        Plutonium244 = addMaterial(9, "plutonium_244")
         {
             ingot()
             liquid(FluidBuilder().temperature(913))
@@ -258,7 +258,7 @@ object GTLiteElementMaterials
         }
 
         // 10 Degenerate Rhenium
-        DegenerateRhenium = matCreator(10, "degenerate_rhenium")
+        DegenerateRhenium = addMaterial(10, "degenerate_rhenium")
         {
             dust()
             plasma(FluidBuilder().temperature(1_000_000))
@@ -266,11 +266,10 @@ object GTLiteElementMaterials
             element(Rh)
             flags(STD_METAL, NO_UNIFICATION)
         }
-        .setFormula("§cR§de", true)
 
         // TODO: Maybe we needs a renderer which allowed to set foreground and background colors?
         // 11 Magnetium
-        Magnetium = matCreator(11, "magnetium")
+        Magnetium = addMaterial(11, "magnetium")
         {
             ingot()
             liquid(FluidBuilder().temperature(2_560_000))
@@ -285,7 +284,7 @@ object GTLiteElementMaterials
         }
 
         // 12 Rhugnor
-        Rhugnor = matCreator(12, "rhugnor")
+        Rhugnor = addMaterial(12, "rhugnor")
         {
             ingot()
             liquid(FluidBuilder().temperature(9025))
@@ -306,7 +305,7 @@ object GTLiteElementMaterials
         }
 
         // 13 Hypogen
-        Hypogen = matCreator(13, "hypogen")
+        Hypogen = addMaterial(13, "hypogen")
         {
             ingot()
             liquid(FluidBuilder().temperature(11530))
@@ -318,7 +317,7 @@ object GTLiteElementMaterials
         }
 
         // 14 Shirabon
-        Shirabon = matCreator(14, "shirabon")
+        Shirabon = addMaterial(14, "shirabon")
         {
             ingot()
             liquid()
@@ -331,7 +330,7 @@ object GTLiteElementMaterials
 
         // TODO: New renderer with rotate animation.
         // 15 Transcendent Metal
-        TranscendentMetal = matCreator(15, "transcendent_metal")
+        TranscendentMetal = addMaterial(15, "transcendent_metal")
         {
             ingot()
             liquid()
@@ -347,7 +346,7 @@ object GTLiteElementMaterials
         }
 
         // 16 Space Time
-        SpaceTime = matCreator(16, "space_time")
+        SpaceTime = addMaterial(16, "space_time")
         {
             ingot()
             liquid()
@@ -363,7 +362,7 @@ object GTLiteElementMaterials
         }
 
         // 17 Creon
-        Creon = matCreator(17, "creon")
+        Creon = addMaterial(17, "creon")
         {
             ingot()
             liquid().plasma()
@@ -390,7 +389,7 @@ object GTLiteElementMaterials
         }
 
         // 18 Mag Matter
-        MagMatter = matCreator(18, "mag_matter")
+        MagMatter = addMaterial(18, "mag_matter")
         {
             ingot()
             liquid()
@@ -404,7 +403,7 @@ object GTLiteElementMaterials
 
         // TODO: Finished renderer for universium and supported block format iconSet textures.
         // 19 Universium
-        Universium = matCreator(19, "universium")
+        Universium = addMaterial(19, "universium")
         {
             ingot()
             liquid()
@@ -416,7 +415,7 @@ object GTLiteElementMaterials
         }
 
         // 20 Eternity
-        Eternity = matCreator(20, "eternity")
+        Eternity = addMaterial(20, "eternity")
         {
             ingot()
             liquid()
@@ -429,7 +428,7 @@ object GTLiteElementMaterials
         }
 
         // 21 Omnium
-        Omnium = matCreator(21, "omnium")
+        Omnium = addMaterial(21, "omnium")
         {
             ingot()
             liquid()

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteElementMaterials.kt
@@ -16,7 +16,6 @@ import gregtech.api.unification.Elements.Fl
 import gregtech.api.unification.Elements.Hs
 import gregtech.api.unification.Elements.Og
 import gregtech.api.unification.Elements.Rh
-import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.Materials.EXT2_METAL
 import gregtech.api.unification.material.Materials.EXT_METAL
 import gregtech.api.unification.material.Materials.STD_METAL
@@ -37,9 +36,16 @@ import gregtech.api.unification.material.info.MaterialFlags.NO_UNIFICATION
 import gregtech.api.unification.material.info.MaterialIconSet.BRIGHT
 import gregtech.api.unification.material.info.MaterialIconSet.METALLIC
 import gregtech.api.unification.material.info.MaterialIconSet.SHINY
-import gregtech.api.unification.material.properties.BlastProperty
-import gregtech.api.unification.material.properties.MaterialToolProperty
-import gregtechlite.gtlitecore.GTLiteMod
+import gregtech.api.unification.material.properties.BlastProperty.GasTier
+import gregtechlite.gtlitecore.api.MINUTE
+import gregtechlite.gtlitecore.api.SECOND
+import gregtechlite.gtlitecore.api.TICK
+import gregtechlite.gtlitecore.api.extension.blastProp
+import gregtechlite.gtlitecore.api.extension.cableProp
+import gregtechlite.gtlitecore.api.extension.fluidPipeProp
+import gregtechlite.gtlitecore.api.extension.itemPipeProp
+import gregtechlite.gtlitecore.api.extension.rotorProp
+import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Adamantium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CosmicNeutronium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Creon
@@ -52,6 +58,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Magnetium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MetastableFlerovium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MetastableHassium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MetastableOganesson
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Omnium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Plutonium244
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Rhugnor
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Shirabon
@@ -68,6 +75,7 @@ import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.H
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.If
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.M
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.Mx
+import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.Om
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.Pu244
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.Sh
 import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.SpNt
@@ -84,14 +92,9 @@ import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconS
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.INFINITY
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.MAGMATTER
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.MAGNETIUM
+import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.OMNIUM
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.SPACETIME
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.UNIVERSIUM
-import gregtechlite.gtlitecore.api.MINUTE
-import gregtechlite.gtlitecore.api.SECOND
-import gregtechlite.gtlitecore.api.TICK
-import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Omnium
-import gregtechlite.gtlitecore.api.unification.material.element.GTLiteElements.Om
-import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.OMNIUM
 import net.minecraft.init.Enchantments
 
 object GTLiteElementMaterials
@@ -102,340 +105,341 @@ object GTLiteElementMaterials
     fun init()
     {
         // 1 Adamantium
-        Adamantium = Material.Builder(1, GTLiteMod.id("adamantium"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0xFF0040).iconSet(METALLIC)
-            .element(Ad)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR,
-                GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(10501, BlastProperty.GasTier.HIGH) // Tritanium
-                    .blastStats(VA[UV], 45 * SECOND)
-                    .vacuumStats(VA[ZPM], 22 * SECOND + 10 * TICK)
+        Adamantium = matCreator(1, "adamantium")
+        {
+            ingot()
+            liquid().plasma()
+            color(0xFF0040).iconSet(METALLIC)
+            element(Ad)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR,
+                  GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
+            blastProp(10501, GasTier.HIGH, // Tritanium
+                      VA[UV], 45 * SECOND,
+                      VA[ZPM], 22 * SECOND + 10 * TICK)
+            rotorProp(22.0f, 10.0f, 491520)
+            toolProp(140.0F, 95.0F, 49152, 6)
+            {
+                attackSpeed(0.5F)
+                enchantability(32)
+                enchantment(Enchantments.FORTUNE, 5)
+                magnetic()
             }
-            .rotorStats(22.0f, 10.0f, 491520)
-            .toolStats(MaterialToolProperty.Builder.of(140.0F, 95.0F, 49152, 6)
-                .attackSpeed(0.5F).enchantability(32)
-                .enchantment(Enchantments.FORTUNE, 5)
-                .magnetic().build())
-            .cableProperties(V[UHV], 4, 24)
-            .build()
+            cableProp(V[UHV], 4, 24)
+        }
 
         // 2 Vibranium
-        Vibranium = Material.Builder(2, GTLiteMod.id("vibranium"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0xC880FF).iconSet(SHINY)
-            .element(Vb)
-            .flags(EXT2_METAL, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR,
-                GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR,
-                GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROUND, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(12001, BlastProperty.GasTier.HIGHER) // Adamantium
-                    .blastStats(VA[UHV], 75 * SECOND)
-                    .vacuumStats(VA[UV], 42 * SECOND + 15 * TICK)
+        Vibranium = matCreator(2, "vibranium")
+        {
+            ingot()
+            liquid().plasma()
+            color(0xC880FF).iconSet(SHINY)
+            element(Vb)
+            flags(EXT2_METAL, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
+                  GENERATE_RING, GENERATE_ROTOR, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROUND, GENERATE_SPRING_SMALL)
+            blastProp(12001, GasTier.HIGHER, // Adamantium
+                      VA[UHV], 75 * SECOND,
+                      VA[UV], 42 * SECOND + 15 * TICK)
+            toolProp(155.0F, 120.0F, 73728, 7)
+            {
+                attackSpeed(0.8F)
+                enchantability(34)
+                enchantment(Enchantments.SHARPNESS, 10)
+                enchantment(Enchantments.SWEEPING, 5)
+                enchantment(Enchantments.LOOTING, 3)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(155.0F, 120.0F, 73728, 7)
-                .attackSpeed(0.8F).enchantability(34)
-                .enchantment(Enchantments.SHARPNESS, 10)
-                .enchantment(Enchantments.SWEEPING, 5)
-                .enchantment(Enchantments.LOOTING, 3)
-                .magnetic().build())
-            .build()
+        }
 
         // 3 Taranium
-        Taranium = Material.Builder(3, GTLiteMod.id("taranium"))
-            .ingot()
-            .liquid()
-            .color(0x4F404F).iconSet(METALLIC)
-            .element(Tn)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                GENERATE_SPRING_SMALL, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(7000, BlastProperty.GasTier.HIGH) // Naquadah
-                    .blastStats(VA[ZPM], 22 * SECOND)
-                    .vacuumStats(VA[IV], 11 * SECOND)
-            }
-            .cableProperties(V[UHV], 8, 2)
-            .build()
+        Taranium = matCreator(3, "taranium")
+        {
+            ingot()
+            liquid()
+            color(0x4F404F).iconSet(METALLIC)
+            element(Tn)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_SPRING_SMALL, GENERATE_DENSE)
+            blastProp(7000, GasTier.HIGH, // Naquadah
+                      VA[ZPM], 22 * SECOND,
+                      VA[IV], 11 * SECOND)
+            cableProp(V[UHV], 8, 2)
+        }
 
         // 4 Metastable Flerovium
-        MetastableFlerovium = Material.Builder(4, GTLiteMod.id("metastable_flerovium"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0x521973).iconSet(SHINY)
-            .element(Fl)
-            .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_BOLT_SCREW, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(9900, BlastProperty.GasTier.HIGHEST) // Tritanium
-                    .blastStats(VA[UHV], 2 * MINUTE + 35 * SECOND)
-                    .vacuumStats(VA[UV], 40 * SECOND) }
-            .rotorStats(25.0F, 3.0F, 153600)
-            .build()
+        MetastableFlerovium = matCreator(4, "metastable_flerovium")
+        {
+            ingot()
+            liquid().plasma()
+            color(0x521973).iconSet(SHINY)
+            element(Fl)
+            flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_BOLT_SCREW, GENERATE_FOIL)
+            blastProp(9900, GasTier.HIGHEST, // Tritanium
+                      VA[UHV], 2 * MINUTE + 35 * SECOND,
+                      VA[UV], 40 * SECOND)
+            rotorStats(25.0F, 3.0F, 153_600)
+        }
 
         // 5 Metastable Oganesson
-        MetastableOganesson = Material.Builder(5, GTLiteMod.id("metastable_oganesson"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0xE61C24).iconSet(SHINY)
-            .element(Og)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_RING,
-                GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(12380, BlastProperty.GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UEV], 2 * MINUTE)
-                    .vacuumStats(VA[UV], 40 * SECOND)
+        MetastableOganesson = matCreator(5, "metastable_oganesson")
+        {
+            ingot()
+            liquid().plasma()
+            color(0xE61C24).iconSet(SHINY)
+            element(Og)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_RING, GENERATE_DOUBLE_PLATE,
+                  GENERATE_FRAME, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
+            blastProp(12380, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 2 * MINUTE,
+                      VA[UV], 40 * SECOND)
+            toolProp(55.0F, 95.0F, 110592, 7)
+            {
+                attackSpeed(0.2F)
+                enchantability(36)
+                enchantment(Enchantments.MENDING, 3)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(55.0F, 95.0F, 110592, 7)
-                .enchantment(Enchantments.MENDING, 3)
-                .attackSpeed(0.2F).enchantability(36).magnetic().build())
-            .cableProperties(V[UEV], 18, 9)
-            .build()
+            cableProp(V[UEV], 18, 9)
+        }
 
         // 6 Metastable Hassium
-        MetastableHassium = Material.Builder(6, GTLiteMod.id("metastable_hassium"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0x2D3A9D).iconSet(BRIGHT)
-            .element(Hs)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b -> b
-                .temp(12000, BlastProperty.GasTier.HIGHEST) // Adamantium
-                .blastStats(VA[UEV], 4 * MINUTE + 30 * SECOND)
-                .vacuumStats(VA[UV], 1 * MINUTE)
-            }
-            .itemPipeProperties(256, 128F)
-            .cableProperties(V[UEV], 28, 5)
-            .build()
+        MetastableHassium = matCreator(6, "metastable_hassium")
+        {
+            ingot()
+            liquid().plasma()
+            color(0x2D3A9D).iconSet(BRIGHT)
+            element(Hs)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(12000, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 4 * MINUTE + 30 * SECOND,
+                      VA[UV], 1 * MINUTE)
+            cableProp(V[UEV], 28, 5)
+            itemPipeProp(256, 128F)
+        }
+
 
         // 7 Cosmic Neutronium
-        CosmicNeutronium = Material.Builder(7, GTLiteMod.id("cosmic_neutronium"))
-            .ingot()
-            .liquid()
-            .iconSet(COSMIC)
-            .element(SpNt)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR,
-                GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(12600, BlastProperty.GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UEV], 12 * MINUTE)
-                    .vacuumStats(VA[UHV], 4 * MINUTE)
-            }
-            .cableProperties(V[UEV], 24, 4)
-            .build()
+        CosmicNeutronium = matCreator(7, "cosmic_neutronium")
+        {
+            ingot()
+            liquid()
+            iconSet(COSMIC)
+            element(SpNt)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR,
+                  GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
+            blastProp(12600, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 12 * MINUTE,
+                      VA[UHV], 4 * MINUTE)
+            cableProp(V[UEV], 24, 4)
+        }
 
         // 8 Infinity
-        Infinity = Material.Builder(8, GTLiteMod.id("infinity"))
-            .ingot()
-            .liquid()
-            .iconSet(INFINITY)
-            .element(If)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_SMALL_GEAR,
-                GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(12600, BlastProperty.GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UEV], 16 * MINUTE)
-                    .vacuumStats(VA[UHV], 8 * MINUTE)
-            }
-            .cableProperties(V[UEV], 36, 2)
-            .fluidPipeProperties(200_000, 24000, true, true, true, true)
-            .build()
+        Infinity = matCreator(8, "infinity")
+        {
+            ingot()
+            liquid()
+            iconSet(INFINITY)
+            element(If)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE,
+                  GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FRAME)
+            blastProp(12600, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 16 * MINUTE,
+                      VA[UHV], 8 * MINUTE)
+            cableProp(V[UEV], 36, 2)
+            fluidPipeProp(200_000, 24000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 9 Plutonium-244
-        Plutonium244 = Material.Builder(9, GTLiteMod.id("plutonium_244"))
-            .ingot()
-            .liquid(FluidBuilder().temperature(913))
-            .color(0xD82D2D).iconSet(METALLIC)
-            .element(Pu244)
-            .flags(STD_METAL, GENERATE_FOIL)
-            .build()
+        Plutonium244 = matCreator(9, "plutonium_244")
+        {
+            ingot()
+            liquid(FluidBuilder().temperature(913))
+            color(0xD82D2D).iconSet(METALLIC)
+            element(Pu244)
+            flags(STD_METAL, GENERATE_FOIL)
+        }
 
         // 10 Degenerate Rhenium
-        DegenerateRhenium = Material.Builder(10, GTLiteMod.id("degenerate_rhenium"))
-            .dust()
-            .plasma(FluidBuilder()
-                .temperature(1_000_000))
-            .iconSet(DEGENERATE)
-            .element(Rh)
-            .flags(STD_METAL, NO_UNIFICATION)
-            .build()
-            .setFormula("§cR§de", true)
+        DegenerateRhenium = matCreator(10, "degenerate_rhenium")
+        {
+            dust()
+            plasma(FluidBuilder().temperature(1_000_000))
+            iconSet(DEGENERATE)
+            element(Rh)
+            flags(STD_METAL, NO_UNIFICATION)
+        }
+        .setFormula("§cR§de", true)
 
+        // TODO: Maybe we needs a renderer which allowed to set foreground and background colors?
         // 11 Magnetium
-        Magnetium = Material.Builder(11, GTLiteMod.id("magnetium"))
-            .ingot()
-            .liquid(FluidBuilder()
-                .temperature(2_560_000))
-            // TODO Maybe we needs a new renderer? allowed player set color(), colorBg()?
-            .iconSet(MAGNETIUM) // Foreground RGB: F2F226; Background RGB: 21A7A7;
-                                // Layered Halo RGB: F8F8D5; Transition Dir: LD -> RU.
-            .element(M)
-            .flags(EXT2_METAL, NO_UNIFICATION, GENERATE_GEAR, GENERATE_SMALL_GEAR,
-                GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_SPRING, GENERATE_SPRING_SMALL,
-                GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(13900, BlastProperty.GasTier.HIGHEST) // Infinity
-                    .blastStats(VA[UIV], 30 * SECOND)
-                    .vacuumStats(VA[UHV], 15 * SECOND)
-            }
-            .build()
+        Magnetium = matCreator(11, "magnetium")
+        {
+            ingot()
+            liquid(FluidBuilder().temperature(2_560_000))
+            iconSet(MAGNETIUM) // Foreground Color: 0xF2F226, Background Color: 0x21A7A7
+            element(M)
+            flags(EXT2_METAL, NO_UNIFICATION, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
+                  GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROTOR,
+                  GENERATE_ROUND, GENERATE_FRAME)
+            blastProp(13900, GasTier.HIGHEST, // Infinity
+                      VA[UIV], 30 * SECOND,
+                      VA[UHV], 15 * SECOND)
+        }
 
         // 12 Rhugnor
-        Rhugnor = Material.Builder(12, GTLiteMod.id("rhugnor"))
-            .ingot()
-            .liquid(FluidBuilder()
-                .temperature(9025))
-            .color(0xBE00FF).iconSet(METALLIC)
-            .flags(EXT2_METAL, GENERATE_RING, GENERATE_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR)
-            .element(Fs)
-            .toolStats(MaterialToolProperty.Builder.of(76.0F, 110.0F, 165888, 9)
-                .enchantment(Enchantments.EFFICIENCY, 6)
-                .enchantment(Enchantments.FORTUNE, 4)
-                .attackSpeed(0.4F).enchantability(42).magnetic().build())
-            .itemPipeProperties(16384, 256F)
-            .rotorStats(48.0F, 8.0F, 98304)
-            .build()
+        Rhugnor = matCreator(12, "rhugnor")
+        {
+            ingot()
+            liquid(FluidBuilder().temperature(9025))
+            color(0xBE00FF).iconSet(METALLIC)
+            flags(EXT2_METAL, GENERATE_RING, GENERATE_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR)
+            element(Fs)
+            toolProp(76.0F, 110.0F, 165888, 9)
+            {
+                attackSpeed(0.4F)
+                enchantability(42)
+                enchantment(Enchantments.EFFICIENCY, 6)
+                enchantment(Enchantments.FORTUNE, 4)
+                magnetic()
+            }
+            itemPipeProp(16384, 256F)
+            rotorProp(48.0F, 8.0F, 98_304)
+        }
 
         // 13 Hypogen
-        Hypogen = Material.Builder(13, GTLiteMod.id("hypogen"))
-            .ingot()
-            .liquid(FluidBuilder()
-                .temperature(11530))
-            .color(0xDC784B).iconSet(ENRICHED) // Opacity: 5-10-15-20-25-30-35
-            .element(Hy)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_ROTOR, GENERATE_FRAME)
-            .cableProperties(V[UIV], 16, 4)
-            .build()
+        Hypogen = matCreator(13, "hypogen")
+        {
+            ingot()
+            liquid(FluidBuilder().temperature(11530))
+            color(0xDC784B).iconSet(ENRICHED) // Opacity Changing: 5-35 (per 5)
+            element(Hy)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_ROTOR,
+                  GENERATE_FRAME)
+            cableProp(V[UIV], 16, 4)
+        }
 
         // 14 Shirabon
-        Shirabon = Material.Builder(14, GTLiteMod.id("shirabon"))
-            .ingot()
-            .liquid()
-            .color(0xE0156D).iconSet(BRIGHT)
-            .element(Sh)
-            .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING,
-                   GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING,
-                   GENERATE_ROTOR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_NANITE)
-            .rotorStats(144.0F, 2.4F, 786432)
-            .build()
+        Shirabon = matCreator(14, "shirabon")
+        {
+            ingot()
+            liquid()
+            color(0xE0156D).iconSet(BRIGHT)
+            element(Sh)
+            flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_ROTOR,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_FRAME, GENERATE_ROUND, GENERATE_NANITE)
+            rotorProp(144.0F, 2.4F, 786_432)
+        }
 
+        // TODO: New renderer with rotate animation.
         // 15 Transcendent Metal
-        TranscendentMetal = Material.Builder(15, GTLiteMod.id("transcendent_metal"))
-            .ingot()
-            .liquid()
-            .color(0x1A1A1A).iconSet(METALLIC) // TODO Rotated animations.
-            .element(Tsx)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR,
-                GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE, GENERATE_NANITE)
-            .blast { b ->
-                b.temp(23500, BlastProperty.GasTier.HIGHEST) // Error
-                    .blastStats(VA[UXV], 3 * MINUTE)
-                    .vacuumStats(VA[UIV], 2 * MINUTE)
-            }
-            .fluidPipeProperties(800_000, 40000, true, true, true, true)
-            .build()
+        TranscendentMetal = matCreator(15, "transcendent_metal")
+        {
+            ingot()
+            liquid()
+            color(0x1A1A1A).iconSet(METALLIC)
+            element(Tsx)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR,
+                  GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE,
+                  GENERATE_NANITE)
+            blastProp(23500, GasTier.HIGHEST, // Eternity Plus
+                      VA[UXV], 3 * MINUTE,
+                      VA[UIV], 2 * MINUTE)
+            fluidPipeProp(800_000, 40000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 16 Space Time
-        SpaceTime = Material.Builder(16, GTLiteMod.id("space_time"))
-            .ingot()
-            .liquid()
-            .iconSet(SPACETIME)
-            .element(Spx)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR)
-            .blast { b ->
-                b.temp(16201, BlastProperty.GasTier.HIGHEST) // Halkonite Steel
-                    .blastStats(VA[UXV], 4 * MINUTE + 30 * SECOND)
-                    .vacuumStats(VA[UIV], 3 * MINUTE + 25 * SECOND)
-            }
-            .cableProperties(V[UXV], 96,16)
-            .fluidPipeProperties(1_200_000, 65000, true, true, true, true)
-            .build()
+        SpaceTime = matCreator(16, "space_time")
+        {
+            ingot()
+            liquid()
+            iconSet(SPACETIME)
+            element(Spx)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME,
+                  GENERATE_GEAR, GENERATE_SMALL_GEAR)
+            blastProp(16201, GasTier.HIGHEST, // Halkonite Steel
+                      VA[UXV], 4 * MINUTE + 30 * SECOND,
+                      VA[UIV], 3 * MINUTE + 25 * SECOND)
+            cableProp(V[UXV], 96,16)
+            fluidPipeProp(1_200_000, 65000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 17 Creon
-        Creon = Material.Builder(17, GTLiteMod.id("creon"))
-            .ingot()
-            .liquid()
-            .plasma()
-            .color(0x460046).iconSet(SHINY)
-            .element(Crx)
-            .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING,
-                   GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING,
-                   GENERATE_ROTOR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(24000, BlastProperty.GasTier.HIGHEST) // Error
-                    .blastStats(VA[UXV], 2 * MINUTE + 40 * SECOND)
-                    .vacuumStats(VA[UIV], 1 * MINUTE + 45 * SECOND)
+        Creon = matCreator(17, "creon")
+        {
+            ingot()
+            liquid().plasma()
+            color(0x460046).iconSet(SHINY)
+            element(Crx)
+            flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_RING,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_FOIL,
+                  GENERATE_FINE_WIRE)
+            blastProp(24000, GasTier.HIGHEST, // Eternity Plus
+                      VA[UXV], 2 * MINUTE + 40 * SECOND,
+                      VA[UIV], 1 * MINUTE + 45 * SECOND)
+            toolProp(160.0F, 320.0F, 62_914_560, 20)
+            {
+                attackSpeed(0.2F)
+                enchantability(40)
+                enchantment(Enchantments.SHARPNESS, 20)
+                enchantment(Enchantments.SWEEPING, 20)
+                enchantment(Enchantments.LOOTING, 20)
+                enchantment(Enchantments.FORTUNE, 20)
+                magnetic()
+                unbreakable()
             }
-            .toolStats(MaterialToolProperty.Builder.of(160.0F, 320.0F, 62914560, 20)
-                .attackSpeed(0.2F).enchantability(40)
-                .enchantment(Enchantments.SHARPNESS, 20)
-                .enchantment(Enchantments.SWEEPING, 20)
-                .enchantment(Enchantments.LOOTING, 20)
-                .enchantment(Enchantments.FORTUNE, 20)
-                .magnetic()
-                .unbreakable()
-                .build())
-            .rotorStats(576.0F, 64.0F, 62914560)
-            .build()
+            rotorProp(576.0F, 64.0F, 62914560)
+        }
 
         // 18 Mag Matter
-        MagMatter = Material.Builder(18, GTLiteMod.id("mag_matter"))
-            .ingot()
-            .liquid()
-            .iconSet(MAGMATTER)
-            .element(Mx)
-            .flags(EXT2_METAL, NO_UNIFICATION, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_RING,
-                GENERATE_ROTOR, GENERATE_FRAME, GENERATE_NANITE)
-            .cableProperties(V[UXV], 56, 14)
-            .build()
+        MagMatter = matCreator(18, "mag_matter")
+        {
+            ingot()
+            liquid()
+            iconSet(MAGMATTER)
+            element(Mx)
+            flags(EXT2_METAL, NO_UNIFICATION, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_RING, GENERATE_ROTOR, GENERATE_FRAME,
+                  GENERATE_NANITE)
+            cableProp(V[UXV], 56, 14)
+        }
 
+        // TODO: Finished renderer for universium and supported block format iconSet textures.
         // 19 Universium
-        Universium = Material.Builder(19, GTLiteMod.id("universium"))
-            .ingot()
-            .liquid()
-            .iconSet(UNIVERSIUM)
-            .element(Ux)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
-                GENERATE_NANITE, GENERATE_FRAME)
-            .cableProperties(V[OpV], 144, 8)
-            .build()
+        Universium = matCreator(19, "universium")
+        {
+            ingot()
+            liquid()
+            iconSet(UNIVERSIUM)
+            element(Ux)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_NANITE,
+                  GENERATE_FRAME)
+            cableProp(V[OpV], 144, 8)
+        }
 
         // 20 Eternity
-        Eternity = Material.Builder(20, GTLiteMod.id("eternity"))
-            .ingot()
-            .liquid()
-            .iconSet(ETERNITY)
-            .element(En)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                GENERATE_NANITE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_GEAR,
-                GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_ROUND)
-            .cableProperties(V[OpV], 180, 40)
-            .build()
+        Eternity = matCreator(20, "eternity")
+        {
+            ingot()
+            liquid()
+            iconSet(ETERNITY)
+            element(En)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_NANITE,
+                  GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_FRAME,
+                  GENERATE_ROUND)
+            cableProperties(V[OpV], 180, 40)
+        }
 
         // 21 Omnium
-        Omnium = Material.Builder(21, GTLiteMod.id("omnium"))
-            .ingot()
-            .liquid()
-            .iconSet(OMNIUM)
-            .element(Om)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME, GENERATE_ROTOR,
-                   GENERATE_ROUND, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR, GENERATE_SMALL_GEAR)
-            .cableProperties(V[MAX] - 1, 360, 20)
-            .build()
+        Omnium = matCreator(21, "omnium")
+        {
+            ingot()
+            liquid()
+            iconSet(OMNIUM)
+            element(Om)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR, GENERATE_SMALL_GEAR)
+            cableProp(V[MAX] - 1, 360, 20)
+        }
+
     }
 
     // @formatter:on

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
@@ -13,7 +13,6 @@ import gregtech.api.GTValues.UXV
 import gregtech.api.GTValues.V
 import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.ZPM
-import gregtech.api.fluids.FluidBuilder
 import gregtech.api.fluids.attribute.FluidAttributes
 import gregtech.api.unification.material.Materials.AceticAcid
 import gregtech.api.unification.material.Materials.Actinium
@@ -563,6 +562,9 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RheniumPentachlor
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumThiocyanate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThalliumChloride
 import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconSet.CHROMATIC
+import gregtechlite.gtlitecore.api.extension.liquid
+import gregtechlite.gtlitecore.api.extension.gas
+import gregtechlite.gtlitecore.api.extension.plasma
 
 object GTLiteFirstDegreeMaterials
 {
@@ -1013,7 +1015,10 @@ object GTLiteFirstDegreeMaterials
         // 2048 Molybdenum Flue
         MolybdenumFlue = addMaterial(2048, "molybdenum_flue")
         {
-            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
             color(0x39194A)
             components(Rhenium, 1, Oxygen, 2, RareEarth, 1)
             flags(DISABLE_DECOMPOSITION)
@@ -1030,7 +1035,10 @@ object GTLiteFirstDegreeMaterials
         // 2050 Trace Rhenium Flue
         TraceRheniumFlue = addMaterial(2050, "trace_rhenium_flue")
         {
-            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
             color(0x96D6D5)
             components(Rhenium, 1, Oxygen, 2)
             flags(DISABLE_DECOMPOSITION)
@@ -1332,7 +1340,10 @@ object GTLiteFirstDegreeMaterials
         // 2083 Hydrobromic Acid
         HydrobromicAcid = addMaterial(2083, "hydrobromic_acid")
         {
-            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
             color(0x8D1212)
             components(Hydrogen, 1, Bromine, 1)
         }
@@ -1655,7 +1666,10 @@ object GTLiteFirstDegreeMaterials
         // 2121 Hexachloroplatinic Acid
         HexachloroplatinicAcid = addMaterial(2121, "hexachloroplatinic_acid")
         {
-            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            liquid()
+            {
+                attribute(FluidAttributes.ACID)
+            }
             color(0xFEF4D1)
             components(Hydrogen, 2, Platinum, 1, Chlorine, 6)
         }
@@ -1845,7 +1859,10 @@ object GTLiteFirstDegreeMaterials
         // 2143 Hydroselenic Acid
         HydroselenicAcid = addMaterial(2143, "hydroselenic_acid")
         {
-            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            liquid()
+            {
+                attribute(FluidAttributes.ACID)
+            }
             color(0xDBC3B5)
             components(Hydrogen, 2, Selenium, 1, Oxygen, 4)
             flags(DISABLE_DECOMPOSITION)
@@ -1902,7 +1919,10 @@ object GTLiteFirstDegreeMaterials
         PotassiumHydroxide = addMaterial(2148, "potassium_hydroxide")
         {
             dust()
-            liquid(FluidBuilder().temperature(633))
+            liquid()
+            {
+                temperature(633)
+            }
             color(0xFA9849)
             components(Potassium, 1, Oxygen, 1, Hydrogen, 1)
         }
@@ -2023,7 +2043,10 @@ object GTLiteFirstDegreeMaterials
         // 2162 Pertechnetate
         Pertechnetate = addMaterial(2162, "pertechnetate")
         {
-            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
             color(0xCC3300)
             flags(DISABLE_DECOMPOSITION)
         }
@@ -2234,7 +2257,11 @@ object GTLiteFirstDegreeMaterials
         // 2185 Flerovium-Ytterbium Plasma
         FleroviumYtterbiumPlasma = addMaterial(2185, "flerovium_ytterbium_plasma")
         {
-            plasma(FluidBuilder().temperature(10550).translation("gregtech.fluid.generic"))
+            plasma()
+            {
+                temperature(10550)
+                translation("gregtech.fluid.generic")
+            }
             colorAverage()
             components(MetastableFlerovium, 1, Ytterbium, 1)
             flags(DISABLE_DECOMPOSITION)
@@ -2406,7 +2433,7 @@ object GTLiteFirstDegreeMaterials
         }
 
         // 2202 Lutetium Manganese Germanium
-        // This is not a reality magnetic material... it is a fantastic permanent magnet? ^^ i think it is well in Gregtech.
+        // This is not a reality magnetic material... it is a fantastic permanent magnet? ^^ I think it is well in Gregtech.
         LutetiumManganeseGermanium = addMaterial(2202, "lutetium_manganese_germanium")
         {
             ingot()
@@ -2868,7 +2895,10 @@ object GTLiteFirstDegreeMaterials
         ActiniumSuperhydride = addMaterial(2253, "actinium_superhydride")
         {
             dust()
-            plasma(FluidBuilder().temperature(500_000))
+            plasma()
+            {
+                temperature(500_000)
+            }
             color(Actinium.materialRGB * 9 / 8).iconSet(SHINY)
             components(Actinium, 1, Hydrogen, 12)
             flags(DISABLE_DECOMPOSITION)
@@ -3014,7 +3044,10 @@ object GTLiteFirstDegreeMaterials
         // 2268 Tetrafluoroboric Acid
         TetrafluoroboricAcid = addMaterial(2268, "tetrafluoroboric_acid")
         {
-            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
             color(0x83A731)
             components(Hydrogen, 1, Boron, 1, Fluorine, 4)
             flags(DISABLE_DECOMPOSITION)
@@ -3129,13 +3162,21 @@ object GTLiteFirstDegreeMaterials
         // 2281 Heavy Quark Enriched Mixture
         HeavyQuarkEnrichedMixture = addMaterial(2281, "heavy_quark_enriched_mixture")
         {
-            plasma(FluidBuilder().translation("gregtech.fluid.generic").temperature(400_000_000).customStill())
+            plasma()
+            {
+                temperature(400_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
         }
 
         // 2282 Deuterium-Superheavy Mixture
         DeuteriumSuperheavyMixture = addMaterial(2282, "deuterium_superheavy_mixture")
         {
-            liquid(FluidBuilder().temperature(18240))
+            liquid()
+            {
+                temperature(18240)
+            }
             color(0x7B9EF8)
             components(Deuterium, 2, MetastableHassium, 1, MetastableFlerovium, 1, MetastableOganesson, 1)
             flags(DISABLE_DECOMPOSITION)
@@ -3146,11 +3187,15 @@ object GTLiteFirstDegreeMaterials
         {
             ingot()
             liquid()
-            plasma(FluidBuilder().temperature(1_600_000_000).customStill())
-            .color(0x5DBD3A).iconSet(BRIGHT)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_GEAR,
-                   GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL,
-                   GENERATE_FOIL, GENERATE_FINE_WIRE)
+            plasma()
+            {
+                temperature(1_600_000_000)
+                customStill()
+            }
+            color(0x5DBD3A).iconSet(BRIGHT)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_GEAR,
+                  GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_FOIL, GENERATE_FINE_WIRE)
             rotorProp(48.0f, 16.0f, 983040)
             fluidPipeProp(200_000, 10000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
         }
@@ -3258,7 +3303,10 @@ object GTLiteFirstDegreeMaterials
         // Add centrifuging decomposition by OpticalCircuits.
         DielectricFormationMixture = addMaterial(2295, "dielectric_formation_mixture")
         {
-            liquid(FluidBuilder().temperature(209))
+            liquid()
+            {
+                temperature(209)
+            }
             color(0xE62A35)
             components(ManganeseDifluoride, 1, ZincSulfide, 1, TantalumPentoxide, 1, Rutile, 1, Ethanol, 1)
             flags(DISABLE_DECOMPOSITION)
@@ -3267,7 +3315,10 @@ object GTLiteFirstDegreeMaterials
         // 2296 Chloroauric Acid
         ChloroauricAcid = addMaterial(2296, "chloroauric_acid")
         {
-            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
             color(0xD1B62C)
             components(Hydrogen, 1, Gold, 1, Chlorine, 4)
         }
@@ -3392,7 +3443,11 @@ object GTLiteFirstDegreeMaterials
         HarmonicPhononMatter = addMaterial(2309, "harmonic_phonon_matter")
         {
             ingot()
-            liquid(FluidBuilder().temperature(2_000_000_000).translation("gregtech.fluid.generic"))
+            liquid()
+            {
+                temperature(2_000_000_000)
+                translation("gregtech.fluid.generic")
+            }
             iconSet(GLITCH)
             flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME)
             blastProp(26000, GasTier.HIGHEST, // Eternity Plus
@@ -3558,7 +3613,10 @@ object GTLiteFirstDegreeMaterials
         // 2326 Hydromoscovic Acid
         HydromoscovicAcid = addMaterial(2326, "hydromoscovic_acid")
         {
-            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            liquid()
+            {
+                attribute(FluidAttributes.ACID)
+            }
             components(Hydrogen, 1, Moscovium, 1, Oxygen, 4)
         }
 
@@ -3740,7 +3798,10 @@ object GTLiteFirstDegreeMaterials
         // 2347 Hexafluorophosphoric Acid
         HexafluorophosphoricAcid = addMaterial(2347, "hexafluorophosphoric_acid")
         {
-            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
             color(0xFCC782)
             components(Hydrogen, 1, Phosphorus, 1, Fluorine, 6)
         }

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
@@ -2803,8 +2803,7 @@ object GTLiteFirstDegreeMaterials
             flags(NO_SMASHING, NO_WORKING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
                   GENERATE_LENS)
             blastProp(1163, GasTier.MID, // Cupronickel
-                      VA[IV], 7 * SECOND + 4 * TICK,
-                      VA[HV], 2 * SECOND + 16 * TICK)
+                      VA[IV], 7 * SECOND + 4 * TICK)
         }
 
         // 2246 Potassium Tertbutoxide

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteFirstDegreeMaterials.kt
@@ -15,7 +15,6 @@ import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.ZPM
 import gregtech.api.fluids.FluidBuilder
 import gregtech.api.fluids.attribute.FluidAttributes
-import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.Materials.AceticAcid
 import gregtech.api.unification.material.Materials.Actinium
 import gregtech.api.unification.material.Materials.Aluminium
@@ -187,9 +186,7 @@ import gregtech.api.unification.material.info.MaterialIconSet.ROUGH
 import gregtech.api.unification.material.info.MaterialIconSet.RUBY
 import gregtech.api.unification.material.info.MaterialIconSet.SAND
 import gregtech.api.unification.material.info.MaterialIconSet.SHINY
-import gregtech.api.unification.material.properties.BlastProperty
-import gregtech.api.unification.material.properties.MaterialToolProperty
-import gregtechlite.gtlitecore.GTLiteMod
+import gregtech.api.unification.material.properties.BlastProperty.GasTier
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumOxalate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumSuperhydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumTrihydride
@@ -541,7 +538,13 @@ import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconS
 import gregtechlite.gtlitecore.api.MINUTE
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
+import gregtechlite.gtlitecore.api.extension.blastProp
+import gregtechlite.gtlitecore.api.extension.cableProp
 import gregtechlite.gtlitecore.api.extension.colorAverage
+import gregtechlite.gtlitecore.api.extension.fluidPipeProp
+import gregtechlite.gtlitecore.api.extension.itemPipeProp
+import gregtechlite.gtlitecore.api.extension.rotorProp
+import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AstatineAzide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumDichloride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumManganate
@@ -569,3011 +572,3197 @@ object GTLiteFirstDegreeMaterials
     fun init()
     {
         // 2001 Dolomite
-        Dolomite = Material.Builder(2001, GTLiteMod.id("dolomite"))
-            .dust()
-            .ore()
-            .color(0xBBB8B2).iconSet(DULL)
-            .components(Calcium, 1, Magnesium, 1, Carbon, 2, Oxygen, 6)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("CaMg(CO3)2", true)
+        Dolomite = addMaterial(2001, "dolomite")
+        {
+            dust()
+            ore()
+            color(0xBBB8B2).iconSet(DULL)
+            components(Calcium, 1, Magnesium, 1, Carbon, 2, Oxygen, 6)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2002 Tanzanite
-        Tanzanite = Material.Builder(2002, GTLiteMod.id("tanzanite"))
-            .gem(2)
-            .ore()
-            .color(0x4000C8).iconSet(GEM_VERTICAL)
-            .components(Calcium, 2, Aluminium, 3, Silicon, 3, Hydrogen, 1, Oxygen, 13)
-            .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, CRYSTALLIZABLE, GENERATE_LENS)
-            .build()
+        Tanzanite = addMaterial(2002, "tanzanite")
+        {
+            gem(2)
+            ore()
+            color(0x4000C8).iconSet(GEM_VERTICAL)
+            components(Calcium, 2, Aluminium, 3, Silicon, 3, Hydrogen, 1, Oxygen, 13)
+            flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, CRYSTALLIZABLE, GENERATE_LENS)
+        }
 
         // 2003 Azurite
-        Azurite = Material.Builder(2003, GTLiteMod.id("azurite"))
-            .dust()
-            .ore()
-            .color(0x2E6DCE).iconSet(DULL)
-            .components(Copper, 3, Carbon, 2, Oxygen, 8, Hydrogen, 2)
-            .build()
-            .setFormula("Cu3(CO3)2(OH)2", true)
+        Azurite = addMaterial(2003, "azurite")
+        {
+            dust()
+            ore()
+            color(0x2E6DCE).iconSet(DULL)
+            components(Copper, 3, Carbon, 2, Oxygen, 8, Hydrogen, 2)
+        }
 
         // 2004 Forsterite
-        Forsterite = Material.Builder(2004, GTLiteMod.id("forsterite"))
-            .gem()
-            .ore()
-            .color(0x1D640F).iconSet(LAPIS)
-            .components(Magnesium, 2, Silicon, 1, Oxygen, 4)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, GENERATE_BOULE)
-            .build()
-            .setFormula("Mg2(SiO4)", true)
+        Forsterite = addMaterial(2004, "forsterite")
+        {
+            gem()
+            ore()
+            color(0x1D640F).iconSet(LAPIS)
+            components(Magnesium, 2, Silicon, 1, Oxygen, 4)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2005 Augite
-        Augite = Material.Builder(2005, GTLiteMod.id("augite"))
-            .dust()
-            .ore()
-            .color(0x1B1717).iconSet(ROUGH)
-            .components(Calcium, 2, Magnesium, 3, Iron, 3, Silicon, 8, Oxygen, 24)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("(Ca2MgFe)(MgFe)2(Si2O6)4", true)
+        Augite = addMaterial(2005, "augite")
+        {
+            dust()
+            ore()
+            color(0x1B1717).iconSet(ROUGH)
+            components(Calcium, 2, Magnesium, 3, Iron, 3, Silicon, 8, Oxygen, 24)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2006 Lizardite
-        Lizardite = Material.Builder(2006, GTLiteMod.id("lizardite"))
-            .dust()
-            .ore()
-            .color(0xA79E42).iconSet(DULL)
-            .components(Magnesium, 3, Silicon, 2, Oxygen, 9, Hydrogen, 4)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("Mg3Si2O5(OH)4", true)
+        Lizardite = addMaterial(2006, "lizardite")
+        {
+            dust()
+            ore()
+            color(0xA79E42).iconSet(DULL)
+            components(Magnesium, 3, Silicon, 2, Oxygen, 9, Hydrogen, 4)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2007 Muscovite
-        Muscovite = Material.Builder(2007, GTLiteMod.id("muscovite"))
-            .dust()
-            .ore()
-            .color(0x8B876A)
-            .components(Potassium, 1, Aluminium, 3, Silicon, 3, Hydrogen, 10, Oxygen, 12)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("KAl2(AlSi3O10)(OH)2", true)
+        Muscovite = addMaterial(2007, "muscovite")
+        {
+            dust()
+            ore()
+            color(0x8B876A)
+            components(Potassium, 1, Aluminium, 3, Silicon, 3, Hydrogen, 10, Oxygen, 12)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2008 Clinochlore
-        Clinochlore = Material.Builder(2008, GTLiteMod.id("clinochlore"))
-            .gem()
-            .ore()
-            .color(0x303E38).iconSet(EMERALD)
-            .components(Magnesium, 5, Aluminium, 2, Silicon, 3, Hydrogen, 8, Oxygen, 18)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
-            .setFormula("Mg5Al2Si3O10(OH)8", true)
+        Clinochlore = addMaterial(2008, "clinochlore")
+        {
+            gem()
+            ore()
+            color(0x303E38).iconSet(EMERALD)
+            components(Magnesium, 5, Aluminium, 2, Silicon, 3, Hydrogen, 8, Oxygen, 18)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2009 Albite
-        Albite = Material.Builder(2009, GTLiteMod.id("albite"))
-            .gem()
-            .ore()
-            .color(0xC4A997).iconSet(CERTUS)
-            .components(Sodium, 1, Aluminium, 1, Silicon, 3, Oxygen, 8)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Albite = addMaterial(2009, "albite")
+        {
+            gem()
+            ore()
+            color(0xC4A997).iconSet(CERTUS)
+            components(Sodium, 1, Aluminium, 1, Silicon, 3, Oxygen, 8)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2010 Fluorite
-        Fluorite = Material.Builder(2010, GTLiteMod.id("fluorite"))
-            .gem()
-            .ore()
-            .color(0x276A4C).iconSet(GEM_HORIZONTAL)
-            .components(Calcium, 1, Fluorine, 2)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, GENERATE_BOULE)
-            .build()
+        Fluorite = addMaterial(2010, "fluorite")
+        {
+            gem()
+            ore()
+            color(0x276A4C).iconSet(GEM_HORIZONTAL)
+            components(Calcium, 1, Fluorine, 2)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2011 Anorthite
-        Anorthite = Material.Builder(2011, GTLiteMod.id("anorthite"))
-            .gem()
-            .ore()
-            .color(0x595853).iconSet(CERTUS)
-            .components(Calcium, 1, Aluminium, 2, Silicon, 2, Oxygen, 8)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Anorthite = addMaterial(2011, "anorthite")
+        {
+            gem()
+            ore()
+            color(0x595853).iconSet(CERTUS)
+            components(Calcium, 1, Aluminium, 2, Silicon, 2, Oxygen, 8)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2012 Oligoclase
-        Oligoclase = Material.Builder(2012, GTLiteMod.id("oligoclase"))
-            .gem()
-            .ore()
-            .color(0xC4A997).iconSet(CERTUS)
-            .components(Sodium, 1, Aluminium, 1, Silicon, 3, Oxygen, 8)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Oligoclase = addMaterial(2012, "oligoclase")
+        {
+            gem()
+            ore()
+            color(0xC4A997).iconSet(CERTUS)
+            components(Sodium, 1, Aluminium, 1, Silicon, 3, Oxygen, 8)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2013 Labradorite
-        Labradorite = Material.Builder(2013, GTLiteMod.id("labradorite"))
-            .gem()
-            .ore()
-            .color(0x5C7181).iconSet(RUBY)
-            .components(Albite, 2, Anorthite, 3)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Labradorite = addMaterial(2013, "labradorite")
+        {
+            gem()
+            ore()
+            color(0x5C7181).iconSet(RUBY)
+            components(Albite, 2, Anorthite, 3)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2014 Bytownite
-        Bytownite = Material.Builder(2014, GTLiteMod.id("bytownite"))
-            .gem()
-            .ore()
-            .color(0xC99C67).iconSet(LAPIS)
-            .components(Albite, 1, Anorthite, 4)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Bytownite = addMaterial(2014, "bytownite")
+        {
+            gem()
+            ore()
+            color(0xC99C67).iconSet(LAPIS)
+            components(Albite, 1, Anorthite, 4)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2015 Tenorite
-        Tenorite = Material.Builder(2015, GTLiteMod.id("tenorite"))
-            .dust()
-            .ore()
-            .color(0x443744).iconSet(DULL)
-            .components(Copper, 1, Oxygen, 1)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
+        Tenorite = addMaterial(2015, "tenorite")
+        {
+            dust()
+            ore()
+            color(0x443744).iconSet(DULL)
+            components(Copper, 1, Oxygen, 1)
+            flags(DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2016 Cuprite
-        Cuprite = Material.Builder(2016, GTLiteMod.id("cuprite"))
-            .dust()
-            .ore()
-            .color(0x99292E).iconSet(DULL)
-            .components(Copper, 2, Oxygen, 1)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
+        Cuprite = addMaterial(2016, "cuprite")
+        {
+            dust()
+            ore()
+            color(0x99292E).iconSet(DULL)
+            components(Copper, 2, Oxygen, 1)
+            flags(DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2017 Wollastonite
-        Wollastonite = Material.Builder(2017, GTLiteMod.id("wollastonite"))
-            .dust()
-            .ore()
-            .color(0xDFDFDF).iconSet(ROUGH)
-            .components(Calcium, 1, Silicon, 1, Oxygen, 3)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
+        Wollastonite = addMaterial(2017, "wollastonite")
+        {
+            dust()
+            ore()
+            color(0xDFDFDF).iconSet(ROUGH)
+            components(Calcium, 1, Silicon, 1, Oxygen, 3)
+            flags(DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2018 Fluorapatite
-        Fluorapatite = Material.Builder(2018, GTLiteMod.id("fluorapatite"))
-            .gem()
-            .ore()
-            .color(0x4FB3D8).iconSet(QUARTZ)
-            .components(Calcium, 5, Phosphorus, 3, Oxygen, 12, Fluorine, 1)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING, HIGH_SIFTER_OUTPUT, GENERATE_LENS, GENERATE_BOULE)
-            .build()
-            .setFormula("Ca5(PO4)3F", true)
+        Fluorapatite = addMaterial(2018, "fluorapatite")
+        {
+            gem()
+            ore()
+            color(0x4FB3D8).iconSet(QUARTZ)
+            components(Calcium, 5, Phosphorus, 3, Oxygen, 12, Fluorine, 1)
+            flags(DECOMPOSITION_BY_ELECTROLYZING, HIGH_SIFTER_OUTPUT, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2019 Kaolinite
-        Kaolinite = Material.Builder(2019, GTLiteMod.id("kaolinite"))
-            .dust()
-            .ore()
-            .color(0xDBCAC6).iconSet(DULL)
-            .components(Aluminium, 2, Silicon, 2, Hydrogen, 4, Oxygen, 9)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
+        Kaolinite = addMaterial(2019, "kaolinite")
+        {
+            dust()
+            ore()
+            color(0xDBCAC6).iconSet(DULL)
+            components(Aluminium, 2, Silicon, 2, Hydrogen, 4, Oxygen, 9)
+            flags(DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2020 Lignite
-        Lignite = Material.Builder(2020, GTLiteMod.id("lignite"))
-            .gem(0, 80 * SECOND)
-            .ore()
-            .color(6571590)
-            .iconSet(LIGNITE)
-            .flags(FLAMMABLE, DISABLE_DECOMPOSITION, NO_SMELTING, NO_SMASHING, MORTAR_GRINDABLE)
-            .components(Carbon, 3, Water, 1)
-            .build()
-            .setFormula("C3(H2O)", true)
+        Lignite = addMaterial(2020, "lignite")
+        {
+            gem(0, 80 * SECOND)
+            ore()
+            color(6571590).iconSet(LIGNITE)
+            components(Carbon, 3, Water, 1)
+            flags(FLAMMABLE, DISABLE_DECOMPOSITION, NO_SMELTING, NO_SMASHING, MORTAR_GRINDABLE)
+        }
 
         // 2021 Firestone
-        Firestone = Material.Builder(2021, GTLiteMod.id("firestone"))
-            .gem(1, 3200)
-            .ore()
-            .color(0xC81400)
-            .iconSet(QUARTZ)
-            .flags(NO_SMASHING, NO_SMELTING)
-            .components(SiliconDioxide, 2, Flint, 1, Pyrite, 1)
-            .build()
-            .setFormula("(SiO2)3(FeS2)?", true)
+        Firestone = addMaterial(2021, "firestone")
+        {
+            gem(1, 160 * SECOND)
+            ore()
+            color(0xC81400).iconSet(QUARTZ)
+            flags(NO_SMASHING, NO_SMELTING)
+            components(SiliconDioxide, 2, Flint, 1, Pyrite, 1)
+        }
 
         // 2022 Iron (III) Sulfate
-        Iron3Sulfate = Material.Builder(2022, GTLiteMod.id("iron_sulfate"))
-            .dust()
-            .color(0xB09D99)
-            .components(Iron, 2, Sulfur, 3, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Fe2(SO4)3", true)
+        Iron3Sulfate = addMaterial(2022, "iron_sulfate")
+        {
+            dust()
+            color(0xB09D99)
+            components(Iron, 2, Sulfur, 3, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2023 Celestine
-        Celestine = Material.Builder(2023, GTLiteMod.id("celestine"))
-            .gem(2)
-            .ore()
-            .color(0x4AE3E6).iconSet(OPAL)
-            .components(Strontium, 1, Sulfur, 1, Oxygen, 4)
-            .flags(CRYSTALLIZABLE, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
-            .build()
+        Celestine = addMaterial(2023, "celestine")
+        {
+            gem(2)
+            ore()
+            color(0x4AE3E6).iconSet(OPAL)
+            components(Strontium, 1, Sulfur, 1, Oxygen, 4)
+            flags(CRYSTALLIZABLE, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2024 Strontianite
-        Strontianite = Material.Builder(2024, GTLiteMod.id("strontianite"))
-            .dust()
-            .ore()
-            .color(0x1DAFD3).iconSet(SAND)
-            .components(Strontium, 1, Carbon, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Strontianite = addMaterial(2024, "strontianite")
+        {
+            dust()
+            ore()
+            color(0x1DAFD3).iconSet(SAND)
+            components(Strontium, 1, Carbon, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2025 Strontium Oxide
-        StrontiumOxide = Material.Builder(2025, GTLiteMod.id("strontium_oxide"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Strontium, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        StrontiumOxide = addMaterial(2025, "strontium_oxide")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Strontium, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2026 Strontium Sulfide
-        StrontiumSulfide = Material.Builder(2026, GTLiteMod.id("strontium_sulfide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Strontium, 1, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        StrontiumSulfide = addMaterial(2026, "strontium_sulfide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Strontium, 1, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2027 Alumina
-        Alumina = Material.Builder(2027, GTLiteMod.id("alumina"))
-            .dust()
-            .color(0x78C3EB).iconSet(METALLIC)
-            .components(Aluminium, 2, Oxygen, 3)
-            .build()
+        Alumina = addMaterial(2027, "alumina")
+        {
+            dust()
+            color(0x78C3EB).iconSet(METALLIC)
+            components(Aluminium, 2, Oxygen, 3)
+        }
 
         // 2028 Phlogopite
-        Phlogopite = Material.Builder(2028, GTLiteMod.id("phlogopite"))
-            .dust()
-            .ore()
-            .color(0xDCDD0D)
-            .components(Potassium, 1, Magnesium, 3, Aluminium, 1, Silicon, 3, Oxygen, 10, Fluorine, 2)
-            .flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("KMg3(AlSi3O10)F2", true)
+        Phlogopite = addMaterial(2028, "phlogopite")
+        {
+            dust()
+            ore()
+            color(0xDCDD0D)
+            components(Potassium, 1, Magnesium, 3, Aluminium, 1, Silicon, 3, Oxygen, 10, Fluorine, 2)
+            flags(NO_SMASHING, DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 2029 Baddeleyite
-        Baddeleyite = Material.Builder(2029, GTLiteMod.id("baddeleyite"))
-            .gem()
-            .ore()
-            .color(0x689F9F).iconSet(GEM_HORIZONTAL)
-            .components(Zirconium, 1, Oxygen, 2)
-            .flags(HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
-            .build()
+        Baddeleyite = addMaterial(2029, "baddeleyite")
+        {
+            gem()
+            ore()
+            color(0x689F9F).iconSet(GEM_HORIZONTAL)
+            components(Zirconium, 1, Oxygen, 2)
+            flags(HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2030 Nephelite
-        Nephelite = Material.Builder(2030, GTLiteMod.id("nephelite"))
-            .gem()
-            .ore()
-            .color(0xE56842).iconSet(CERTUS)
-            .components(Potassium, 1, Sodium, 3, Aluminium, 4, Silicon, 4, Oxygen, 16)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
-            .setFormula("KNa3(AlSiO4)4", true)
+        Nephelite = addMaterial(2030, "nephelite")
+        {
+            gem()
+            ore()
+            color(0xE56842).iconSet(CERTUS)
+            components(Potassium, 1, Sodium, 3, Aluminium, 4, Silicon, 4, Oxygen, 16)
+            flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2031 Aegirine
-        Aegirine = Material.Builder(2031, GTLiteMod.id("aegirine"))
-            .gem()
-            .ore()
-            .color(0x4ACA3B).iconSet(EMERALD)
-            .components(Sodium, 1, Iron, 1, Silicon, 2, Oxygen, 6)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Aegirine = addMaterial(2031, "aegirine")
+        {
+            gem()
+            ore()
+            color(0x4ACA3B).iconSet(EMERALD)
+            components(Sodium, 1, Iron, 1, Silicon, 2, Oxygen, 6)
+            flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2032 Niobium Pentoxide
-        NiobiumPentoxide = Material.Builder(2032, GTLiteMod.id("niobium_pentoxide"))
-            .dust()
-            .color(0xBAB0C3).iconSet(ROUGH)
-            .components(Niobium, 2, Oxygen, 5)
-            .build()
+        NiobiumPentoxide = addMaterial(2032, "niobium_pentoxide")
+        {
+            dust()
+            color(0xBAB0C3).iconSet(ROUGH)
+            components(Niobium, 2, Oxygen, 5)
+        }
 
         // 2033 Tantalum Pentoxide
-        TantalumPentoxide = Material.Builder(2033, GTLiteMod.id("tantalum_pentoxide"))
-            .dust()
-            .color(0x72728A).iconSet(ROUGH)
-            .components(Tantalum, 2, Oxygen, 5)
-            .build()
+        TantalumPentoxide = addMaterial(2033, "tantalum_pentoxide")
+        {
+            dust()
+            color(0x72728A).iconSet(ROUGH)
+            components(Tantalum, 2, Oxygen, 5)
+        }
 
         // 2034 Calcium Difluoride
-        CalciumDifluoride = Material.Builder(2034, GTLiteMod.id("calcium_difluoride"))
-            .dust()
-            .color(0xFFFC9E).iconSet(ROUGH)
-            .components(Calcium, 1, Fluorine, 2)
-            .build()
+        CalciumDifluoride = addMaterial(2034, "calcium_difluoride")
+        {
+            dust()
+            color(0xFFFC9E).iconSet(ROUGH)
+            components(Calcium, 1, Fluorine, 2)
+        }
 
         // 2035 Manganese Difluoride
-        ManganeseDifluoride = Material.Builder(2035, GTLiteMod.id("manganese_difluoride"))
-            .dust()
-            .color(0xEF4B3D).iconSet(ROUGH)
-            .components(Manganese, 1, Fluorine, 2)
-            .build()
+        ManganeseDifluoride = addMaterial(2035, "manganese_difluoride")
+        {
+            dust()
+            color(0xEF4B3D).iconSet(ROUGH)
+            components(Manganese, 1, Fluorine, 2)
+        }
 
         // 2036 Heavy Alkali Chlorides Solution
-        HeavyAlkaliChloridesSolution = Material.Builder(2036, GTLiteMod.id("heavy_alkali_chlorides_solution"))
-            .liquid()
-            .color(0x8F5353)
-            .components(Rubidium, 1, Caesium, 2, Chlorine, 6, Water, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(RbCl)(CsCl)2Cl3(H2O)2", true)
+        HeavyAlkaliChloridesSolution = addMaterial(2036, "heavy_alkali_chlorides_solution")
+        {
+            liquid()
+            color(0x8F5353)
+            components(Rubidium, 1, Caesium, 2, Chlorine, 6, Water, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2037 Tin Dichloride
-        TinDichloride = Material.Builder(2037, GTLiteMod.id("tin_dichloride"))
-            .dust()
-            .color(0xDBDBDB).iconSet(METALLIC)
-            .components(Tin, 1, Chlorine, 2)
-            .build()
+        TinDichloride = addMaterial(2037, "tin_dichloride")
+        {
+            dust()
+            color(0xDBDBDB).iconSet(METALLIC)
+            components(Tin, 1, Chlorine, 2)
+        }
 
         // 2038 Tin Tetrachloride
-        TinTetrachloride = Material.Builder(2038, GTLiteMod.id("tin_tetrachloride"))
-            .dust()
-            .color(0x33BBF5).iconSet(METALLIC)
-            .components(Tin, 1, Chlorine, 4)
-            .build()
+        TinTetrachloride = addMaterial(2038, "tin_tetrachloride")
+        {
+            dust()
+            color(0x33BBF5).iconSet(METALLIC)
+            components(Tin, 1, Chlorine, 4)
+        }
 
         // 2039 Caesium Hexachlorotinate
-        CaesiumHexachlorotinate = Material.Builder(2039, GTLiteMod.id("caesium_hexachlorotinate"))
-            .dust()
-            .color(0xBDAD88).iconSet(SHINY)
-            .components(Caesium, 2, Tin, 1, Chlorine, 6)
-            .build()
+        CaesiumHexachlorotinate = addMaterial(2039, "caesium_hexachlorotinate")
+        {
+            dust()
+            color(0xBDAD88).iconSet(SHINY)
+            components(Caesium, 2, Tin, 1, Chlorine, 6)
+        }
 
         // 2040 Rubidium Hexachlorotinate
-        RubidiumHexachlorotinate = Material.Builder(2040, GTLiteMod.id("rubidium_hexachlorotinate"))
-            .dust()
-            .color(0xBD888A).iconSet(METALLIC)
-            .components(Rubidium, 2, Tin, 1, Chlorine, 6)
-            .build()
+        RubidiumHexachlorotinate = addMaterial(2040, "rubidium_hexachlorotinate")
+        {
+            dust()
+            color(0xBD888A).iconSet(METALLIC)
+            components(Rubidium, 2, Tin, 1, Chlorine, 6)
+        }
 
         // 2041 Cryolite
-        Cryolite = Material.Builder(2041, GTLiteMod.id("cryolite"))
-            .gem()
-            .ore()
-            .color(0xBFEFFF).iconSet(QUARTZ)
-            .components(Sodium, 3, Aluminium, 1, Fluorine, 6)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Cryolite = addMaterial(2041, "cryolite")
+        {
+            gem()
+            ore()
+            color(0xBFEFFF).iconSet(QUARTZ)
+            components(Sodium, 3, Aluminium, 1, Fluorine, 6)
+            flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2042 Aluminium Hydroxide
-        AluminiumHydroxide = Material.Builder(2042, GTLiteMod.id("aluminium_hydroxide"))
-            .dust()
-            .color(0xBEBEC8)
-            .components(Aluminium, 1, Oxygen, 3, Hydrogen, 3)
-            .build()
-            .setFormula("Al(OH)3", true)
+        AluminiumHydroxide = addMaterial(2042, "aluminium_hydroxide")
+        {
+            dust()
+            color(0xBEBEC8)
+            components(Aluminium, 1, Oxygen, 3, Hydrogen, 3)
+        }
 
         // 2043 Sodium Aluminate
-        SodiumAluminate = Material.Builder(2043, GTLiteMod.id("sodium_aluminate"))
-            .dust()
-            .colorAverage()
-            .components(Sodium, 1, Aluminium, 1, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumAluminate = addMaterial(2043, "sodium_aluminate")
+        {
+            dust()
+            colorAverage()
+            components(Sodium, 1, Aluminium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
-        // 2044 Sodium Carbonate
-        SodiumCarbonate = Material.Builder(2044, GTLiteMod.id("sodium_carbonate"))
-            .liquid()
-            .colorAverage()
-            .components(SodaAsh, 1, Water, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        // 2044 Sodium Carbonate (Solution)
+        SodiumCarbonate = addMaterial(2044, "sodium_carbonate")
+        {
+            liquid()
+            colorAverage()
+            components(SodaAsh, 1, Water, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2045 Aluminium Sulfate
-        AluminiumSulfate = Material.Builder(2045, GTLiteMod.id("aluminium_sulfate"))
-            .dust()
-            .colorAverage()
-            .components(Aluminium, 2, Sulfur, 3, Oxygen, 12)
-            .build()
-            .setFormula("Al2(SO4)3", true)
+        AluminiumSulfate = addMaterial(2045, "aluminium_sulfate")
+        {
+            dust()
+            colorAverage()
+            components(Aluminium, 2, Sulfur, 3, Oxygen, 12)
+        }
 
         // 2046 ZSM-5
-        ZSM5 = Material.Builder(2046, GTLiteMod.id("zsm_5"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE)
-            .components(Sodium, 1, Aluminium, 2, Sulfur, 3, Silicon, 2, Oxygen, 18, Hydrogen, 4)
-            .build()
-            .setFormula("Na(Al2(SO4)3)(SiO2)2(H2O)2", true)
+        ZSM5 = addMaterial(2046, "zsm_5")
+        {
+            dust() // Na(Al2(SO4)3)(SiO2)2(H2O)2
+            colorAverage().iconSet(SHINY)
+            components(Sodium, 1, AluminiumSulfate, 1, SiliconDioxide, 2, Water, 2)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE)
+        }
 
         // 2047 Molybdenum Trioxide
-        MolybdenumTrioxide = Material.Builder(2047, GTLiteMod.id("molybdenum_trioxide"))
-            .dust()
-            .color(0xCBCFDA)
-            .iconSet(ROUGH)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Molybdenum, 1, Oxygen, 3)
-            .build()
+        MolybdenumTrioxide = addMaterial(2047, "molybdenum_trioxide")
+        {
+            dust()
+            color(0xCBCFDA).iconSet(ROUGH)
+            components(Molybdenum, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2048 Molybdenum Flue
-        MolybdenumFlue = Material.Builder(2048, GTLiteMod.id("molybdenum_flue"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x39194A)
-            .components(Rhenium, 1, Oxygen, 2, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        MolybdenumFlue = addMaterial(2048, "molybdenum_flue")
+        {
+            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            color(0x39194A)
+            components(Rhenium, 1, Oxygen, 2, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2049 Lead Dichloride
-        LeadDichloride = Material.Builder(2049, GTLiteMod.id("lead_dichloride"))
-            .dust()
-            .color(0xF3F3F3).iconSet(ROUGH)
-            .components(Lead, 1, Chlorine, 2)
-            .build()
+        LeadDichloride = addMaterial(2049, "lead_dichloride")
+        {
+            dust()
+            color(0xF3F3F3).iconSet(ROUGH)
+            components(Lead, 1, Chlorine, 2)
+        }
 
         // 2050 Trace Rhenium Flue
-        TraceRheniumFlue = Material.Builder(2050, GTLiteMod.id("trace_rhenium_flue"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x96D6D5)
-            .components(Rhenium, 1, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TraceRheniumFlue = addMaterial(2050, "trace_rhenium_flue")
+        {
+            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            color(0x96D6D5)
+            components(Rhenium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2051 Perrhenic Acid
-        PerrhenicAcid = Material.Builder(2051, GTLiteMod.id("perrhenic_acid"))
-            .dust()
-            .color(0xE6DC70).iconSet(SHINY)
-            .components(Hydrogen, 1, Rhenium, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PerrhenicAcid = addMaterial(2051, "perrhenic_acid")
+        {
+            dust()
+            color(0xE6DC70).iconSet(SHINY)
+            components(Hydrogen, 1, Rhenium, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2052 Ammonium Perrhenate
-        AmmoniumPerrhenate = Material.Builder(2052, GTLiteMod.id("ammonium_perrhenate"))
-            .dust()
-            .color(0xA69970).iconSet(METALLIC)
-            .components(Nitrogen, 1, Hydrogen, 4, Rhenium, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        AmmoniumPerrhenate = addMaterial(2052, "ammonium_perrhenate")
+        {
+            dust()
+            color(0xA69970).iconSet(METALLIC)
+            components(Nitrogen, 1, Hydrogen, 4, Rhenium, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2053 Jade
-        Jade = Material.Builder(2053, GTLiteMod.id("jade"))
-            .gem(2)
-            .ore()
-            .color(0x006400).iconSet(RUBY)
-            .components(Sodium, 1, Aluminium, 1, Silicon, 2, Oxygen, 6)
-            .flags(CRYSTALLIZABLE, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Jade = addMaterial(2053, "jade")
+        {
+            gem(2)
+            ore()
+            color(0x006400).iconSet(RUBY)
+            components(Sodium, 1, Aluminium, 1, Silicon, 2, Oxygen, 6)
+            flags(CRYSTALLIZABLE, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2054 Jasper
-        Jasper = Material.Builder(2054, GTLiteMod.id("jasper"))
-            .gem(2)
-            .ore()
-            .color(0xC85050).iconSet(EMERALD)
-            .components(Calcium, 1, Magnesium, 5, Oxygen, 24, Hydrogen, 2, Silicon, 8)
-            .flags(HIGH_SIFTER_OUTPUT, CRYSTALLIZABLE, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
-            .setFormula("CaMg5(OH)2(Si4O11)2", true)
+        Jasper = addMaterial(2054, "jasper")
+        {
+            gem(2)
+            ore()
+            color(0xC85050).iconSet(EMERALD)
+            components(Calcium, 1, Magnesium, 5, Oxygen, 24, Hydrogen, 2, Silicon, 8)
+            flags(HIGH_SIFTER_OUTPUT, CRYSTALLIZABLE, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2055 Picotite
-        Picotite = Material.Builder(2055, GTLiteMod.id("picotite"))
-            .gem(3)
-            .ore(2, 3)
-            .color(0x931C24).iconSet(DIAMOND)
-            .components(Iron, 1, Chrome, 2, Oxygen, 4)
-            .flags(GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
-            .build()
+        Picotite = addMaterial(2055, "picotite")
+        {
+            gem(3)
+            ore(2, 3)
+            color(0x931C24).iconSet(DIAMOND)
+            components(Iron, 1, Chrome, 2, Oxygen, 4)
+            flags(GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2056 Manganese Monoxide
-        ManganeseMonoxide = Material.Builder(2056, GTLiteMod.id("manganese_monoxide"))
-            .dust()
-            .color(0x472400)
-            .components(Manganese, 1, Oxygen, 1)
-            .build()
+        ManganeseMonoxide = addMaterial(2056, "manganese_monoxide")
+        {
+            dust()
+            color(0x472400)
+            components(Manganese, 1, Oxygen, 1)
+        }
 
         // 2057 Lead Chromate
-        LeadChromate = Material.Builder(2057, GTLiteMod.id("lead_chromate"))
-            .dust()
-            .color(0xFFFB00).iconSet(SHINY)
-            .components(Lead, 1, Chrome, 1, Oxygen, 4)
-            .build()
+        LeadChromate = addMaterial(2057, "lead_chromate")
+        {
+            dust()
+            color(0xFFFB00).iconSet(SHINY)
+            components(Lead, 1, Chrome, 1, Oxygen, 4)
+        }
 
         // 2058 Lead Nitrate
-        LeadNitrate = Material.Builder(2058, GTLiteMod.id("lead_nitrate"))
-            .dust()
-            .color(0xFFFFFF).iconSet(SHINY)
-            .components(Lead, 1, Nitrogen, 2, Oxygen, 6)
-            .build()
-            .setFormula("Pb(NO3)2", true)
+        LeadNitrate = addMaterial(2058, "lead_nitrate")
+        {
+            dust()
+            color(0xFFFFFF).iconSet(SHINY)
+            components(Lead, 1, Nitrogen, 2, Oxygen, 6)
+        }
 
         // 2059 Cobalt Aluminate
-        CobaltAluminate = Material.Builder(2059,  GTLiteMod.id("cobalt_aluminate"))
-            .dust()
-            .color(0x1605FF).iconSet(SHINY)
-            .components(Cobalt, 1, Aluminium, 2, Oxygen, 4)
-            .build()
+        CobaltAluminate = addMaterial(2059, "cobalt_aluminate")
+        {
+            dust()
+            color(0x1605FF).iconSet(SHINY)
+            components(Cobalt, 1, Aluminium, 2, Oxygen, 4)
+        }
 
         // 2060 Orpiment
-        Orpiment = Material.Builder(2060, GTLiteMod.id("orpiment"))
-            .gem()
-            .ore()
-            .color(0xEBD352).iconSet(EMERALD)
-            .components(Arsenic, 2, Sulfur, 3)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Orpiment = addMaterial(2060, "orpiment")
+        {
+            gem()
+            ore()
+            color(0xEBD352).iconSet(EMERALD)
+            components(Arsenic, 2, Sulfur, 3)
+            flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2061 Sodium Chlorate
-        SodiumChlorate = Material.Builder(2061, GTLiteMod.id("sodium_chlorate"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Sodium, 1,  Chlorine, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumChlorate = addMaterial(2061, "sodium_chlorate")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Sodium, 1,  Chlorine, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2062 Sodium Perchlorate
-        SodiumPerchlorate = Material.Builder(2062, GTLiteMod.id("sodium_perchlorate"))
-            .dust()
-            .color(Salt.materialRGB).iconSet(ROUGH)
-            .components(Sodium, 1, Chlorine, 1, Oxygen, 4)
-            .build()
+        SodiumPerchlorate = addMaterial(2062, "sodium_perchlorate")
+        {
+            dust()
+            color(Salt.materialRGB).iconSet(ROUGH)
+            components(Sodium, 1, Chlorine, 1, Oxygen, 4)
+        }
 
         // 2063 Sodium Hypochlorite
-        SodiumHypochlorite = Material.Builder(2063, GTLiteMod.id("sodium_hypochlorite"))
-            .dust()
-            .color(0x778D56).iconSet(SHINY)
-            .components(Sodium, 1, Chlorine, 1, Oxygen, 1)
-            .build()
+        SodiumHypochlorite = addMaterial(2063, "sodium_hypochlorite")
+        {
+            dust()
+            color(0x778D56).iconSet(SHINY)
+            components(Sodium, 1, Chlorine, 1, Oxygen, 1)
+        }
 
         // 2064 Tungsten Trioxide
-        TungstenTrioxide = Material.Builder(2064, GTLiteMod.id("tungsten_trioxide"))
-            .dust()
-            .color(0xC7D300).iconSet(DULL)
-            .components(Tungsten, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TungstenTrioxide = addMaterial(2064, "tungsten_trioxide")
+        {
+            dust()
+            color(0xC7D300).iconSet(DULL)
+            components(Tungsten, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2065 Strontium Ferrite
-        StrontiumFerrite = Material.Builder(2065, GTLiteMod.id("strontium_ferrite"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(MAGNETIC)
-            .components(Strontium, 1, Iron, 12, Oxygen, 19)
-            .flags(GENERATE_ROD, GENERATE_RING)
-            .blast { b ->
-                b.temp(3000, BlastProperty.GasTier.MID)
-                    .blastStats(VA[EV], 40 * SECOND)
-                    .vacuumStats(VA[MV], 10 * SECOND)
-            }
-            .build()
+        StrontiumFerrite = addMaterial(2065, "strontium_ferrite")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(MAGNETIC)
+            components(Strontium, 1, Iron, 12, Oxygen, 19)
+            flags(GENERATE_ROD, GENERATE_RING)
+            blastProp(3000, GasTier.MID, // Nichrome
+                      VA[EV], 40 * SECOND,
+                      VA[MV], 10 * SECOND)
+        }
 
         // 2066 Titanium Nitrate
-        TitaniumNitrate = Material.Builder(2066, GTLiteMod.id("titanium_nitrate"))
-            .dust()
-            .colorAverage()
-            .components(Titanium, 1, Nitrogen, 4, Oxygen, 12)
-            .build()
-            .setFormula("Ti(NO3)4", true)
+        TitaniumNitrate = addMaterial(2066, "titanium_nitrate")
+        {
+            dust()
+            colorAverage()
+            components(Titanium, 1, Nitrogen, 4, Oxygen, 12)
+        }
 
         // 2067 Lithium Titanate
-        LithiumTitanate = Material.Builder(2067, GTLiteMod.id("lithium_titanate"))
-            .ingot()
-            .fluid()
-            .color(0xFE71A9).iconSet(SHINY)
-            .components(Lithium, 2, Titanium, 1, Oxygen, 3)
-            .flags(EXT2_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_DOUBLE_PLATE, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_RING, GENERATE_SMALL_GEAR,
-                GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(3100, BlastProperty.GasTier.MID) // Nichrome
-                    .blastStats(VA[EV], 16 * SECOND)
-                    .vacuumStats(VA[MV], 8 * SECOND)
+        LithiumTitanate = addMaterial(2067, "lithium_titanate")
+        {
+            ingot()
+            fluid()
+            color(0xFE71A9).iconSet(SHINY)
+            components(Lithium, 2, Titanium, 1, Oxygen, 3)
+            flags(EXT2_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_GEAR, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
+            blastProp(3100, GasTier.MID, // Nichrome
+                      VA[EV], 16 * SECOND,
+                      VA[MV], 8 * SECOND)
+            toolProp(8.5F, 7.0F, 2304, 4)
+            {
+                magnetic()
             }
-            .toolStats(MaterialToolProperty(8.5F, 7.0F, 2304, 4))
-            .rotorStats(8.5f, 4.0f, 3200)
-            .fluidPipeProperties(2830, 200, true, true, false, false)
-            .build()
+            rotorProp(8.5f, 4.0f, 3200)
+            fluidPipeProp(2830, 200, gasProof = true, acidProof = true)
+        }
 
         // 2068 Palladium Nitrate
-        PalladiumNitrate = Material.Builder(2068, GTLiteMod.id("palladium_nitrate"))
-            .dust()
-            .color(0x82312A).iconSet(METALLIC)
-            .components(Palladium, 1, Nitrogen, 2, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Pd(NO3)2", true)
+        PalladiumNitrate = addMaterial(2068, "palladium_nitrate")
+        {
+            dust()
+            color(0x82312A).iconSet(METALLIC)
+            components(Palladium, 1, Nitrogen, 2, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2069 Palladium Acetate
-        PalladiumAcetate = Material.Builder(2069, GTLiteMod.id("palladium_acetate"))
-            .dust()
-            .color(0x693C2D).iconSet(SHINY)
-            .components(Palladium, 1, AceticAcid, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Pd(CH3COOH)2", true)
+        PalladiumAcetate = addMaterial(2069, "palladium_acetate")
+        {
+            dust()
+            color(0x693C2D).iconSet(SHINY)
+            components(Palladium, 1, AceticAcid, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2070 Palladium Loaded Rutile Nanoparticles
-        PalladiumLoadedRutileNanoparticles = Material.Builder(2070, GTLiteMod.id("palladium_loaded_rutile_nanoparticles"))
-            .dust()
-            .colorAverage().iconSet(NANOPARTICLES)
-            .components(Palladium, 1, Rutile, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PalladiumLoadedRutileNanoparticles = addMaterial(2070, "palladium_loaded_rutile_nanoparticles")
+        {
+            dust()
+            colorAverage().iconSet(NANOPARTICLES)
+            components(Palladium, 1, Rutile, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2071 Lithium Oxide
-        LithiumOxide = Material.Builder(2071, GTLiteMod.id("lithium_oxide"))
-            .dust()
-            .color(0x9DB6B9).iconSet(DULL)
-            .components(Lithium, 2, Oxygen, 1)
-            .build()
+        LithiumOxide = addMaterial(2071, "lithium_oxide")
+        {
+            dust()
+            color(0x9DB6B9).iconSet(DULL)
+            components(Lithium, 2, Oxygen, 1)
+        }
 
         // 2072 Lithium Carbonate
-        LithiumCarbonate = Material.Builder(2072, GTLiteMod.id("lithium_carbonate"))
-            .dust()
-            .color(0xD1F3F6).iconSet(ROUGH)
-            .components(Lithium, 2, Carbon, 1, Oxygen, 3)
-            .build()
+        LithiumCarbonate = addMaterial(2072, "lithium_carbonate")
+        {
+            dust()
+            color(0xD1F3F6).iconSet(ROUGH)
+            components(Lithium, 2, Carbon, 1, Oxygen, 3)
+        }
 
         // 2073 Blue Vitriol
-        BlueVitriol = Material.Builder(2073, GTLiteMod.id("blue_vitriol"))
-            .liquid()
-            .color(0x4242DE)
-            .components(Copper, 1, Sulfur, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BlueVitriol = addMaterial(2073, "blue_vitriol")
+        {
+            liquid()
+            color(0x4242DE)
+            components(Copper, 1, Sulfur, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2074 Sodium Tellurite
-        SodiumTellurite = Material.Builder(2074, GTLiteMod.id("sodium_tellurite"))
-            .dust()
-            .color(0xC6C9BE).iconSet(ROUGH)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Sodium, 2, Tellurium, 1, Oxygen, 3)
-            .build()
+        SodiumTellurite = addMaterial(2074, "sodium_tellurite")
+        {
+            dust()
+            color(0xC6C9BE).iconSet(ROUGH)
+            components(Sodium, 2, Tellurium, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2075 Selenium Dioxide
-        SeleniumDioxide = Material.Builder(2075, GTLiteMod.id("selenium_dioxide"))
-            .dust()
-            .color(0xE0DDD8).iconSet(METALLIC)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Selenium, 1, Oxygen, 2)
-            .build()
+        SeleniumDioxide = addMaterial(2075, "selenium_dioxide")
+        {
+            dust()
+            color(0xE0DDD8).iconSet(METALLIC)
+            components(Selenium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2076 Tellurium Dioxide
-        TelluriumDioxide = Material.Builder(2076, GTLiteMod.id("tellurium_dioxide"))
-            .dust()
-            .color(0xE3DDB8).iconSet(METALLIC)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Tellurium, 1, Oxygen, 2)
-            .build()
+        TelluriumDioxide = addMaterial(2076, "tellurium_dioxide")
+        {
+            dust()
+            color(0xE3DDB8).iconSet(METALLIC)
+            components(Tellurium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2077 Selenous Acid
-        SelenousAcid = Material.Builder(2077, GTLiteMod.id("selenous_acid"))
-            .dust()
-            .color(0xE0E083).iconSet(SHINY)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Hydrogen, 2, Selenium, 1, Oxygen, 3)
-            .build()
+        SelenousAcid = addMaterial(2077, "selenous_acid")
+        {
+            dust()
+            color(0xE0E083).iconSet(SHINY)
+            components(Hydrogen, 2, Selenium, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2078 Aluminium Selenide
-        AluminiumSelenide = Material.Builder(2078, GTLiteMod.id("aluminium_selenide"))
-            .dust()
-            .color(0x969651)
-            .components(Aluminium, 2, Selenium, 3)
-            .build()
+        AluminiumSelenide = addMaterial(2078, "aluminium_selenide")
+        {
+            dust()
+            color(0x969651)
+            components(Aluminium, 2, Selenium, 3)
+        }
 
         // 2079 Hydrogen Selenide
-        HydrogenSelenide = Material.Builder(2079, GTLiteMod.id("hydrogen_selenide"))
-            .gas()
-            .color(0x42f554)
-            .components(Hydrogen, 2, Selenium, 1)
-            .build()
+        HydrogenSelenide = addMaterial(2079, "hydrogen_selenide")
+        {
+            gas()
+            color(0x42f554)
+            components(Hydrogen, 2, Selenium, 1)
+        }
 
         // 2080 Cadmium Bromide
-        CadmiumBromide = Material.Builder(2080, GTLiteMod.id("cadmium_bromide"))
-            .dust()
-            .color(0xFF1774).iconSet(SHINY)
-            .components(Cadmium, 1, Bromine, 2)
-            .build()
+        CadmiumBromide = addMaterial(2080, "cadmium_bromide")
+        {
+            dust()
+            color(0xFF1774).iconSet(SHINY)
+            components(Cadmium, 1, Bromine, 2)
+        }
 
         // 2081 Magnesium Bromide
-        MagnesiumBromide = Material.Builder(2081, GTLiteMod.id("magnesium_bromide"))
-            .dust()
-            .color(0x5F4C32).iconSet(METALLIC)
-            .components(Magnesium, 1, Bromine, 2)
-            .build()
+        MagnesiumBromide = addMaterial(2081, "magnesium_bromide")
+        {
+            dust()
+            color(0x5F4C32).iconSet(METALLIC)
+            components(Magnesium, 1, Bromine, 2)
+        }
 
         // 2082 HRA Magnesium
-        HRAMagnesium = Material.Builder(2082, GTLiteMod.id("hra_magnesium"))
-            .dust()
-            .color(Magnesium.materialRGB).iconSet(SHINY)
-            .components(Magnesium, 1)
-            .build()
+        HRAMagnesium = addMaterial(2082, "hra_magnesium")
+        {
+            dust()
+            color(Magnesium.materialRGB).iconSet(SHINY)
+            components(Magnesium, 1)
+        }
 
         // 2083 Hydrobromic Acid
-        HydrobromicAcid = Material.Builder(2083, GTLiteMod.id("hydrobromic_acid"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0x8D1212)
-            .components(Hydrogen, 1, Bromine, 1)
-            .build()
+        HydrobromicAcid = addMaterial(2083, "hydrobromic_acid")
+        {
+            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            color(0x8D1212)
+            components(Hydrogen, 1, Bromine, 1)
+        }
 
         // 2084 Dimethylcadmium
-        Dimethylcadmium = Material.Builder(2084, GTLiteMod.id("dimethylcadmium"))
-            .liquid()
-            .color(0x5C037F)
-            .components(Carbon, 2, Hydrogen, 6, Cadmium, 1)
-            .build()
-            .setFormula("(CH3)2Cd", true)
+        Dimethylcadmium = addMaterial(2084, "dimethylcadmium")
+        {
+            liquid()
+            color(0x5C037F)
+            components(Carbon, 2, Hydrogen, 6, Cadmium, 1)
+        }
 
         // 2085 Cadmium Selenide
-        CadmiumSelenide = Material.Builder(2085, GTLiteMod.id("cadmium_selenide"))
-            .dust()
-            .liquid()
-            .color(0x983034).iconSet(METALLIC)
-            .components(Cadmium, 1, Selenium, 1)
-            .build()
+        CadmiumSelenide = addMaterial(2085, "cadmium_selenide")
+        {
+            dust()
+            liquid()
+            color(0x983034).iconSet(METALLIC)
+            components(Cadmium, 1, Selenium, 1)
+        }
 
         // 2086 Prasiolite
-        Prasiolite = Material.Builder(2086, GTLiteMod.id("prasiolite"))
-            .gem()
-            .ore()
-            .color(0x9EB749).iconSet(QUARTZ)
-            .components(SiliconDioxide, 5, Iron, 1)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        Prasiolite = addMaterial(2086, "prasiolite")
+        {
+            gem()
+            ore()
+            color(0x9EB749).iconSet(QUARTZ)
+            components(SiliconDioxide, 5, Iron, 1)
+            flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2087 ZBLAN Glass
-        ZBLANGlass = Material.Builder(2087, GTLiteMod.id("zblan_glass"))
-            .ingot()
-            .fluid()
-            .color(0xACB4BC).iconSet(SHINY)
-            .components(Zirconium, 5, Barium, 2, Lanthanum, 1, Aluminium, 1, Sodium, 2, Fluorine, 6)
-            .flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2", true)
+        ZBLANGlass = addMaterial(2087, "zblan_glass")
+        {
+            ingot()
+            fluid()
+            color(0xACB4BC).iconSet(SHINY)
+            components(Zirconium, 5, Barium, 2, Lanthanum, 1, Aluminium, 1, Sodium, 2, Fluorine, 6)
+            flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2088 Er-doped ZBLAN Glass
-        ErbiumDopedZBLANGlass = Material.Builder(2088, GTLiteMod.id("erbium_doped_zblan_glass"))
-            .ingot()
-            .color(0x505444).iconSet(BRIGHT)
-            .components(ZBLANGlass, 1, Erbium, 1)
-            .flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE)
-            .build()
-            .setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2Er", true)
+        ErbiumDopedZBLANGlass = addMaterial(2088, "erbium_doped_zblan_glass")
+        {
+            ingot()
+            color(0x505444).iconSet(BRIGHT)
+            components(ZBLANGlass, 1, Erbium, 1)
+            flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE)
+        }
 
         // 2089 Pr-doped ZBLAN Glass
-        PraseodymiumDopedZBLANGlass = Material.Builder(2089, GTLiteMod.id("praseodymium_doped_zblan_glass"))
-            .ingot()
-            .color(0xC5C88D).iconSet(BRIGHT)
-            .flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE)
-            .components(ZBLANGlass, 1, Praseodymium, 1)
-            .build()
-            .setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2Pr", true)
+        PraseodymiumDopedZBLANGlass = addMaterial(2089, "praseodymium_doped_zblan_glass")
+        {
+            ingot()
+            color(0xC5C88D).iconSet(BRIGHT)
+            flags(NO_SMASHING, NO_WORKING, DISABLE_DECOMPOSITION, GENERATE_PLATE)
+            components(ZBLANGlass, 1, Praseodymium, 1)
+        }
 
         // 2090 Ozone
-        Ozone = Material.Builder(2090, GTLiteMod.id("ozone"))
-            .gas()
-            .color(0xBEF4FA)
-            .components(Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Ozone = addMaterial(2090, "ozone")
+        {
+            gas()
+            color(0xBEF4FA)
+            components(Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2091 Cubic Zirconia
-        CubicZirconia = Material.Builder(2091, GTLiteMod.id("cubic_zirconia"))
-            .gem()
-            .color(0xFFDFE2).iconSet(DIAMOND)
-            .components(Zirconium, 1, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
-            .build()
-            .setFormula("c-ZrO2", true)
+        CubicZirconia = addMaterial(2091, "cubic_zirconia")
+        {
+            gem()
+            color(0xFFDFE2).iconSet(DIAMOND)
+            components(Zirconium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2092 Bismuth Telluride
-        BismuthTelluride = Material.Builder(2092, GTLiteMod.id("bismuth_telluride"))
-            .dust()
-            .color(0x0E8933).iconSet(DULL)
-            .components(Bismuth, 2, Tellurium, 3)
-            .build()
+        BismuthTelluride = addMaterial(2092, "bismuth_telluride")
+        {
+            dust()
+            color(0x0E8933).iconSet(DULL)
+            components(Bismuth, 2, Tellurium, 3)
+        }
 
         // 2093 Magneto Resonatic
-        MagnetoResonatic = Material.Builder(2093, GTLiteMod.id("magneto_resonatic"))
-            .gem()
-            .color(0xFF97FF).iconSet(MAGNETO)
-            .components(BismuthTelluride, 4, Prasiolite, 3, CubicZirconia, 1, SteelMagnetic, 1)
-            .flags(NO_SMELTING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
-            .build()
-            .setFormula("(Bi2Te3)4((SiO2)5Fe)3(ZrO2)Fe", true)
+        MagnetoResonatic = addMaterial(2093, "magneto_resonatic")
+        {
+            gem()
+            color(0xFF97FF).iconSet(MAGNETO)
+            components(BismuthTelluride, 4, Prasiolite, 3, CubicZirconia, 1, SteelMagnetic, 1)
+            flags(NO_SMELTING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, GENERATE_BOULE)
+        }
 
         // 2094 Lanthanum Oxide
-        LanthanumOxide = Material.Builder(2094, GTLiteMod.id("lanthanum_oxide"))
-            .dust()
-            .color(0x5F7777).iconSet(SHINY)
-            .components(Lanthanum, 2, Oxygen, 3)
-            .build()
+        LanthanumOxide = addMaterial(2094, "lanthanum_oxide")
+        {
+            dust()
+            color(0x5F7777).iconSet(SHINY)
+            components(Lanthanum, 2, Oxygen, 3)
+        }
 
         // 2095 Cerium Oxide
-        CeriumOxide = Material.Builder(2095, GTLiteMod.id("cerium_oxide"))
-            .dust()
-            .color(0x10937F).iconSet(METALLIC)
-            .components(Cerium, 1, Oxygen, 2)
-            .build()
+        CeriumOxide = addMaterial(2095, "cerium_oxide")
+        {
+            dust()
+            color(0x10937F).iconSet(METALLIC)
+            components(Cerium, 1, Oxygen, 2)
+        }
 
         // 2096 Praseodymium Oxide
-        PraseodymiumOxide = Material.Builder(2096, GTLiteMod.id("praseodymium_oxide"))
-            .dust()
-            .color(0xD0D0D0).iconSet(METALLIC)
-            .components(Praseodymium, 2, Oxygen, 3)
-            .build()
+        PraseodymiumOxide = addMaterial(2096, "praseodymium_oxide")
+        {
+            dust()
+            color(0xD0D0D0).iconSet(METALLIC)
+            components(Praseodymium, 2, Oxygen, 3)
+        }
 
         // 2097 Neodymium Oxide
-        NeodymiumOxide = Material.Builder(2097, GTLiteMod.id("neodymium_oxide"))
-            .dust()
-            .color(0x868686)
-            .components(Neodymium, 2, Oxygen, 3)
-            .build()
+        NeodymiumOxide = addMaterial(2097, "neodymium_oxide")
+        {
+            dust()
+            color(0x868686)
+            components(Neodymium, 2, Oxygen, 3)
+        }
 
         // 2098 Samarium Oxide
-        SamariumOxide = Material.Builder(2098, GTLiteMod.id("samarium_oxide"))
-            .dust()
-            .color(0xFFFFDD)
-            .components(Samarium, 2, Oxygen, 3)
-            .build()
+        SamariumOxide = addMaterial(2098, "samarium_oxide")
+        {
+            dust()
+            color(0xFFFFDD)
+            components(Samarium, 2, Oxygen, 3)
+        }
 
         // 2099 Europium Oxide
-        EuropiumOxide = Material.Builder(2099, GTLiteMod.id("europium_oxide"))
-            .dust()
-            .color(0x20AAAA).iconSet(SHINY)
-            .components(Europium, 2, Oxygen, 3)
-            .build()
+        EuropiumOxide = addMaterial(2099, "europium_oxide")
+        {
+            dust()
+            color(0x20AAAA).iconSet(SHINY)
+            components(Europium, 2, Oxygen, 3)
+        }
 
         // 2100 Gadolinium Oxide
-        GadoliniumOxide = Material.Builder(2100, GTLiteMod.id("gadolinium_oxide"))
-            .dust()
-            .color(0xEEEEFF).iconSet(METALLIC)
-            .components(Gadolinium, 2, Oxygen, 3)
-            .build()
+        GadoliniumOxide = addMaterial(2100, "gadolinium_oxide")
+        {
+            dust()
+            color(0xEEEEFF).iconSet(METALLIC)
+            components(Gadolinium, 2, Oxygen, 3)
+        }
 
         // 2101 Terbium Oxide
-        TerbiumOxide = Material.Builder(2101, GTLiteMod.id("terbium_oxide"))
-            .dust()
-            .color(0xA264A2).iconSet(METALLIC)
-            .components(Terbium, 2, Oxygen, 3)
-            .build()
+        TerbiumOxide = addMaterial(2101, "terbium_oxide")
+        {
+            dust()
+            color(0xA264A2).iconSet(METALLIC)
+            components(Terbium, 2, Oxygen, 3)
+        }
 
         // 2102 Dysprosium Oxide
-        DysprosiumOxide = Material.Builder(2102, GTLiteMod.id("dysprosium_oxide"))
-            .dust()
-            .color(0xD273D2).iconSet(METALLIC)
-            .components(Dysprosium, 2, Oxygen, 3)
-            .build()
+        DysprosiumOxide = addMaterial(2102, "dysprosium_oxide")
+        {
+            dust()
+            color(0xD273D2).iconSet(METALLIC)
+            components(Dysprosium, 2, Oxygen, 3)
+        }
 
         // 2103 Holmium Oxide
-        HolmiumOxide = Material.Builder(2103, GTLiteMod.id("holmium_oxide"))
-            .dust()
-            .color(0xAF7F2A).iconSet(SHINY)
-            .components(Holmium, 2, Oxygen, 3)
-            .build()
+        HolmiumOxide = addMaterial(2103, "holmium_oxide")
+        {
+            dust()
+            color(0xAF7F2A).iconSet(SHINY)
+            components(Holmium, 2, Oxygen, 3)
+        }
 
         // 2104 Erbium Oxide
-        ErbiumOxide = Material.Builder(2104, GTLiteMod.id("erbium_oxide"))
-            .dust()
-            .color(0xE07A32).iconSet(METALLIC)
-            .components(Erbium, 2, Oxygen, 3)
-            .build()
+        ErbiumOxide = addMaterial(2104, "erbium_oxide")
+        {
+            dust()
+            color(0xE07A32).iconSet(METALLIC)
+            components(Erbium, 2, Oxygen, 3)
+        }
 
         // 2105 Thulium Oxide
-        ThuliumOxide = Material.Builder(2105, GTLiteMod.id("thulium_oxide"))
-            .dust()
-            .color(0x3B9E8B)
-            .components(Thulium, 2, Oxygen, 3)
-            .build()
+        ThuliumOxide = addMaterial(2105, "thulium_oxide")
+        {
+            dust()
+            color(0x3B9E8B)
+            components(Thulium, 2, Oxygen, 3)
+        }
 
         // 2106 Ytterbium Oxide
-        YtterbiumOxide = Material.Builder(2106, GTLiteMod.id("ytterbium_oxide"))
-            .dust()
-            .color(0xA9A9A9)
-            .components(Ytterbium, 2, Oxygen, 3)
-            .build()
+        YtterbiumOxide = addMaterial(2106, "ytterbium_oxide")
+        {
+            dust()
+            color(0xA9A9A9)
+            components(Ytterbium, 2, Oxygen, 3)
+        }
 
         // 2107 Lutetium Oxide
-        LutetiumOxide = Material.Builder(2107, GTLiteMod.id("lutetium_oxide"))
-            .dust()
-            .color(0x11BBFF).iconSet(METALLIC)
-            .components(Lutetium, 2, Oxygen, 3)
-            .build()
+        LutetiumOxide = addMaterial(2107, "lutetium_oxide")
+        {
+            dust()
+            color(0x11BBFF).iconSet(METALLIC)
+            components(Lutetium, 2, Oxygen, 3)
+        }
 
         // 2108 Scandium Oxide
-        ScandiumOxide = Material.Builder(2108, GTLiteMod.id("scandium_oxide"))
-            .dust()
-            .color(0x43964F).iconSet(METALLIC)
-            .components(Scandium, 2, Oxygen, 3)
-            .build()
+        ScandiumOxide = addMaterial(2108, "scandium_oxide")
+        {
+            dust()
+            color(0x43964F).iconSet(METALLIC)
+            components(Scandium, 2, Oxygen, 3)
+        }
 
         // 2109 Yttrium Oxide
-        YttriumOxide = Material.Builder(2109, GTLiteMod.id("yttrium_oxide"))
-            .dust()
-            .color(0x78544E).iconSet(SHINY)
-            .components(Yttrium, 2, Oxygen, 3)
-            .build()
+        YttriumOxide = addMaterial(2109, "yttrium_oxide")
+        {
+            dust()
+            color(0x78544E).iconSet(SHINY)
+            components(Yttrium, 2, Oxygen, 3)
+        }
 
         // 2110 Promethium Oxide
-        PromethiumOxide = Material.Builder(2110, GTLiteMod.id("promethium_oxide"))
-            .dust()
-            .color(0x1B8828).iconSet(METALLIC)
-            .components(Promethium, 2, Oxygen, 3)
-            .build()
+        PromethiumOxide = addMaterial(2110, "promethium_oxide")
+        {
+            dust()
+            color(0x1B8828).iconSet(METALLIC)
+            components(Promethium, 2, Oxygen, 3)
+        }
 
         // 2111 La-Pr-Nd-Ce Oxides Solution
-        LaPrNdCeOxidesSolution = Material.Builder(2111, GTLiteMod.id("la_pr_nd_ce_oxides_solution"))
-            .liquid()
-            .color(0x9CE3DB)
-            .components(LanthanumOxide, 1, PraseodymiumOxide, 1, NeodymiumOxide, 1, CeriumOxide, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        LaPrNdCeOxidesSolution = addMaterial(2111, "la_pr_nd_ce_oxides_solution")
+        {
+            liquid()
+            color(0x9CE3DB)
+            components(LanthanumOxide, 1, PraseodymiumOxide, 1, NeodymiumOxide, 1, CeriumOxide, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2112 Sc-Eu-Gd-Sm Oxides Solution
-        ScEuGdSmOxidesSolution = Material.Builder(2112, GTLiteMod.id("sc_eu_gd_sm_oxides_solution"))
-            .liquid()
-            .color(0xFFFF99)
-            .components(ScandiumOxide, 1, EuropiumOxide, 1, GadoliniumOxide, 1, SamariumOxide, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        ScEuGdSmOxidesSolution = addMaterial(2112, "sc_eu_gd_sm_oxides_solution")
+        {
+            liquid()
+            color(0xFFFF99)
+            components(ScandiumOxide, 1, EuropiumOxide, 1, GadoliniumOxide, 1, SamariumOxide, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2113 Y-Tb-Dy-Ho Oxides Solution
-        YTbDyHoOxidesSolution = Material.Builder(2113, GTLiteMod.id("y_tb_dy_ho_oxides_solution"))
-            .liquid()
-            .color(0x99FF99)
-            .components(YttriumOxide, 1, TerbiumOxide, 1, DysprosiumOxide, 1, HolmiumOxide, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        YTbDyHoOxidesSolution = addMaterial(2113, "y_tb_dy_ho_oxides_solution")
+        {
+            liquid()
+            color(0x99FF99)
+            components(YttriumOxide, 1, TerbiumOxide, 1, DysprosiumOxide, 1, HolmiumOxide, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2114 Er-Tm-Yb-Lu Oxides Solution
-        ErTmYbLuOxidesSolution = Material.Builder(2114, GTLiteMod.id("er_tm_yb_lu_oxides_solution"))
-            .liquid()
-            .color(0xFFB3FF)
-            .components(ErbiumOxide, 1, ThuliumOxide, 1, YtterbiumOxide, 1, LutetiumOxide, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        ErTmYbLuOxidesSolution = addMaterial(2114, "er_tm_yb_lu_oxides_solution")
+        {
+            liquid()
+            color(0xFFB3FF)
+            components(ErbiumOxide, 1, ThuliumOxide, 1, YtterbiumOxide, 1, LutetiumOxide, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2115 Platinum Group Residue
-        PlatinumGroupResidue = Material.Builder(2115, GTLiteMod.id("platinum_group_residue"))
-            .dust()
-            .color(0x64632E).iconSet(ROUGH)
-            .components(Iridium, 1, Osmium, 1, Rhodium, 1, Ruthenium, 1, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("RuRhIr2Os(HNO3)3", true)
+        PlatinumGroupResidue = addMaterial(2115, "platinum_group_residue")
+        {
+            dust()
+            color(0x64632E).iconSet(ROUGH)
+            components(Iridium, 1, Osmium, 1, Rhodium, 1, Ruthenium, 1, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2116 Platinum Group Concentrate
-        PlatinumGroupConcentrate = Material.Builder(2116, GTLiteMod.id("platinum_group_concentrate"))
-            .liquid()
-            .color(0xFFFFA6)
-            .components(Gold, 1, Platinum, 1, Palladium, 1, HydrochloricAcid, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("AuPtPd(HCl)6", true)
+        PlatinumGroupConcentrate = addMaterial(2116, "platinum_group_concentrate")
+        {
+            liquid()
+            color(0xFFFFA6)
+            components(Gold, 1, Platinum, 1, Palladium, 1, HydrochloricAcid, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2117 Purified Platinum Group Concentrate
-        PurifiedPlatinumGroupConcentrate = Material.Builder(2117, GTLiteMod.id("purified_platinum_group_concentrate"))
-            .liquid()
-            .color(0xFFFFC8)
-            .components(Hydrogen, 2, Platinum, 1, Palladium, 1, Chlorine, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("H2PtPdCl6", true)
+        PurifiedPlatinumGroupConcentrate = addMaterial(2117, "purified_platinum_group_concentrate")
+        {
+            liquid()
+            color(0xFFFFC8)
+            components(Hydrogen, 2, Platinum, 1, Palladium, 1, Chlorine, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2118 Ammonium Hexachloroplatinate
-        AmmoniumHexachloroplatinate = Material.Builder(2118, GTLiteMod.id("ammonium_hexachloroplatinate"))
-            .liquid()
-            .color(0xFEF0C2)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Nitrogen, 2, Hydrogen, 8, Platinum, 1, Chlorine, 6)
-            .build()
-            .setFormula("(NH4)2PtCl6", true)
+        AmmoniumHexachloroplatinate = addMaterial(2118, "ammonium_hexachloroplatinate")
+        {
+            liquid()
+            color(0xFEF0C2)
+            flags(DISABLE_DECOMPOSITION)
+            components(Nitrogen, 2, Hydrogen, 8, Platinum, 1, Chlorine, 6)
+        }
 
         // 2119 Ammonium Hexachloropalladate
-        AmmoniumHexachloropalladate = Material.Builder(2119, GTLiteMod.id("ammonium_hexachloropalladate"))
-            .liquid()
-            .color(0x808080)
-            .components(Nitrogen, 2, Hydrogen, 8, Palladium, 1, Chlorine, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(NH4)2PdCl6", true)
+        AmmoniumHexachloropalladate = addMaterial(2119, "ammonium_hexachloropalladate")
+        {
+            liquid()
+            color(0x808080)
+            components(Nitrogen, 2, Hydrogen, 8, Palladium, 1, Chlorine, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2120 Sodium Nitrate
-        SodiumNitrate = Material.Builder(2120, GTLiteMod.id("sodium_nitrate"))
-            .dust()
-            .color(0x846684).iconSet(ROUGH)
-            .components(Sodium, 1, Nitrogen, 1, Oxygen, 3)
-            .build()
+        SodiumNitrate = addMaterial(2120, "sodium_nitrate")
+        {
+            dust()
+            color(0x846684).iconSet(ROUGH)
+            components(Sodium, 1, Nitrogen, 1, Oxygen, 3)
+        }
 
         // 2121 Hexachloroplatinic Acid
-        HexachloroplatinicAcid = Material.Builder(2121, GTLiteMod.id("hexachloroplatinic_acid"))
-            .liquid(FluidBuilder().attribute(FluidAttributes.ACID))
-            .color(0xFEF4D1)
-            .components(Hydrogen, 2, Platinum, 1, Chlorine, 6)
-            .build()
+        HexachloroplatinicAcid = addMaterial(2121, "hexachloroplatinic_acid")
+        {
+            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            color(0xFEF4D1)
+            components(Hydrogen, 2, Platinum, 1, Chlorine, 6)
+        }
 
         // 2122 Carbon Tetrachloride
-        CarbonTetrachloride = Material.Builder(2122, GTLiteMod.id("carbon_tetrachloride"))
-            .liquid()
-            .color(0x75201A)
-            .components(Carbon, 1, Chlorine, 4)
-            .build()
+        CarbonTetrachloride = addMaterial(2122, "carbon_tetrachloride")
+        {
+            liquid()
+            color(0x75201A)
+            components(Carbon, 1, Chlorine, 4)
+        }
 
         // 2123 Sodium Peroxide
-        SodiumPeroxide = Material.Builder(2123, GTLiteMod.id("sodium_peroxide"))
-            .dust()
-            .color(0xECFF80).iconSet(ROUGH)
-            .components(Sodium, 2, Oxygen, 2)
-            .build()
+        SodiumPeroxide = addMaterial(2123, "sodium_peroxide")
+        {
+            dust()
+            color(0xECFF80).iconSet(ROUGH)
+            components(Sodium, 2, Oxygen, 2)
+        }
 
         // 2124 Ruthenium Trichloride
-        RutheniumTrichloride = Material.Builder(2124, GTLiteMod.id("ruthenium_trichloride"))
-            .dust()
-            .color(0x605C6C).iconSet(METALLIC)
-            .components(Ruthenium, 1, Chlorine, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RutheniumTrichloride = addMaterial(2124, "ruthenium_trichloride")
+        {
+            dust()
+            color(0x605C6C).iconSet(METALLIC)
+            components(Ruthenium, 1, Chlorine, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2125 Rhodium Trioxide
-        RhodiumTrioxide = Material.Builder(2125, GTLiteMod.id("rhodium_trioxide"))
-            .dust()
-            .color(0xD93D16).iconSet(METALLIC)
-            .components(Rhodium, 2, Oxygen, 3)
-            .build()
+        RhodiumTrioxide = addMaterial(2125, "rhodium_trioxide")
+        {
+            dust()
+            color(0xD93D16).iconSet(METALLIC)
+            components(Rhodium, 2, Oxygen, 3)
+        }
 
         // 2126 Sulfur Dichloride
-        SulfurDichloride = Material.Builder(2126, GTLiteMod.id("sulfur_dichloride"))
-            .liquid()
-            .color(0x761410)
-            .components(Sulfur, 1, Chlorine, 2)
-            .build()
+        SulfurDichloride = addMaterial(2126, "sulfur_dichloride")
+        {
+            liquid()
+            color(0x761410)
+            components(Sulfur, 1, Chlorine, 2)
+        }
 
         // 2127 Osmium Tetrachloride
-        OsmiumTetrachloride = Material.Builder(2127, GTLiteMod.id("osmium_tetrachloride"))
-            .dust()
-            .color(0x29080A).iconSet(METALLIC)
-            .components(Osmium, 1, Chlorine, 4)
-            .build()
+        OsmiumTetrachloride = addMaterial(2127, "osmium_tetrachloride")
+        {
+            dust()
+            color(0x29080A).iconSet(METALLIC)
+            components(Osmium, 1, Chlorine, 4)
+        }
 
         // 2128 Beryllium Oxide
-        BerylliumOxide = Material.Builder(2128, GTLiteMod.id("beryllium_oxide"))
-            .ingot()
-            .color(0x54C757)
-            .components(Beryllium, 1, Oxygen, 1)
-            .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_RING)
-            .build()
+        BerylliumOxide = addMaterial(2128, "beryllium_oxide")
+        {
+            ingot()
+            color(0x54C757)
+            components(Beryllium, 1, Oxygen, 1)
+            flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_RING)
+        }
 
         // 2129 Hydrogen Peroxide
-        HydrogenPeroxide = Material.Builder(2129, GTLiteMod.id("hydrogen_peroxide"))
-            .liquid()
-            .color(0xD2FFFF)
-            .components(Hydrogen, 2, Oxygen, 2)
-            .build()
+        HydrogenPeroxide = addMaterial(2129, "hydrogen_peroxide")
+        {
+            liquid()
+            color(0xD2FFFF)
+            components(Hydrogen, 2, Oxygen, 2)
+        }
 
         // 2130 Graphene Oxide
-        GrapheneOxide = Material.Builder(2130, GTLiteMod.id("graphene_oxide"))
-            .dust()
-            .color(0x777777).iconSet(ROUGH)
-            .components(Graphene, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        GrapheneOxide = addMaterial(2130, "graphene_oxide")
+        {
+            dust()
+            color(0x777777).iconSet(ROUGH)
+            components(Graphene, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2131 Yttrium Nitrate
-        YttriumNitrate = Material.Builder(2131, GTLiteMod.id("yttrium_nitrate"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Yttrium, 1, Nitrogen, 3, Oxygen, 9)
-            .build()
-            .setFormula("Y(NO3)3", true)
+        YttriumNitrate = addMaterial(2131, "yttrium_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Yttrium, 1, Nitrogen, 3, Oxygen, 9)
+        }
 
         // 2132 Barium Nitrate
-        BariumNitrate = Material.Builder(2132, GTLiteMod.id("barium_nitrate"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Barium, 1, Nitrogen, 2, Oxygen, 6)
-            .build()
-            .setFormula("Ba(NO3)2", true)
+        BariumNitrate = addMaterial(2132, "barium_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Barium, 1, Nitrogen, 2, Oxygen, 6)
+        }
 
         // 2133 Copper Nitrate
-        CopperNitrate = Material.Builder(2133, GTLiteMod.id("copper_nitrate"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Copper, 1, Nitrogen, 2, Oxygen, 6)
-            .build()
-            .setFormula("Cu(NO3)2", true)
+        CopperNitrate = addMaterial(2133, "copper_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Copper, 1, Nitrogen, 2, Oxygen, 6)
+        }
 
         // 2134 Yttrium Barium Copper Oxides Mixture
-        YttriumBariumCopperOxidesMixture = Material.Builder(2134, GTLiteMod.id("yttrium_barium_copper_oxides_mixture"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Yttrium, 1, Barium, 2, Copper, 3, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        YttriumBariumCopperOxidesMixture = addMaterial(2134, "yttrium_barium_copper_oxides_mixture")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Yttrium, 1, Barium, 2, Copper, 3, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2135 GST Glass
-        GSTGlass = Material.Builder(2135, GTLiteMod.id("gst_glass"))
-            .ingot()
-            .fluid()
-            .color(0xCFFFFF).iconSet(SHINY)
-            .components(Germanium, 2, Antimony, 2, Tellurium, 5)
-            .flags(NO_SMASHING, NO_WORKING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE,
-                   GENERATE_LENS)
-            .blast { b ->
-                b.temp(873, BlastProperty.GasTier.MID)
-            }
-            .build()
+        GSTGlass = addMaterial(2135, "gst_glass")
+        {
+            ingot()
+            fluid()
+            color(0xCFFFFF).iconSet(SHINY)
+            components(Germanium, 2, Antimony, 2, Tellurium, 5)
+            flags(NO_SMASHING, NO_WORKING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE, GENERATE_LENS)
+            blastProp(873, GasTier.MID)
+        }
 
         // 2136 Germanium Dioxide
-        GermaniumDioxide = Material.Builder(2136, GTLiteMod.id("germanium_dioxide"))
-            .dust()
-            .color(0x666666)
-            .components(Germanium, 1, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        GermaniumDioxide = addMaterial(2136, "germanium_dioxide")
+        {
+            dust()
+            color(0x666666)
+            components(Germanium, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2137 Roasted Sphalerite
-        RoastedSphalerite = Material.Builder(2137, GTLiteMod.id("roasted_sphalerite"))
-            .dust()
-            .color(0xAC8B5C).iconSet(ROASTED)
-            .components(GermaniumDioxide, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(GeO2)?", true)
+        RoastedSphalerite = addMaterial(2137, "roasted_sphalerite")
+        {
+            dust()
+            color(0xAC8B5C).iconSet(ROASTED)
+            components(GermaniumDioxide, 1, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
-        // 2138 Zn-rich Sphalerite
-        ZincRichSphalerite = Material.Builder(2138, GTLiteMod.id("zinc_rich_sphalerite"))
-            .dust()
-            .color(0xC3AC8F).iconSet(METALLIC)
-            .components(Zinc, 2, RoastedSphalerite, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Zn2(GaGeO2)?", true)
+        // 2138 Zinc-rich Sphalerite
+        ZincRichSphalerite = addMaterial(2138, "zinc_rich_sphalerite")
+        {
+            dust()
+            color(0xC3AC8F).iconSet(METALLIC)
+            components(Zinc, 2, RoastedSphalerite, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2139 Waelz Oxide
-        WaelzOxide = Material.Builder(2139, GTLiteMod.id("waelz_oxide"))
-            .dust()
-            .color(0xB8B8B8).iconSet(FINE)
-            .components(Zinc, 1, GermaniumDioxide, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(GeO2)Zn", true)
+        WaelzOxide = addMaterial(2139, "waelz_oxide")
+        {
+            dust()
+            color(0xB8B8B8).iconSet(FINE)
+            components(Zinc, 1, GermaniumDioxide, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2140 Waelz Slag
-        WaelzSlag = Material.Builder(2140, GTLiteMod.id("waelz_slag"))
-            .dust()
-            .color(0xAC8B5C).iconSet(ROUGH)
-            .components(Gallium, 1, Zinc, 1, Sulfur, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(ZnSO4)Ga", true)
+        WaelzSlag = addMaterial(2140, "waelz_slag")
+        {
+            dust()
+            color(0xAC8B5C).iconSet(ROUGH)
+            components(Gallium, 1, Zinc, 1, Sulfur, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2141 Piranha Solution
-        PiranhaSolution = Material.Builder(2141, GTLiteMod.id("piranha_solution"))
-            .liquid()
-            .color(0x4820AB)
-            .components(SulfuricAcid, 1, HydrogenPeroxide, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        PiranhaSolution = addMaterial(2141, "piranha_solution")
+        {
+            liquid()
+            color(0x4820AB)
+            components(SulfuricAcid, 1, HydrogenPeroxide, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2142 Hydroxyquinoline Aluminium
-        HydroxyquinolineAluminium = Material.Builder(2142, GTLiteMod.id("hydroxyquinoline_aluminium"))
-            .ingot()
-            .color(0x3F5A9F).iconSet(SHINY)
-            .components(Aluminium, 1, Carbon, 9, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL)
-            .build()
-            .setFormula("(C9H7NO)Al", true)
+        HydroxyquinolineAluminium = addMaterial(2142, "hydroxyquinoline_aluminium")
+        {
+            ingot()
+            color(0x3F5A9F).iconSet(SHINY)
+            components(Aluminium, 1, Carbon, 9, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL)
+        }
 
         // 2143 Hydroselenic Acid
-        HydroselenicAcid = Material.Builder(2143, GTLiteMod.id("hydroselenic_acid"))
-            .liquid(FluidBuilder().attribute(FluidAttributes.ACID))
-            .color(0xDBC3B5)
-            .components(Hydrogen, 2, Selenium, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        HydroselenicAcid = addMaterial(2143, "hydroselenic_acid")
+        {
+            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            color(0xDBC3B5)
+            components(Hydrogen, 2, Selenium, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2144 Copper Gallium Indium Selenide
-        CopperGalliumIndiumSelenide = Material.Builder(2144, GTLiteMod.id("copper_gallium_indium_selenide"))
-            .ingot()
-            .colorAverage().iconSet(SHINY)
-            .components(Copper, 1, Gallium, 1, Indium, 1, Selenium, 2)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(6000, BlastProperty.GasTier.MID) // Naquadah (HSS-G)
-                    .blastStats(VA[EV], 30 * SECOND)
-                    .vacuumStats(VA[MV], 10 * SECOND)
-            }
-            .build()
+        CopperGalliumIndiumSelenide = addMaterial(2144, "copper_gallium_indium_selenide")
+        {
+            ingot()
+            colorAverage().iconSet(SHINY)
+            components(Copper, 1, Gallium, 1, Indium, 1, Selenium, 2)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(6000, GasTier.MID, // Naquadah
+                      VA[EV], 30 * SECOND,
+                      VA[MV], 10 * SECOND)
+        }
 
         // 2145 Barium Hydroxide
-        BariumHydroxide = Material.Builder(2145, GTLiteMod.id("barium_hydroxide"))
-            .dust()
-            .color(0xFFFFED).iconSet(DULL)
-            .components(Barium, 1, Oxygen, 2, Hydrogen, 2)
-            .build()
-            .setFormula("Ba(OH)2", true)
+        BariumHydroxide = addMaterial(2145, "barium_hydroxide")
+        {
+            dust()
+            color(0xFFFFED).iconSet(DULL)
+            components(Barium, 1, Oxygen, 2, Hydrogen, 2)
+        }
+
 
         // 2146 Barium Titanate
-        BariumTitanate = Material.Builder(2146, GTLiteMod.id("barium_titanate"))
-            .ingot()
-            .fluid()
-            .color(0x99FF99).iconSet(SHINY)
-            .components(Barium, 1, Titanium, 1, Oxygen, 3)
-            .flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(3600, BlastProperty.GasTier.LOW) // Nichrome
-                    .blastStats(VA[IV], 18 * SECOND)
-                    .vacuumStats(VA[HV], 8 * SECOND)
-            }
-            .build()
+        BariumTitanate = addMaterial(2146, "barium_titanate")
+        {
+            ingot()
+            fluid()
+            color(0x99FF99).iconSet(SHINY)
+            components(Barium, 1, Titanium, 1, Oxygen, 3)
+            flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_BOLT_SCREW)
+            blastProp(3600, GasTier.LOW, // Nichrome
+                      VA[IV], 18 * SECOND,
+                      VA[HV], 8 * SECOND)
+        }
 
         // 2147 Samarium Cobalt
-        SamariumCobalt = Material.Builder(2147, GTLiteMod.id("samarium_cobalt"))
-            .ingot()
-            .fluid()
-            .color(0xB3D683).iconSet(MAGNETIC)
-            .components(Samarium, 1,  Cobalt, 5)
-            .flags(GENERATE_ROD, GENERATE_LONG_ROD, GENERATE_RING)
-            .blast { b ->
-                b.temp(5000, BlastProperty.GasTier.HIGH) // HSS-G (RTM Alloy)
-                    .blastStats(VA[IV], 45 * SECOND)
-                    .vacuumStats(VA[HV], 20 * SECOND)
-            }
-            .build()
+        SamariumCobalt = addMaterial(2147, "samarium_cobalt")
+        {
+            ingot()
+            fluid()
+            color(0xB3D683).iconSet(MAGNETIC)
+            components(Samarium, 1,  Cobalt, 5)
+            flags(GENERATE_ROD, GENERATE_LONG_ROD, GENERATE_RING)
+            blastProp(5000, GasTier.HIGH, // HSS-G
+                      VA[IV], 45 * SECOND,
+                      VA[HV], 20 * SECOND)
+        }
 
         // 2148 Potassium Hydroxide
-        PotassiumHydroxide = Material.Builder(2148, GTLiteMod.id("potassium_hydroxide"))
-            .dust()
-            .liquid(FluidBuilder().temperature(633))
-            .color(0xFA9849)
-            .components(Potassium, 1, Oxygen, 1, Hydrogen, 1)
-            .build()
+        PotassiumHydroxide = addMaterial(2148, "potassium_hydroxide")
+        {
+            dust()
+            liquid(FluidBuilder().temperature(633))
+            color(0xFA9849)
+            components(Potassium, 1, Oxygen, 1, Hydrogen, 1)
+        }
 
         // 2149 Copper Dichloride
-        CopperDichloride = Material.Builder(2149, GTLiteMod.id("copper_dichloride"))
-            .dust()
-            .color(0x3FB3B8).iconSet(ROUGH)
-            .components(Copper, 1, Chlorine, 2)
-            .build()
+        CopperDichloride = addMaterial(2149, "copper_dichloride")
+        {
+            dust()
+            color(0x3FB3B8).iconSet(ROUGH)
+            components(Copper, 1, Chlorine, 2)
+        }
 
         // 2150 Sodium Cyanide
-        SodiumCyanide = Material.Builder(2150, GTLiteMod.id("sodium_cyanide"))
-            .dust()
-            .color(0x1B3818).iconSet(DULL)
-            .components(Sodium, 1, Carbon, 1, Nitrogen, 1)
-            .build()
+        SodiumCyanide = addMaterial(2150, "sodium_cyanide")
+        {
+            dust()
+            color(0x1B3818).iconSet(DULL)
+            components(Sodium, 1, Carbon, 1, Nitrogen, 1)
+        }
 
         // 2151 Potassium Bromate
-        PotassiumBromate = Material.Builder(2151, GTLiteMod.id("potassium_bromate"))
-            .dust()
-            .color(0x782828).iconSet(ROUGH)
-            .components(Potassium, 1, Bromine, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PotassiumBromate = addMaterial(2151, "potassium_bromate")
+        {
+            dust()
+            color(0x782828).iconSet(ROUGH)
+            components(Potassium, 1, Bromine, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2152 White Phosphorus
-        WhitePhosphorus = Material.Builder(2152, GTLiteMod.id("white_phosphorus"))
-            .gem()
-            .color(0xECEADD).iconSet(FLINT)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        WhitePhosphorus = addMaterial(2152, "white_phosphorus")
+        {
+            gem()
+            color(0xECEADD).iconSet(FLINT)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2153 Red Phosphorus
-        RedPhosphorus = Material.Builder(2153, GTLiteMod.id("red_phosphorus"))
-            .gem()
-            .color(0x77040E).iconSet(FLINT)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RedPhosphorus = addMaterial(2153, "red_phosphorus")
+        {
+            gem()
+            color(0x77040E).iconSet(FLINT)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2154 Violet Phosphorus
-        VioletPhosphorus = Material.Builder(2154, GTLiteMod.id("violet_phosphorus"))
-            .gem()
-            .color(0x8000FF).iconSet(FLINT)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        VioletPhosphorus = addMaterial(2154, "violet_phosphorus")
+        {
+            gem()
+            color(0x8000FF).iconSet(FLINT)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2155 Black Phosphorus
-        BlackPhosphorus = Material.Builder(2155, GTLiteMod.id("black_phosphorus"))
-            .gem()
-            .color(0x36454F).iconSet(FLINT)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BlackPhosphorus = addMaterial(2155, "black_phosphorus")
+        {
+            gem()
+            color(0x36454F).iconSet(FLINT)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2156 Blue Phosphorus
-        BluePhosphorus = Material.Builder(2156, GTLiteMod.id("blue_phosphorus"))
-            .gem()
-            .color(0x9BE3E4).iconSet(FLINT)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BluePhosphorus = addMaterial(2156, "blue_phosphorus")
+        {
+            gem()
+            color(0x9BE3E4).iconSet(FLINT)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2157 Phosphorus Trichloride
-        PhosphorusTrichloride = Material.Builder(2157, GTLiteMod.id("phosphorus_trichloride"))
-            .liquid()
-            .color(0xD8D85B)
-            .components(Phosphorus, 1, Chlorine, 3)
-            .build()
+        PhosphorusTrichloride = addMaterial(2157, "phosphorus_trichloride")
+        {
+            liquid()
+            color(0xD8D85B)
+            components(Phosphorus, 1, Chlorine, 3)
+        }
 
         // 2158 Sodium Fluoride
-        SodiumFluoride = Material.Builder(2158, GTLiteMod.id("sodium_fluoride"))
-            .dust()
-            .color(0x460012).iconSet(DULL)
-            .components(Sodium, 1, Fluorine, 1)
-            .build()
+        SodiumFluoride = addMaterial(2158, "sodium_fluoride")
+        {
+            dust()
+            color(0x460012).iconSet(DULL)
+            components(Sodium, 1, Fluorine, 1)
+        }
 
         // 2159 Sodium Trifluoroethanolate
-        SodiumTrifluoroethanolate = Material.Builder(2159, GTLiteMod.id("sodium_trifluoroethanolate"))
-            .dust()
-            .color(0x50083E).iconSet(ROUGH)
-            .components(Sodium, 1, Carbon, 2, Hydrogen, 4, Oxygen, 1, Fluorine, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumTrifluoroethanolate = addMaterial(2159, "sodium_trifluoroethanolate")
+        {
+            dust()
+            color(0x50083E).iconSet(ROUGH)
+            components(Sodium, 1, Carbon, 2, Hydrogen, 4, Oxygen, 1, Fluorine, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2160 Technetium Heptaoxide
-        TechnetiumHeptaoxide = Material.Builder(2160, GTLiteMod.id("technetium_heptaoxide"))
-            .dust()
-            .color(0xFCE9A4).iconSet(SHINY)
-            .components(Technetium, 2, Oxygen, 7)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TechnetiumHeptaoxide = addMaterial(2160, "technetium_heptaoxide")
+        {
+            dust()
+            color(0xFCE9A4).iconSet(SHINY)
+            components(Technetium, 2, Oxygen, 7)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2161 Trinium Trioxide
-        TriniumTrioxide = Material.Builder(2161, GTLiteMod.id("trinium_trioxide"))
-            .dust()
-            .color(0xC037C5).iconSet(METALLIC)
-            .components(Trinium, 2, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TriniumTrioxide = addMaterial(2161, "trinium_trioxide")
+        {
+            dust()
+            color(0xC037C5).iconSet(METALLIC)
+            components(Trinium, 2, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2162 Pertechnetate
-        Pertechnetate = Material.Builder(2162, GTLiteMod.id("pertechnetate"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0xCC3300)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Pertechnetate = addMaterial(2162, "pertechnetate")
+        {
+            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            color(0xCC3300)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2163 Ammonium Nitrate
-        AmmoniumNitrate = Material.Builder(2163, GTLiteMod.id("ammonium_nitrate"))
-            .dust()
-            .color(0xA59ED7).iconSet(METALLIC)
-            .components(Ammonia, 1, NitricAcid, 1)
-            .build()
-            .setFormula("NH4NO3", true)
+        AmmoniumNitrate = addMaterial(2163, "ammonium_nitrate")
+        {
+            dust()
+            color(0xA59ED7).iconSet(METALLIC)
+            components(Ammonia, 1, NitricAcid, 1)
+        }
 
         // 2164 Ammonium Pertechnetate
-        AmmoniumPertechnetate = Material.Builder(2164, GTLiteMod.id("ammonium_pertechnetate"))
-            .dust()
-            .color(0x996666).iconSet(ROUGH)
-            .components(Nitrogen, 1, Hydrogen, 4, Technetium, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        AmmoniumPertechnetate = addMaterial(2164, "ammonium_pertechnetate")
+        {
+            dust()
+            color(0x996666).iconSet(ROUGH)
+            components(Nitrogen, 1, Hydrogen, 4, Technetium, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2165 Technetium Dioxide
-        TechnetiumDioxide = Material.Builder(2165, GTLiteMod.id("technetium_dioxide"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Technetium, 1, Oxygen, 2)
-            .build()
+        TechnetiumDioxide = addMaterial(2165, "technetium_dioxide")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Technetium, 1, Oxygen, 2)
+        }
 
         // 2166 Indium Phosphate
-        IndiumPhosphate = Material.Builder(2166, GTLiteMod.id("indium_phosphate"))
-            .dust()
-            .color(0x2B2E70).iconSet(SHINY)
-            .components(Indium, 1, Phosphorus, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        IndiumPhosphate = addMaterial(2166, "indium_phosphate")
+        {
+            dust()
+            color(0x2B2E70).iconSet(SHINY)
+            components(Indium, 1, Phosphorus, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2167 Gallium Dioxide
-        GalliumDioxide = Material.Builder(2167, GTLiteMod.id("gallium_dioxide"))
-            .dust()
-            .color(0xAB9ABF).iconSet(DULL)
-            .components(Gallium, 1, Oxygen, 2)
-            .build()
+        GalliumDioxide = addMaterial(2167, "gallium_dioxide")
+        {
+            dust()
+            color(0xAB9ABF).iconSet(DULL)
+            components(Gallium, 1, Oxygen, 2)
+        }
 
         // 2168 Calcium Sulfide
-        CalciumSulfide = Material.Builder(2168, GTLiteMod.id("calcium_sulfide"))
-            .dust()
-            .color(0xF9F9F9).iconSet(METALLIC)
-            .components(Calcium, 1, Sulfur, 1)
-            .build()
+        CalciumSulfide = addMaterial(2168, "calcium_sulfide")
+        {
+            dust()
+            color(0xF9F9F9).iconSet(METALLIC)
+            components(Calcium, 1, Sulfur, 1)
+        }
 
         // 2169 RP-1 Rocket Fuel
-        RP1RocketFuel = Material.Builder(2169, GTLiteMod.id("rp_1_rocket_fuel"))
-            .liquid()
-            .color(0xFB2A08)
-            .components(CoalTar, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RP1RocketFuel = addMaterial(2169, "rp_1_rocket_fuel")
+        {
+            liquid()
+            color(0xFB2A08)
+            components(CoalTar, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2170 Bismuth Trioxide
-        BismuthTrioxide = Material.Builder(2170, GTLiteMod.id("bismuth_trioxide"))
-            .dust()
-            .color(0xF5EF42).iconSet(FINE)
-            .components(Bismuth, 2, Oxygen, 3)
-            .build()
+        BismuthTrioxide = addMaterial(2170, "bismuth_trioxide")
+        {
+            dust()
+            color(0xF5EF42).iconSet(FINE)
+            components(Bismuth, 2, Oxygen, 3)
+        }
 
         // 2171 Bismuth Strontium Calcium Cuprate (BSCCO)
-        BismuthStrontiumCalciumCuprate = Material.Builder(2171, GTLiteMod.id("bismuth_strontium_calcium_cuprate"))
-            .ingot()
-            .fluid()
-            .color(0xD880D8)
-            .components(BismuthTrioxide, 1, Strontianite, 2, Calcite, 1, Tenorite, 2)
-            .blast { b ->
-                b.temp(7000, BlastProperty.GasTier.HIGHER) // Naquadah
-                    .blastStats(VA[UV], 43 * SECOND)
-                    .vacuumStats(VA[IV], 21 * SECOND) }
-            .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .cableProperties(V[UV], 4, 3)
-            .build()
-            .setFormula("Bi2Sr2CaCu2O8", true)
+        BismuthStrontiumCalciumCuprate = addMaterial(2171, "bismuth_strontium_calcium_cuprate")
+        {
+            ingot()
+            fluid()
+            color(0xD880D8)
+            components(BismuthTrioxide, 1, Strontianite, 2, Calcite, 1, Tenorite, 2)
+            flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(7000, GasTier.HIGHER, // Naquadah
+                      VA[UV], 43 * SECOND,
+                      VA[IV], 21 * SECOND)
+            cableProp(V[UV], 4, 3)
+        }
 
         // 2172 Bedrockium
-        Bedrockium = Material.Builder(2172, GTLiteMod.id("bedrockium"))
-            .ingot()
-            .fluid()
-            .iconSet(BEDROCKIUM)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FRAME,
-                GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(9900, BlastProperty.GasTier.HIGHER) // Tritanium
-                    .blastStats(VA[ZPM], 50 * SECOND)
-                    .vacuumStats(VA[LuV], 25 * SECOND)
-            }
-            .cableProperties(V[UHV], 2, 16)
-            .build()
+        Bedrockium = addMaterial(2172, "bedrockium")
+        {
+            ingot()
+            fluid()
+            iconSet(BEDROCKIUM)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FRAME, GENERATE_GEAR,
+                  GENERATE_SMALL_GEAR, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(9900, GasTier.HIGHER, // Tritanium
+                      VA[ZPM], 50 * SECOND,
+                      VA[LuV], 25 * SECOND)
+            cableProp(V[UHV], 2, 16)
+        }
 
         // 2173 Adamantite
-        Adamantite = Material.Builder(2173, GTLiteMod.id("adamantite"))
-            .dust()
-            .color(0xC83C3C).iconSet(ROUGH)
-            .components(Adamantium, 3, Oxygen, 4)
-            .build()
+        Adamantite = addMaterial(2173, "adamantite")
+        {
+            dust()
+            color(0xC83C3C).iconSet(ROUGH)
+            components(Adamantium, 3, Oxygen, 4)
+        }
 
         // 2174 Unstable Adamantium
-        AdamantiumUnstable = Material.Builder(2174, GTLiteMod.id("adamantium_unstable"))
-            .liquid()
-            .color(0xFF763C)
-            .components(Adamantium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Ad*", true)
+        AdamantiumUnstable = addMaterial(2174, "adamantium_unstable")
+        {
+            liquid()
+            color(0xFF763C)
+            components(Adamantium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2175 Enriched Adamantium
-        AdamantiumEnriched = Material.Builder(2175, GTLiteMod.id("adamantium_enriched"))
-            .dust()
-            .color(0x64B4FF).iconSet(ROUGH)
-            .components(Vibranium, 1, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        AdamantiumEnriched = addMaterial(2175, "adamantium_enriched")
+        {
+            dust()
+            color(0x64B4FF).iconSet(ROUGH)
+            components(Vibranium, 1, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2176 Unstable Vibranium
-        VibraniumUnstable = Material.Builder(2176, GTLiteMod.id("vibranium_unstable"))
-            .liquid()
-            .color(0xFF7832)
-            .components(Vibranium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        VibraniumUnstable = addMaterial(2176, "vibranium_unstable")
+        {
+            liquid()
+            color(0xFF7832)
+            components(Vibranium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2177 Deep Iron
-        DeepIron = Material.Builder(2177, GTLiteMod.id("deep_iron"))
-            .dust()
-            .color(0x968C8C).iconSet(METALLIC)
-            .components(Iron, 2, Trinium, 1, Indium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DeepIron = addMaterial(2177, "deep_iron")
+        {
+            dust()
+            color(0x968C8C).iconSet(METALLIC)
+            components(Iron, 2, Trinium, 1, Indium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2178 Eutatic Sodium Potassium
-        SodiumPotassiumEutatic = Material.Builder(2178, GTLiteMod.id("sodium_potassium_eutatic"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(DULL)
-            .components(Sodium, 7, Potassium, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumPotassiumEutatic = addMaterial(2178, "sodium_potassium_eutatic")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(DULL)
+            components(Sodium, 7, Potassium, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2179 Eutatic Lead Bismuth
-        LeadBismuthEutatic = Material.Builder(2179, GTLiteMod.id("lead_bismuth_eutatic"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(SHINY)
-            .components(Lead, 3, Bismuth, 7)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        LeadBismuthEutatic = addMaterial(2179, "lead_bismuth_eutatic")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(SHINY)
+            components(Lead, 3, Bismuth, 7)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2180 Lithium Fluoride
-        LithiumFluoride = Material.Builder(2180, GTLiteMod.id("lithium_fluoride"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Lithium, 1, Fluorine, 1)
-            .build()
+        LithiumFluoride = addMaterial(2180, "lithium_fluoride")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Lithium, 1, Fluorine, 1)
+        }
 
         // 2181 Potassium Fluoride
-        PotassiumFluoride = Material.Builder(2181, GTLiteMod.id("potassium_fluoride"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Potassium, 1, Fluorine, 1)
-            .build()
+        PotassiumFluoride = addMaterial(2181, "potassium_fluoride")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Potassium, 1, Fluorine, 1)
+        }
 
         // 2182 Lithium Sodium Potassium Fluorides
-        LithiumSodiumPotassiumFluorides = Material.Builder(2182, GTLiteMod.id("lithium_sodium_potassium_fluorides"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(LithiumFluoride, 1, SodiumFluoride, 1, PotassiumFluoride, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("F3LiNaK", true)
+        LithiumSodiumPotassiumFluorides = addMaterial(2182, "lithium_sodium_potassium_fluorides")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(LithiumFluoride, 1, SodiumFluoride, 1, PotassiumFluoride, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2183 Beryllium Difluoride
-        BerylliumDifluoride = Material.Builder(2183, GTLiteMod.id("beryllium_difluoride"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Beryllium, 1, Fluorine, 2)
-            .build()
+        BerylliumDifluoride = addMaterial(2183, "beryllium_difluoride")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Beryllium, 1, Fluorine, 2)
+        }
 
         // 2184 Lithium Beryllium Fluorides
-        LithiumBerylliumFluorides = Material.Builder(2184, GTLiteMod.id("lithium_beryllium_fluorides"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(ROUGH)
-            .components(LithiumFluoride, 1, BerylliumDifluoride, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("F3LiBe", true)
+        LithiumBerylliumFluorides = addMaterial(2184, "lithium_beryllium_fluorides")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(ROUGH)
+            components(LithiumFluoride, 1, BerylliumDifluoride, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2185 Flerovium-Ytterbium Plasma
-        FleroviumYtterbiumPlasma = Material.Builder(2185, GTLiteMod.id("flerovium_ytterbium_plasma"))
-            .plasma(FluidBuilder()
-                .temperature(10550)
-                .translation("gregtech.fluid.generic"))
-            .colorAverage()
-            .components(MetastableFlerovium, 1, Ytterbium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("FlY?", true)
+        FleroviumYtterbiumPlasma = addMaterial(2185, "flerovium_ytterbium_plasma")
+        {
+            plasma(FluidBuilder().temperature(10550).translation("gregtech.fluid.generic"))
+            colorAverage()
+            components(MetastableFlerovium, 1, Ytterbium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2186 Rubidium Titanate
-        RubidiumTitanate = Material.Builder(2186, GTLiteMod.id("rubidium_titanate"))
-            .ingot()
-            .fluid()
-            .color(0xB52E15).iconSet(SHINY)
-            .components(Rubidium, 2, Titanium, 1, Oxygen, 3)
-            .flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_BOLT_SCREW,
-                GENERATE_FOIL)
-            .blast { b ->
-                b.temp(4100, BlastProperty.GasTier.LOW) // RTM Alloy
-                    .blastStats(VA[LuV], 20 * SECOND)
-                    .vacuumStats(VA[EV], 16 * SECOND)
-            }
-            .build()
+        RubidiumTitanate = addMaterial(2186, "rubidium_titanate")
+        {
+            ingot()
+            fluid()
+            color(0xB52E15).iconSet(SHINY)
+            components(Rubidium, 2, Titanium, 1, Oxygen, 3)
+            flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_BOLT_SCREW, GENERATE_FOIL)
+            blastProp(4100, GasTier.LOW, // RTM Alloy
+                      VA[LuV], 20 * SECOND,
+                      VA[EV], 16 * SECOND)
+        }
 
         // 2187 Sodium Titanate
-        SodiumTitanate = Material.Builder(2187, GTLiteMod.id("sodium_titanate"))
-            .dust()
-            .color(0x2274BA).iconSet(SHINY)
-            .components(Sodium, 2, Titanium, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumTitanate = addMaterial(2187, "sodium_titanate")
+        {
+            dust()
+            color(0x2274BA).iconSet(SHINY)
+            components(Sodium, 2, Titanium, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2188 Rubidium Chloride
-        RubidiumChloride = Material.Builder(2188, GTLiteMod.id("rubidium_chloride"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Rubidium, 1, Chlorine, 1)
-            .build()
+        RubidiumChloride = addMaterial(2188, "rubidium_chloride")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Rubidium, 1, Chlorine, 1)
+        }
 
         // 2189 Sodium Oxide
-        SodiumOxide = Material.Builder(2189, GTLiteMod.id("sodium_oxide"))
-            .dust()
-            .color(0x2C96FC).iconSet(BRIGHT)
-            .components(Sodium, 2, Oxygen, 1)
-            .build()
+        SodiumOxide = addMaterial(2189, "sodium_oxide")
+        {
+            dust()
+            color(0x2C96FC).iconSet(BRIGHT)
+            components(Sodium, 2, Oxygen, 1)
+        }
 
         // 2190 Sodium Acetate
-        SodiumAcetate = Material.Builder(2190, GTLiteMod.id("sodium_acetate"))
-            .liquid()
-            .color(0xC5D624)
-            .components(SodiumHydroxide, 1, Ethenone, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C2H3NaO2", true)
+        SodiumAcetate = addMaterial(2190, "sodium_acetate")
+        {
+            liquid()
+            color(0xC5D624)
+            components(SodiumHydroxide, 1, Ethenone, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2191 Caesium Bromide
-        CaesiumBromide = Material.Builder(2191, GTLiteMod.id("caesium_bromide"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Caesium, 1, Bromine, 1)
-            .build()
+        CaesiumBromide = addMaterial(2191, "caesium_bromide")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Caesium, 1, Bromine, 1)
+        }
+
 
         // 2192 Francium Bromide
-        FranciumBromide = Material.Builder(2192, GTLiteMod.id("francium_bromide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Francium, 1, Bromine, 1)
-            .build()
+        FranciumBromide = addMaterial(2192, "francium_bromide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Francium, 1, Bromine, 1)
+        }
 
         // 2193 Francium Caesium Cadmium Bromide
-        FranciumCaesiumCadmiumBromide = Material.Builder(2193, GTLiteMod.id("francium_caesium_cadmium_bromide"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(SHINY)
-            .components(Francium, 1, Caesium, 1, Cadmium, 2, Bromine, 6)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(7100, BlastProperty.GasTier.HIGHER)
-                    .blastStats(VA[UHV], 20 * SECOND)
-                    .vacuumStats(VA[ZPM], 15 * SECOND)
-            }
-            .build()
+        FranciumCaesiumCadmiumBromide = addMaterial(2193, "francium_caesium_cadmium_bromide")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(SHINY)
+            components(Francium, 1, Caesium, 1, Cadmium, 2, Bromine, 6)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL)
+            blastProp(7100, GasTier.HIGHER, // Naquadah
+                      VA[UHV], 20 * SECOND,
+                      VA[ZPM], 15 * SECOND)
+        }
 
         // 2194 Sodium Seaborgate
-        SodiumSeaborgate = Material.Builder(2194, GTLiteMod.id("sodium_seaborgate"))
-            .ingot()
-            .fluid()
-            .color(0x55bbd4).iconSet(BRIGHT)
-            .components(Sodium, 2, Seaborgium, 1, Oxygen, 4)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(9800, BlastProperty.GasTier.HIGHER) // Tritanium
-                    .blastStats(VA[UV], 24 * SECOND)
-                    .vacuumStats(VA[ZPM], 12 * SECOND)
-            }
-            .build()
+        SodiumSeaborgate = addMaterial(2194, "sodium_seaborgate")
+        {
+            ingot()
+            fluid()
+            color(0x55bbd4).iconSet(BRIGHT)
+            components(Sodium, 2, Seaborgium, 1, Oxygen, 4)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(9800, GasTier.HIGHER, // Tritanium
+                      VA[UV], 24 * SECOND,
+                      VA[ZPM], 12 * SECOND)
+        }
 
         // 2195 Lead Scandium Tantalate
-        LeadScandiumTantalate = Material.Builder(2195, GTLiteMod.id("lead_scandium_tantalate"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Lead, 1, Scandium, 1, Tantalum, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        LeadScandiumTantalate = addMaterial(2195, "lead_scandium_tantalate")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Lead, 1, Scandium, 1, Tantalum, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2196 Thallium Sulfate
-        ThalliumSulfate = Material.Builder(2196, GTLiteMod.id("thallium_sulfate"))
-            .dust()
-            .color(0x9C222C).iconSet(METALLIC)
-            .components(Thallium, 2, Sulfur, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ThalliumSulfate = addMaterial(2196, "thallium_sulfate")
+        {
+            dust()
+            color(0x9C222C).iconSet(METALLIC)
+            components(Thallium, 2, Sulfur, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2197 Thallium Barium Calcium Cuprate (TBCCO)
-        ThalliumBariumCalciumCuprate = Material.Builder(2197, GTLiteMod.id("thallium_barium_calcium_cuprate"))
-            .ingot()
-            .fluid()
-            .color(0x669900).iconSet(SHINY)
-            .components(Thallium, 1, Barium, 2, Calcium, 2, Copper, 3, Oxygen, 10)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(7000, BlastProperty.GasTier.HIGHER) // Naquadah
-                    .blastStats(VA[UV], 43 * SECOND)
-                    .vacuumStats(VA[IV], 21 * SECOND)
-            }
-            .cableProperties(V[UHV], 2, 1)
-            .build()
+        ThalliumBariumCalciumCuprate = addMaterial(2197, "thallium_barium_calcium_cuprate")
+        {
+            ingot()
+            fluid()
+            color(0x669900).iconSet(SHINY)
+            components(Thallium, 1, Barium, 2, Calcium, 2, Copper, 3, Oxygen, 10)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(7000, GasTier.HIGHER, // Naquadah
+                      VA[UV], 43 * SECOND,
+                      VA[IV], 21 * SECOND)
+            cableProp(V[UHV], 2, 1)
+        }
 
         // 2198 Potassium Manganate
-        PotassiumManganate = Material.Builder(2198, GTLiteMod.id("potassium_manganate"))
-            .dust()
-            .color(0x873883).iconSet(METALLIC)
-            .components(Potassium, 2, Manganese, 1, Oxygen, 4)
-            .build()
+        PotassiumManganate = addMaterial(2198, "potassium_manganate")
+        {
+            dust()
+            color(0x873883).iconSet(METALLIC)
+            components(Potassium, 2, Manganese, 1, Oxygen, 4)
+        }
 
         // 2199 Potassium Permanganate
-        PotassiumPermanganate = Material.Builder(2199, GTLiteMod.id("potassium_permanganate"))
-            .dust()
-            .color(0x871D82).iconSet(DULL)
-            .components(Potassium, 1, Manganese, 1, Oxygen, 4)
-            .build()
+        PotassiumPermanganate = addMaterial(2199, "potassium_permanganate")
+        {
+            dust()
+            color(0x871D82).iconSet(DULL)
+            components(Potassium, 1, Manganese, 1, Oxygen, 4)
+        }
 
         // 2200 Lanthanum Gallium Manganate
-        LanthanumGalliumManganate = Material.Builder(2200, GTLiteMod.id("lanthanum_gallium_manganate"))
-            .ingot()
-            .fluid()
-            .color(0x8AA07B).iconSet(METALLIC)
-            .components(Lanthanum, 1, Gallium, 1, Manganese, 1, Oxygen, 4)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(8000, BlastProperty.GasTier.HIGH) // Trinium
-                    .blastStats(VA[UV], 45 * SECOND)
-                    .vacuumStats(VA[IV], 22 * SECOND + 10 * TICK)
-            }
-            .build()
+        LanthanumGalliumManganate = addMaterial(2200, "lanthanum_gallium_manganate")
+        {
+            ingot()
+            fluid()
+            color(0x8AA07B).iconSet(METALLIC)
+            components(Lanthanum, 1, Gallium, 1, Manganese, 1, Oxygen, 4)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL)
+            blastProp(8000, GasTier.HIGH, // Trinium
+                      VA[UV], 45 * SECOND,
+                      VA[IV], 22 * SECOND + 10 * TICK)
+        }
 
         // 2201 Barium Strontium Titanate
-        BariumStrontiumTitanate = Material.Builder(2201, GTLiteMod.id("barium_strontium_titanate"))
-            .ingot()
-            .fluid()
-            .color(0xFF0066).iconSet(SHINY)
-            .components(Barium, 1, Strontium, 1, Titanium, 1, Oxygen, 4)
-            .flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(7200, BlastProperty.GasTier.HIGH) // Naquadah
-                    .blastStats(VA[ZPM], 36 * SECOND)
-                    .vacuumStats(VA[IV], 18 * SECOND)
-            }
-            .build()
+        BariumStrontiumTitanate = addMaterial(2201, "barium_strontium_titanate")
+        {
+            ingot()
+            fluid()
+            color(0xFF0066).iconSet(SHINY)
+            components(Barium, 1, Strontium, 1, Titanium, 1, Oxygen, 4)
+            flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_BOLT_SCREW)
+            blastProp(7200, GasTier.HIGH, // Naquadah
+                      VA[ZPM], 36 * SECOND,
+                      VA[IV], 18 * SECOND)
+        }
 
         // 2202 Lutetium Manganese Germanium
-        LutetiumManganeseGermanium = Material.Builder(2202, GTLiteMod.id("lutetium_manganese_germanium"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(MAGNETIC)
-            .components(Lutetium, 1, Manganese, 3, Germanium, 6)
-            .flags(EXT_METAL, GENERATE_LONG_ROD, GENERATE_RING, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(7000, BlastProperty.GasTier.HIGHER) // Naquadah
-                    .blastStats(VA[LuV], 1 * MINUTE)
-                    .vacuumStats(VA[EV], 30 * SECOND)
-            }
-            .build() // This is not a reality magnetic material... it is a fantastic permanent magnet? ^^ i think it is well in Gregtech.
+        // This is not a reality magnetic material... it is a fantastic permanent magnet? ^^ i think it is well in Gregtech.
+        LutetiumManganeseGermanium = addMaterial(2202, "lutetium_manganese_germanium")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(MAGNETIC)
+            components(Lutetium, 1, Manganese, 3, Germanium, 6)
+            flags(EXT_METAL, GENERATE_LONG_ROD, GENERATE_RING, GENERATE_SPRING_SMALL)
+            blastProp(7000, GasTier.HIGHER, // Naquadah
+                      VA[LuV], 1 * MINUTE,
+                      VA[EV], 30 * SECOND)
+        }
 
         // 2203 Boric Acid
-        BoricAcid = Material.Builder(2203, GTLiteMod.id("boric_acid"))
-            .dust()
-            .color(0xFAFAFA).iconSet(SHINY)
-            .components(Hydrogen, 3, Boron, 1, Oxygen, 3)
-            .build()
+        BoricAcid = addMaterial(2203, "boric_acid")
+        {
+            dust()
+            color(0xFAFAFA).iconSet(SHINY)
+            components(Hydrogen, 3, Boron, 1, Oxygen, 3)
+        }
 
         // 2204 Boron Trioxide
-        BoronTrioxide = Material.Builder(2204, GTLiteMod.id("boron_trioxide"))
-            .dust()
-            .color(0xE9FAC0).iconSet(METALLIC)
-            .components(Boron, 2, Oxygen, 3)
-            .build()
+        BoronTrioxide = addMaterial(2204, "boron_trioxide")
+        {
+            dust()
+            color(0xE9FAC0).iconSet(METALLIC)
+            components(Boron, 2, Oxygen, 3)
+        }
 
         // 2205 Boron Trifluoride
-        BoronTrifluoride = Material.Builder(2205, GTLiteMod.id("boron_trifluoride"))
-            .gas()
-            .color(0xFAF191)
-            .components(Boron, 1, Fluorine, 3)
-            .build()
+        BoronTrifluoride = addMaterial(2205, "boron_trifluoride")
+        {
+            gas()
+            color(0xFAF191)
+            components(Boron, 1, Fluorine, 3)
+        }
 
         // 2206 Lithium Hydride
-        LithiumHydride = Material.Builder(2206, GTLiteMod.id("lithium_hydride"))
-            .ingot()
-            .color(0x9BAFDB).iconSet(METALLIC)
-            .components(Lithium, 1, Hydrogen, 1)
-            .build()
+        LithiumHydride = addMaterial(2206, "lithium_hydride")
+        {
+            ingot()
+            color(0x9BAFDB).iconSet(METALLIC)
+            components(Lithium, 1, Hydrogen, 1)
+        }
 
         // 2207 Lithium Tetrafluoroborate
-        LithiumTetrafluoroborate = Material.Builder(2207, GTLiteMod.id("lithium_tetrafluoroborate"))
-            .dust()
-            .color(0x90FAF6).iconSet(SHINY)
-            .components(Lithium, 1, Boron, 1, Fluorine, 4)
-            .build()
+        LithiumTetrafluoroborate = addMaterial(2207, "lithium_tetrafluoroborate")
+        {
+            dust()
+            color(0x90FAF6).iconSet(SHINY)
+            components(Lithium, 1, Boron, 1, Fluorine, 4)
+        }
 
         // 2208 Boron Trichloride
-        BoronTrichloride = Material.Builder(2208, GTLiteMod.id("boron_trichloride"))
-            .gas()
-            .color(0x033F1B)
-            .components(Boron, 1, Chlorine, 3)
-            .build()
+        BoronTrichloride = addMaterial(2208, "boron_trichloride")
+        {
+            gas()
+            color(0x033F1B)
+            components(Boron, 1, Chlorine, 3)
+        }
+
 
         // 2209 Hexagonal Boron Nitride
-        HexagonalBoronNitride = Material.Builder(2209, GTLiteMod.id("hexagonal_boron_nitride"))
-            .gem()
-            .color(0x6A6A72).iconSet(GEM_VERTICAL)
-            .components(Boron, 1, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("h-BN", true)
+        HexagonalBoronNitride = addMaterial(2209, "hexagonal_boron_nitride")
+        {
+            gem()
+            color(0x6A6A72).iconSet(GEM_VERTICAL)
+            components(Boron, 1, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2210 Cubic Boron Nitride
-        CubicBoronNitride = Material.Builder(2210, GTLiteMod.id("cubic_boron_nitride"))
-            .gem()
-            .color(0x545572).iconSet(DIAMOND)
-            .components(Boron, 1, Nitrogen, 1)
-            .flags(EXT_METAL, DISABLE_CRYSTALLIZATION, DISABLE_DECOMPOSITION, FLAMMABLE,
-                EXPLOSIVE, GENERATE_GEAR, GENERATE_LONG_ROD, GENERATE_LENS)
-            .toolStats(MaterialToolProperty(14.0F, 9.0F, 12400, 15))
-            .build()
-            .setFormula("c-BN", true)
+        CubicBoronNitride = addMaterial(2210, "cubic_boron_nitride")
+        {
+            gem()
+            color(0x545572).iconSet(DIAMOND)
+            components(Boron, 1, Nitrogen, 1)
+            flags(EXT_METAL, DISABLE_CRYSTALLIZATION, DISABLE_DECOMPOSITION, FLAMMABLE, EXPLOSIVE, GENERATE_GEAR,
+                  GENERATE_LONG_ROD, GENERATE_LENS)
+            toolProp(14.0F, 9.0F, 12400, 15)
+        }
 
         // 2211 Amorphous Boron Nitride
-        AmorphousBoronNitride = Material.Builder(2211, GTLiteMod.id("amorphous_boron_nitride"))
-            .ingot()
-            .color(0x9193C5).iconSet(SHINY)
-            .components(Boron, 1, Nitrogen, 1)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_FOIL)
-            .build()
-            .setFormula("a-BN", true)
+        AmorphousBoronNitride = addMaterial(2211, "amorphous_boron_nitride")
+        {
+            ingot()
+            color(0x9193C5).iconSet(SHINY)
+            components(Boron, 1, Nitrogen, 1)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_FOIL)
+        }
 
         // 2212 Heterodiamond
-        Heterodiamond = Material.Builder(2212, GTLiteMod.id("heterodiamond"))
-            .gem()
-            .color(0x512A72).iconSet(GEM_HORIZONTAL)
-            .components(Boron, 1, Carbon, 1, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
+        Heterodiamond = addMaterial(2212, "heterodiamond")
+        {
+            gem()
+            color(0x512A72).iconSet(GEM_HORIZONTAL)
+            components(Boron, 1, Carbon, 1, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2213 Cubic Heterodiamond
-        CubicHeterodiamond = Material.Builder(2213, GTLiteMod.id("cubic_heterodiamond"))
-            .gem()
-            .color(0x753DA6).iconSet(DIAMOND)
-            .components(Boron, 1, Carbon, 2, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("c-BC2N", true)
+        CubicHeterodiamond = addMaterial(2213, "cubic_heterodiamond")
+        {
+            gem()
+            color(0x753DA6).iconSet(DIAMOND)
+            components(Boron, 1, Carbon, 2, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2214 Calcium Carbide
-        CalciumCarbide = Material.Builder(2214, GTLiteMod.id("calcium_carbide"))
-            .dust()
-            .color(0x807B70).iconSet(DULL)
-            .components(Calcium, 1, Carbon, 2)
-            .build()
+        CalciumCarbide = addMaterial(2214, "calcium_carbide")
+        {
+            dust()
+            color(0x807B70).iconSet(DULL)
+            components(Calcium, 1, Carbon, 2)
+        }
 
         // 2215 Calcium Hydroxide
-        CalciumHydroxide = Material.Builder(2215, GTLiteMod.id("calcium_hydroxide"))
-            .dust()
-            .color(0x5F8764).iconSet(ROUGH)
-            .components(Calcium, 1, Hydrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Ca(OH)2", true)
+        CalciumHydroxide = addMaterial(2215, "calcium_hydroxide")
+        {
+            dust()
+            color(0x5F8764).iconSet(ROUGH)
+            components(Calcium, 1, Hydrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2216 Chromium Germanium Telluride
-        ChromiumGermaniumTelluride = Material.Builder(2216, GTLiteMod.id("chromium_germanium_telluride"))
-            .ingot()
-            .fluid()
-            .color(0x8F103E).iconSet(METALLIC)
-            .components(Chrome, 1, Germanium, 1, Tellurium, 3)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_ROD, GENERATE_LONG_ROD)
-            .blast { b ->
-                b.temp(8900, BlastProperty.GasTier.HIGHER) // Trinium
-                    .blastStats(VA[LuV], 1 * MINUTE + 30 * SECOND)
-                    .vacuumStats(VA[IV], 20 * SECOND)
-            }
-            .build()
+        ChromiumGermaniumTelluride = addMaterial(2216, "chromium_germanium_telluride")
+        {
+            ingot()
+            fluid()
+            color(0x8F103E).iconSet(METALLIC)
+            components(Chrome, 1, Germanium, 1, Tellurium, 3)
+            flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_ROD, GENERATE_LONG_ROD)
+            blastProp(8900, GasTier.HIGHER, // Trinium
+                      VA[LuV], 1 * MINUTE + 30 * SECOND,
+                      VA[IV], 20 * SECOND)
+        }
 
         // 2217 Magnetic Chromium Germanium Telluride
-        ChromiumGermaniumTellurideMagnetic = Material.Builder(2217, GTLiteMod.id("chromium_germanium_telluride_magnetic"))
-            .ingot()
-            .color(0x8F103E).iconSet(MAGNETIC)
-            .components(ChromiumGermaniumTelluride, 1)
-            .flags(GENERATE_ROD, GENERATE_LONG_ROD, IS_MAGNETIC, GENERATE_SPRING_SMALL)
-            .ingotSmeltInto(ChromiumGermaniumTelluride)
-            .arcSmeltInto(ChromiumGermaniumTelluride)
-            .macerateInto(ChromiumGermaniumTelluride)
-            .build()
+        ChromiumGermaniumTellurideMagnetic = addMaterial(2217, "chromium_germanium_telluride_magnetic")
+        {
+            ingot()
+            color(0x8F103E).iconSet(MAGNETIC)
+            components(ChromiumGermaniumTelluride, 1)
+            flags(GENERATE_ROD, GENERATE_LONG_ROD, IS_MAGNETIC, GENERATE_SPRING_SMALL)
+            ingotSmeltInto(ChromiumGermaniumTelluride)
+            arcSmeltInto(ChromiumGermaniumTelluride)
+            macerateInto(ChromiumGermaniumTelluride)
+        }
 
         // 2218 Gallium Trichloride
-        GalliumTrichloride = Material.Builder(2218, GTLiteMod.id("gallium_trichloride"))
-            .dust()
-            .color(0x6EB4FF).iconSet(ROUGH)
-            .components(Gallium, 1, Chlorine, 3)
-            .build()
+        GalliumTrichloride = addMaterial(2218, "gallium_trichloride")
+        {
+            dust()
+            color(0x6EB4FF).iconSet(ROUGH)
+            components(Gallium, 1, Chlorine, 3)
+        }
 
         // 2219 Gallium Trioxide
-        GalliumTrioxide = Material.Builder(2219, GTLiteMod.id("gallium_trioxide"))
-            .dust()
-            .color(0xE4CDFF).iconSet(METALLIC)
-            .components(Gallium, 2, Oxygen, 3)
-            .build()
+        GalliumTrioxide = addMaterial(2219, "gallium_trioxide")
+        {
+            dust()
+            color(0xE4CDFF).iconSet(METALLIC)
+            components(Gallium, 2, Oxygen, 3)
+        }
 
         // 2220 Gallium Nitride
-        GalliumNitride = Material.Builder(2220, GTLiteMod.id("gallium_nitride"))
-            .ingot()
-            .color(0xFFF458).iconSet(SHINY)
-            .flags(STD_METAL)
-            .components(Gallium, 1, Nitrogen, 1)
-            .build()
+        GalliumNitride = addMaterial(2220, "gallium_nitride")
+        {
+            ingot()
+            color(0xFFF458).iconSet(SHINY)
+            flags(STD_METAL)
+            components(Gallium, 1, Nitrogen, 1)
+        }
 
         // 2221 Aluminium Trichloride
-        AluminiumTrichloride = Material.Builder(2221, GTLiteMod.id("aluminium_trichloride"))
-            .dust()
-            .color(0x78C3EB).iconSet(SHINY)
-            .components(Aluminium, 1, Chlorine, 3)
-            .build()
+        AluminiumTrichloride = addMaterial(2221, "aluminium_trichloride")
+        {
+            dust()
+            color(0x78C3EB).iconSet(SHINY)
+            components(Aluminium, 1, Chlorine, 3)
+        }
 
         // 2222 Niobium Pentachloride
-        NiobiumPentachloride = Material.Builder(2222, GTLiteMod.id("niobium_pentachloride"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Niobium, 1, Chlorine, 5)
-            .build()
+        NiobiumPentachloride = addMaterial(2222, "niobium_pentachloride")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Niobium, 1, Chlorine, 5)
+        }
 
         // 2223 Lithium Niobate
-        LithiumNiobate = Material.Builder(2223, GTLiteMod.id("lithium_niobate"))
-            .ingot()
-            .fluid()
-            .color(0xD27700).iconSet(SHINY)
-            .components(Lithium, 1, Niobium, 1, Oxygen, 4)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_LENS, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(3226, BlastProperty.GasTier.HIGH) // Nichrome
-                    .blastStats(VA[ZPM], 40 * SECOND)
-                    .vacuumStats(VA[IV], 10 * SECOND)
-            }
-            .build()
+        LithiumNiobate = addMaterial(2223, "lithium_niobate")
+        {
+            ingot()
+            fluid()
+            color(0xD27700).iconSet(SHINY)
+            components(Lithium, 1, Niobium, 1, Oxygen, 4)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_LENS, GENERATE_FOIL)
+            blastProp(3226, GasTier.HIGH, // Nichrome
+                      VA[ZPM], 40 * SECOND,
+                      VA[IV], 10 * SECOND)
+        }
 
         // 2224 Manganese Sulfate
-        ManganeseSulfate = Material.Builder(2224, GTLiteMod.id("manganese_sulfate"))
-            .dust()
-            .color(0xF0F895).iconSet(ROUGH)
-            .components(Manganese, 1, Sulfur, 1, Oxygen, 4)
-            .build()
+        ManganeseSulfate = addMaterial(2224, "manganese_sulfate")
+        {
+            dust()
+            color(0xF0F895).iconSet(ROUGH)
+            components(Manganese, 1, Sulfur, 1, Oxygen, 4)
+        }
 
         // 2225 Potassium Sulfate
-        PotassiumSulfate = Material.Builder(2225, GTLiteMod.id("potassium_sulfate"))
-            .dust()
-            .color(0xF4FBB0).iconSet(DULL)
-            .components(Potassium, 2, Sulfur, 1, Oxygen, 4)
-            .build()
+        PotassiumSulfate = addMaterial(2225, "potassium_sulfate")
+        {
+            dust()
+            color(0xF4FBB0).iconSet(DULL)
+            components(Potassium, 2, Sulfur, 1, Oxygen, 4)
+        }
 
         // 2226 Neodymium-doped Yttrium Oxide
-        NeodymiumDopedYttriumOxide = Material.Builder(2226, GTLiteMod.id("neodymium_doped_yttrium_oxide"))
-            .dust()
-            .color(0x5AD55F).iconSet(DULL)
-            .components(YttriumOxide, 1, NeodymiumOxide, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NeodymiumDopedYttriumOxide = addMaterial(2226, "neodymium_doped_yttrium_oxide")
+        {
+            dust()
+            color(0x5AD55F).iconSet(DULL)
+            components(YttriumOxide, 1, NeodymiumOxide, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2227 Aluminium Nitrate
-        AluminiumNitrate = Material.Builder(2227, GTLiteMod.id("aluminium_nitrate"))
-            .dust()
-            .color(0x3AB3AA).iconSet(SHINY)
-            .components(Aluminium, 1, Nitrogen, 3, Oxygen, 9)
-            .build()
-            .setFormula("Al(NO3)3", true)
+        AluminiumNitrate = addMaterial(2227, "aluminium_nitrate")
+        {
+            dust()
+            color(0x3AB3AA).iconSet(SHINY)
+            components(Aluminium, 1, Nitrogen, 3, Oxygen, 9)
+        }
 
         // 2228 Chlorinated Solvents
-        ChlorinatedSolvents = Material.Builder(2228, GTLiteMod.id("chlorinated_solvents"))
-            .liquid()
-            .color(0x40804c)
-            .components(Carbon, 2, Hydrogen, 8, Chlorine, 5)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH4)2Cl5", true)
+        ChlorinatedSolvents = addMaterial(2228, "chlorinated_solvents")
+        {
+            liquid()
+            color(0x40804c)
+            components(Carbon, 2, Hydrogen, 8, Chlorine, 5)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2229 Alumina Solution
-        AluminaSolution = Material.Builder(2229, GTLiteMod.id("alumina_solution"))
-            .liquid()
-            .color(0x6C4DC1)
-            .components(Alumina, 1, Carbon, 25, Hydrogen, 56, Chlorine, 2, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(Al2O3)(CH2Cl2)(C12H27N)2", true)
+        AluminaSolution = addMaterial(2229, "alumina_solution")
+        {
+            liquid()
+            color(0x6C4DC1)
+            components(Alumina, 1, Carbon, 25, Hydrogen, 56, Chlorine, 2, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2230 Nd:YAG
-        NdYAG = Material.Builder(2230, GTLiteMod.id("nd_yag"))
-            .gem()
-            .color(0xD99DE4).iconSet(GEM_VERTICAL)
-            .components(YttriumOxide, 2, NeodymiumOxide, 1, Alumina, 5)
-            .flags(CRYSTALLIZABLE, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("Nd:YAG", true)
+        NdYAG = addMaterial(2230, "nd_yag")
+        {
+            gem()
+            color(0xD99DE4).iconSet(GEM_VERTICAL)
+            components(YttriumOxide, 2, NeodymiumOxide, 1, Alumina, 5)
+            flags(STD_METAL, CRYSTALLIZABLE, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_LENS)
+        }
 
         // 2231 Scandium-Titanium Mixture
-        ScandiumTitaniumMixture = Material.Builder(2231, GTLiteMod.id("scandium_titanium_mixture"))
-            .liquid()
-            .colorAverage()
-            .components(Scandium, 1, Titanium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ScandiumTitaniumMixture = addMaterial(2231, "scandium_titanium_mixture")
+        {
+            liquid()
+            colorAverage()
+            components(Scandium, 1, Titanium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2232 Radium-Radon Mixture
-        RadiumRadonMixture = Material.Builder(2232, GTLiteMod.id("radium_radon_mixture"))
-            .liquid()
-            .colorAverage()
-            .components(Radium, 1, Radon, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RadiumRadonMixture = addMaterial(2232, "radium_radon_mixture")
+        {
+            liquid()
+            colorAverage()
+            components(Radium, 1, Radon, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2233 Polonium Nitrate
-        PoloniumNitrate = Material.Builder(2233, GTLiteMod.id("polonium_nitrate"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Polonium, 1, Nitrogen, 4, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Po(NO3)4", true)
+        PoloniumNitrate = addMaterial(2233, "polonium_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Polonium, 1, Nitrogen, 4, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2234 Sodium Polonate
-        SodiumPolonate = Material.Builder(2234, GTLiteMod.id("sodium_polonate"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Sodium, 2, Polonium, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Na2PoO4", true)
+        SodiumPolonate = addMaterial(2234, "sodium_polonate")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Sodium, 2, Polonium, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2235 Polonium Dioxide
-        PoloniumDioxide = Material.Builder(2235, GTLiteMod.id("polonium_dioxide"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Polonium, 1, Oxygen, 2)
-            .build()
+        PoloniumDioxide = addMaterial(2235, "polonium_dioxide")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Polonium, 1, Oxygen, 2)
+        }
 
         // 2236 Uranyl Chloride Solution
-        UranylChlorideSolution = Material.Builder(2236, GTLiteMod.id("uranyl_chloride_solution"))
-            .liquid()
-            .color(0xDFE018)
-            .components(Uraninite, 1, Chlorine, 2, Water, 1, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        UranylChlorideSolution = addMaterial(2236, "uranyl_chloride_solution")
+        {
+            liquid()
+            color(0xDFE018)
+            components(Uraninite, 1, Chlorine, 2, Water, 1, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2237 Uranyl Nitrate Solution
-        UranylNitrateSolution = Material.Builder(2237, GTLiteMod.id("uranyl_nitrate_solution"))
-            .liquid()
-            .colorAverage()
-            .components(Uraninite, 1, Nitrogen, 2, Oxygen, 7, Hydrogen, 2, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(UO2)(NO3)2(H2O)?", true)
+        UranylNitrateSolution = addMaterial(2237, "uranyl_nitrate_solution")
+        {
+            liquid()
+            colorAverage()
+            components(Uraninite, 1, Nitrogen, 2, Oxygen, 7, Hydrogen, 2, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2238 Radium Sulfate
-        RadiumSulfate = Material.Builder(2238, GTLiteMod.id("radium_sulfate"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Radium, 1, Sulfur, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RadiumSulfate = addMaterial(2238, "radium_sulfate")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Radium, 1, Sulfur, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2239 Lead Sulfate
-        LeadSulfate = Material.Builder(2239, GTLiteMod.id("lead_sulfate"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Lead, 1, Sulfur, 1, Oxygen, 4)
-            .build()
+        LeadSulfate = addMaterial(2239, "lead_sulfate")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Lead, 1, Sulfur, 1, Oxygen, 4)
+        }
 
         // 2240 Thorium Nitrate
-        ThoriumNitrate = Material.Builder(2240, GTLiteMod.id("thorium_nitrate"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Thorium, 1, Nitrogen, 4, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Th(NO3)4", true)
+        ThoriumNitrate = addMaterial(2240, "thorium_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Thorium, 1, Nitrogen, 4, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2241 Radium Dichloride
-        RadiumDichloride = Material.Builder(2241, GTLiteMod.id("radium_dichloride"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Radium, 1, Chlorine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RadiumDichloride = addMaterial(2241, "radium_dichloride")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Radium, 1, Chlorine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2242 Thorium Dioxide
-        ThoriumDioxide = Material.Builder(2242, GTLiteMod.id("thorium_dioxide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Thorium, 1, Oxygen, 2)
-            .build()
+        ThoriumDioxide = addMaterial(2242, "thorium_dioxide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Thorium, 1, Oxygen, 2)
+        }
 
         // 2243 Uranyl Nitrate
-        UranylNitrate = Material.Builder(2243, GTLiteMod.id("uranyl_nitrate"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Uraninite, 1, Nitrogen, 2, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("UO2(NO3)2", true)
+        UranylNitrate = addMaterial(2243, "uranyl_nitrate")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Uraninite, 1, Nitrogen, 2, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2244 Barium Oxide
-        BariumOxide = Material.Builder(2244, GTLiteMod.id("barium_oxide"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Barium, 1, Oxygen, 1)
-            .build()
+        BariumOxide = addMaterial(2244, "barium_oxide")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Barium, 1, Oxygen, 1)
+        }
 
         // 2245 Woods Glass
-        WoodsGlass = Material.Builder(2245, GTLiteMod.id("woods_glass"))
-            .ingot()
-            .fluid()
-            .color(0x730099).iconSet(SHINY)
-            .components(SodaAsh, 6, SiliconDioxide, 3, BariumOxide, 2, Garnierite, 2)
-            .flags(NO_SMASHING, NO_WORKING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                   GENERATE_LENS)
-            .blast { b ->
-                b.temp(1163, BlastProperty.GasTier.MID)
-                    .blastStats(VA[IV])
-            }
-            .build()
+        WoodsGlass = addMaterial(2245, "woods_glass")
+        {
+            ingot()
+            fluid()
+            color(0x730099).iconSet(SHINY)
+            components(SodaAsh, 6, SiliconDioxide, 3, BariumOxide, 2, Garnierite, 2)
+            flags(NO_SMASHING, NO_WORKING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_LENS)
+            blastProp(1163, GasTier.MID, // Cupronickel
+                      VA[IV], 7 * SECOND + 4 * TICK,
+                      VA[HV], 2 * SECOND + 16 * TICK)
+        }
 
         // 2246 Potassium Tertbutoxide
-        PotassiumTertbutoxide = Material.Builder(2246, GTLiteMod.id("potassium_tertbutoxide"))
-            .dust()
-            .color(0xFB7366).iconSet(DULL)
-            .components(Carbon, 4, Hydrogen, 9, Oxygen, 1, Potassium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PotassiumTertbutoxide = addMaterial(2246, "potassium_tertbutoxide")
+        {
+            dust()
+            color(0xFB7366).iconSet(DULL)
+            components(Carbon, 4, Hydrogen, 9, Oxygen, 1, Potassium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2247 Caesium Hydroxide
-        CaesiumHydroxide = Material.Builder(2247, GTLiteMod.id("caesium_hydroxide"))
-            .dust()
-            .color(0xAF6341).iconSet(METALLIC)
-            .components(Caesium, 1, Oxygen, 1, Hydrogen, 1)
-            .build()
+        CaesiumHydroxide = addMaterial(2247, "caesium_hydroxide")
+        {
+            dust()
+            color(0xAF6341).iconSet(METALLIC)
+            components(Caesium, 1, Oxygen, 1, Hydrogen, 1)
+        }
 
         // 2248 Caesium Carbonate
-        CaesiumCarbonate = Material.Builder(2248, GTLiteMod.id("caesium_carbonate"))
-            .dust()
-            .color(0x62D4F3).iconSet(SHINY)
-            .components(Caesium, 2, Carbon, 1, Oxygen, 3)
-            .build()
+        CaesiumCarbonate = addMaterial(2248, "caesium_carbonate")
+        {
+            dust()
+            color(0x62D4F3).iconSet(SHINY)
+            components(Caesium, 2, Carbon, 1, Oxygen, 3)
+        }
 
         // 2249 Sodium Hydride
-        SodiumHydride = Material.Builder(2249, GTLiteMod.id("sodium_hydride"))
-            .ingot()
-            .color(0xCACAC8).iconSet(METALLIC)
-            .components(Sodium, 1, Hydrogen, 1)
-            .build()
+        SodiumHydride = addMaterial(2249, "sodium_hydride")
+        {
+            ingot()
+            color(0xCACAC8).iconSet(METALLIC)
+            components(Sodium, 1, Hydrogen, 1)
+        }
 
         // 2250 Vanadium Pentoxide
-        VanadiumPentoxide = Material.Builder(2250, GTLiteMod.id("vanadium_pentoxide"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Vanadium, 2, Oxygen, 5)
-            .build()
+        VanadiumPentoxide = addMaterial(2250, "vanadium_pentoxide")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Vanadium, 2, Oxygen, 5)
+        }
 
         // 2251 Actinium Oxalate
-        ActiniumOxalate = Material.Builder(2251, GTLiteMod.id("actinium_oxalate"))
-            .dust()
-            .color(0x92ACFF).iconSet(SHINY)
-            .components(Actinium, 1, Carbon, 4, Oxygen, 8)
-            .build()
-            .setFormula("Ac(CO2)4", true)
+        ActiniumOxalate = addMaterial(2251, "actinium_oxalate")
+        {
+            dust()
+            color(0x92ACFF).iconSet(SHINY)
+            components(Actinium, 1, Carbon, 4, Oxygen, 8)
+        }
 
         // 2252 Actinium Trihydride
-        ActiniumTrihydride = Material.Builder(2252, GTLiteMod.id("actinium_trihydride"))
-            .dust()
-            .color(0xD5DFFF).iconSet(SHINY)
-            .components(Actinium, 1, Hydrogen, 3)
-            .flags(DISABLE_DECOMPOSITION, FORCE_GENERATE_BLOCK)
-            .build()
+        ActiniumTrihydride = addMaterial(2252, "actinium_trihydride")
+        {
+            dust()
+            color(0xD5DFFF).iconSet(SHINY)
+            components(Actinium, 1, Hydrogen, 3)
+            flags(DISABLE_DECOMPOSITION, FORCE_GENERATE_BLOCK)
+        }
 
         // 2253 Actinium Superhydride
-        ActiniumSuperhydride = Material.Builder(2253, GTLiteMod.id("actinium_superhydride"))
-            .dust()
-            .plasma(FluidBuilder()
-                .temperature(500_000))
-            .color(Actinium.materialRGB * 9 / 8).iconSet(SHINY)
-            .components(Actinium, 1, Hydrogen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ActiniumSuperhydride = addMaterial(2253, "actinium_superhydride")
+        {
+            dust()
+            plasma(FluidBuilder().temperature(500_000))
+            color(Actinium.materialRGB * 9 / 8).iconSet(SHINY)
+            components(Actinium, 1, Hydrogen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2254 Sodium Formate
-        SodiumFormate = Material.Builder(2254, GTLiteMod.id("sodium_formate"))
-            .dust()
-            .color(0x416CC0).iconSet(ROUGH)
-            .components(Carbon, 1, Hydrogen, 1, Oxygen, 2, Sodium, 1)
-            .build()
-            .setFormula("HCOONa", false)
+        SodiumFormate = addMaterial(2254, "sodium_formate")
+        {
+            dust()
+            color(0x416CC0).iconSet(ROUGH)
+            components(Carbon, 1, Hydrogen, 1, Oxygen, 2, Sodium, 1)
+        }
 
         // 2255 Sodium Thiosulfate
-        SodiumThiosulfate = Material.Builder(2255, GTLiteMod.id("sodium_thiosulfate"))
-            .dust()
-            .color(0x1436A7).iconSet(METALLIC)
-            .components(Sodium, 2, Sulfur, 2, Oxygen, 3)
-            .build()
+        SodiumThiosulfate = addMaterial(2255, "sodium_thiosulfate")
+        {
+            dust()
+            color(0x1436A7).iconSet(METALLIC)
+            components(Sodium, 2, Sulfur, 2, Oxygen, 3)
+        }
 
         // 2256 Lithium Thiinediselenide
-        LithiumThiinediselenide = Material.Builder(2256, GTLiteMod.id("lithium_thiinediselenide"))
-            .dust()
-            .color(0x689E64).iconSet(DULL)
-            .components(Carbon, 4, Hydrogen, 4, Sulfur, 2, Lithium, 2, Selenium, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        LithiumThiinediselenide = addMaterial(2256, "lithium_thiinediselenide")
+        {
+            dust()
+            color(0x689E64).iconSet(DULL)
+            components(Carbon, 4, Hydrogen, 4, Sulfur, 2, Lithium, 2, Selenium, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2257 BETS Perrhenate (BETSP)
-        BETSPerrhenate = Material.Builder(2257, GTLiteMod.id("bets_perrhenate"))
-            .dust()
-            .color(0x98E993).iconSet(SHINY)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Rhenium, 1, Carbon, 10, Hydrogen, 8, Sulfur, 4, Selenium, 4, Oxygen, 4)
-            .build()
-            .setFormula("(C10H8S4Se4)ReO4", true)
+        BETSPerrhenate = addMaterial(2257, "bets_perrhenate")
+        {
+            dust()
+            color(0x98E993).iconSet(SHINY)
+            flags(DISABLE_DECOMPOSITION)
+            components(Rhenium, 1, Carbon, 10, Hydrogen, 8, Sulfur, 4, Selenium, 4, Oxygen, 4)
+        }
 
         // 2258 Helium-Neon
-        HeliumNeon = Material.Builder(2258, GTLiteMod.id("helium_neon"))
-            .gas()
-            .color(0xFF0080)
-            .components(Helium, 1, Neon, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        HeliumNeon = addMaterial(2258, "helium_neon")
+        {
+            gas()
+            color(0xFF0080)
+            components(Helium, 1, Neon, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 2259 Germanium Tetrachloride
-        GermaniumTetrachloride = Material.Builder(2259, GTLiteMod.id("germanium_tetrachloride"))
-            .liquid()
-            .color(0x787878)
-            .components(Germanium, 1, Chlorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        GermaniumTetrachloride = addMaterial(2259, "germanium_tetrachloride")
+        {
+            liquid()
+            color(0x787878)
+            components(Germanium, 1, Chlorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2260 Silicon Tetrachloride
-        SiliconTetrachloride = Material.Builder(2260, GTLiteMod.id("silicon_tetrachloride"))
-            .liquid()
-            .color(0x5B5B7A)
-            .components(Silicon, 1, Chlorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SiliconTetrachloride = addMaterial(2260, "silicon_tetrachloride")
+        {
+            liquid()
+            color(0x5B5B7A)
+            components(Silicon, 1, Chlorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2261 Caesium Cerium Cobalt Indium
-        CaesiumCeriumCobaltIndium = Material.Builder(2261, GTLiteMod.id("caesium_cerium_cobalt_indium"))
-            .ingot()
-            .fluid()
-            .color(0x01E068).iconSet(MAGNETIC)
-            .components(Caesium, 1, Cerium, 1, Cobalt, 2, Indium, 10)
-            .flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(8900, BlastProperty.GasTier.HIGH) // Trinium
-                    .blastStats(VA[UV], 34 * SECOND)
-                    .vacuumStats(VA[ZPM], 17 * SECOND)
-            }
-            .build()
+        CaesiumCeriumCobaltIndium = addMaterial(2261, "caesium_cerium_cobalt_indium")
+        {
+            ingot()
+            fluid()
+            color(0x01E068).iconSet(MAGNETIC)
+            components(Caesium, 1, Cerium, 1, Cobalt, 2, Indium, 10)
+            flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_BOLT_SCREW)
+            blastProp(8900, GasTier.HIGH, // Trinium
+                      VA[UV], 34 * SECOND,
+                      VA[ZPM], 17 * SECOND)
+        }
 
         // 2262 Mercury Cadmium Telluride
-        MercuryCadmiumTelluride = Material.Builder(2262, GTLiteMod.id("mercury_cadmium_telluride"))
-            .ingot()
-            .fluid()
-            .color(0x823C80).iconSet(BRIGHT)
-            .flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .components(Mercury, 2, Cadmium, 1, Tellurium, 2)
-            .blast { b ->
-                b.temp(12170, BlastProperty.GasTier.HIGHER) // Adamantium
-                    .blastStats(VA[UHV], 12 * SECOND)
-                    .vacuumStats(VA[UV], 6 * SECOND)
-            }
-            .build()
+        MercuryCadmiumTelluride = addMaterial(2262, "mercury_cadmium_telluride")
+        {
+            ingot()
+            fluid()
+            color(0x823C80).iconSet(BRIGHT)
+            flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            components(Mercury, 2, Cadmium, 1, Tellurium, 2)
+            blastProp(12170, GasTier.HIGHER, // Adamantium
+                      VA[UHV], 12 * SECOND,
+                      VA[UV], 6 * SECOND)
+        }
 
         // 2263 Thallium Roentgenium Chloride
-        ThalliumRoentgeniumChloride = Material.Builder(2263, GTLiteMod.id("thallium_roentgenium_chloride"))
-            .ingot()
-            .fluid()
-            .color(0x3C5CB5).iconSet(MAGNETIC)
-            .components(Thallium, 1, Roentgenium, 1, Chlorine, 3)
-            .flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_RING)
-            .blast { b ->
-                b.temp(12500, BlastProperty.GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UV], 48 * SECOND)
-                    .vacuumStats(VA[ZPM], 24 * SECOND)
-            }
-            .build()
+        ThalliumRoentgeniumChloride = addMaterial(2263, "thallium_roentgenium_chloride")
+        {
+            ingot()
+            fluid()
+            color(0x3C5CB5).iconSet(MAGNETIC)
+            components(Thallium, 1, Roentgenium, 1, Chlorine, 3)
+            flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_RING)
+            blastProp(12500, GasTier.HIGHEST, // Adamantium
+                      VA[UV], 48 * SECOND,
+                      VA[ZPM], 24 * SECOND)
+        }
 
         // 2264 Silica Gel Base
-        SilicaGelBase = Material.Builder(2264, GTLiteMod.id("silica_gel_base"))
-            .liquid()
-            .color(0x7170BE).iconSet(DULL)
-            .components(SiliconDioxide, 1, SodiumHydroxide, 1, HydrochloricAcid, 1, Water, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(SiNa(OH)O2)(HCl)(H2O)", true)
+        SilicaGelBase = addMaterial(2264, "silica_gel_base")
+        {
+            liquid()
+            color(0x7170BE).iconSet(DULL)
+            components(SiliconDioxide, 1, SodiumHydroxide, 1, HydrochloricAcid, 1, Water, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2265 Silica Gel
-        SilicaGel = Material.Builder(2265, GTLiteMod.id("silica_gel"))
-            .dust()
-            .color(0x9695FD).iconSet(NANOPARTICLES)
-            .components(SiliconDioxide, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SilicaGel = addMaterial(2265, "silica_gel")
+        {
+            dust()
+            color(0x9695FD).iconSet(NANOPARTICLES)
+            components(SiliconDioxide, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2266 Nitronium Tetrafluoroborate
-        NitroniumTetrafluoroborate = Material.Builder(2266, GTLiteMod.id("nitronium_tetrafluoroborate"))
-            .dust()
-            .color(0x787449).iconSet(DULL)
-            .components(Nitrogen, 1, Oxygen, 2, Boron, 1, Fluorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NitroniumTetrafluoroborate = addMaterial(2266, "nitronium_tetrafluoroborate")
+        {
+            dust()
+            color(0x787449).iconSet(DULL)
+            components(Nitrogen, 1, Oxygen, 2, Boron, 1, Fluorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2267 Nitrosonium Tetrafluoroborate
-        NitrosoniumTetrafluoroborate = Material.Builder(2267, GTLiteMod.id("nitrosonium_tetrafluoroborate"))
-            .dust()
-            .color(0xA32A8C).iconSet(ROUGH)
-            .components(Nitrogen, 1, Oxygen, 1, Boron, 1, Fluorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NitrosoniumTetrafluoroborate = addMaterial(2267, "nitrosonium_tetrafluoroborate")
+        {
+            dust()
+            color(0xA32A8C).iconSet(ROUGH)
+            components(Nitrogen, 1, Oxygen, 1, Boron, 1, Fluorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2268 Tetrafluoroboric Acid
-        TetrafluoroboricAcid = Material.Builder(2268, GTLiteMod.id("tetrafluoroboric_acid"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0x83A731)
-            .components(Hydrogen, 1, Boron, 1, Fluorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TetrafluoroboricAcid = addMaterial(2268, "tetrafluoroboric_acid")
+        {
+            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            color(0x83A731)
+            components(Hydrogen, 1, Boron, 1, Fluorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2269 Potassium Formate
-        PotassiumFormate = Material.Builder(2269, GTLiteMod.id("potassium_formate"))
-            .dust()
-            .color(0x74B5A9).iconSet(METALLIC)
-            .components(Carbon, 1, Hydrogen, 3, Oxygen, 1, Potassium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PotassiumFormate = addMaterial(2269, "potassium_formate")
+        {
+            dust()
+            color(0x74B5A9).iconSet(METALLIC)
+            components(Carbon, 1, Hydrogen, 3, Oxygen, 1, Potassium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2270 Ammonium Sulfate
-        AmmoniumSulfate = Material.Builder(2270, GTLiteMod.id("ammonium_sulfate"))
-            .dust()
-            .color(0x5858F4).iconSet(METALLIC)
-            .components(Nitrogen, 4, Hydrogen, 8, Sulfur, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(NH4)2SO4", true)
+        AmmoniumSulfate = addMaterial(2270, "ammonium_sulfate")
+        {
+            dust()
+            color(0x5858F4).iconSet(METALLIC)
+            components(Nitrogen, 4, Hydrogen, 8, Sulfur, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2271 Ammonium Carbonate
-        AmmoniumCarbonate = Material.Builder(2271, GTLiteMod.id("ammonium_carbonate"))
-            .dust()
-            .color(0x7C89D9).iconSet(SHINY)
-            .components(Carbon, 1, Hydrogen, 8, Oxygen, 3, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(NH4)2CO3", true)
+        AmmoniumCarbonate = addMaterial(2271, "ammonium_carbonate")
+        {
+            dust()
+            color(0x7C89D9).iconSet(SHINY)
+            components(Carbon, 1, Hydrogen, 8, Oxygen, 3, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2272 Ammonium Acetate
-        AmmoniumAcetate = Material.Builder(2272, GTLiteMod.id("ammonium_acetate"))
-            .dust()
-            .color(0x646882).iconSet(METALLIC)
-            .components(Carbon, 2, Hydrogen, 7, Oxygen, 2, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("NH4CH3CO2", true)
+        AmmoniumAcetate = addMaterial(2272, "ammonium_acetate")
+        {
+            dust()
+            color(0x646882).iconSet(METALLIC)
+            components(Carbon, 2, Hydrogen, 7, Oxygen, 2, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2273 Sodium Azanide
-        SodiumAzanide = Material.Builder(2273, GTLiteMod.id("sodium_azanide"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Sodium, 1, Nitrogen, 1, Hydrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumAzanide = addMaterial(2273, "sodium_azanide")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Sodium, 1, Nitrogen, 1, Hydrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2274 Sodium Azide
-        SodiumAzide = Material.Builder(2274, GTLiteMod.id("sodium_azide"))
-            .dust()
-            .colorAverage()
-            .components(Sodium, 1, Nitrogen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumAzide = addMaterial(2274, "sodium_azide")
+        {
+            dust()
+            colorAverage()
+            components(Sodium, 1, Nitrogen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2275 Palladium Bisdibenzylidieneacetone
-        PalladiumBisdibenzylidieneacetone = Material.Builder(2275, GTLiteMod.id("palladium_bisdibenzylidieneacetone"))
-            .dust()
-            .color(0xBE81A0).iconSet(ROUGH)
-            .components(Carbon, 51, Hydrogen, 42, Oxygen, 3, Palladium, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PalladiumBisdibenzylidieneacetone = addMaterial(2275, "palladium_bisdibenzylidieneacetone")
+        {
+            dust()
+            color(0xBE81A0).iconSet(ROUGH)
+            components(Carbon, 51, Hydrogen, 42, Oxygen, 3, Palladium, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2276 Potassium Tetrachloroplatinate
-        PotassiumTetrachloroplatinate = Material.Builder(2276, GTLiteMod.id("potassium_tetrachloroplatinate"))
-            .dust()
-            .color(0xF1B04F).iconSet(SHINY)
-            .components(Potassium, 2, Platinum, 1, Chlorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PotassiumTetrachloroplatinate = addMaterial(2276, "potassium_tetrachloroplatinate")
+        {
+            dust()
+            color(0xF1B04F).iconSet(SHINY)
+            components(Potassium, 2, Platinum, 1, Chlorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2277 Ammonium Persulfate
-        AmmoniumPersulfate = Material.Builder(2277, GTLiteMod.id("ammonium_persulfate"))
-            .dust()
-            .color(0x4242B7)
-            .components(Nitrogen, 2, Hydrogen, 8, Sulfur, 2, Oxygen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(NH4)2S2O8", true)
+        AmmoniumPersulfate = addMaterial(2277, "ammonium_persulfate")
+        {
+            dust()
+            color(0x4242B7)
+            components(Nitrogen, 2, Hydrogen, 8, Sulfur, 2, Oxygen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2278 SilverTetrafluoroborate
-        SilverTetrafluoroborate = Material.Builder(2278, GTLiteMod.id("silver_tetrafluoroborate"))
-            .dust()
-            .color(0x818024)
-            .components(Silver, 1, Boron, 1, Fluorine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SilverTetrafluoroborate = addMaterial(2278, "silver_tetrafluoroborate")
+        {
+            dust()
+            color(0x818024)
+            components(Silver, 1, Boron, 1, Fluorine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2279 Silver Chloride
-        SilverChloride = Material.Builder(2279, GTLiteMod.id("silver_chloride"))
-            .dust()
-            .color(0x8D8D8D).iconSet(METALLIC)
-            .components(Silver, 1, Chlorine, 1)
-            .build()
+        SilverChloride = addMaterial(2279, "silver_chloride")
+        {
+            dust()
+            color(0x8D8D8D).iconSet(METALLIC)
+            components(Silver, 1, Chlorine, 1)
+        }
 
         // 2280 Silver Oxide
-        SilverOxide = Material.Builder(2280, GTLiteMod.id("silver_oxide"))
-            .dust()
-            .color(0xA4A4A4)
-            .components(Silver, 2, Oxygen, 1)
-            .build()
+        SilverOxide = addMaterial(2280, "silver_oxide")
+        {
+            dust()
+            color(0xA4A4A4)
+            components(Silver, 2, Oxygen, 1)
+        }
 
         // 2281 Heavy Quark Enriched Mixture
-        HeavyQuarkEnrichedMixture = Material.Builder(2281, GTLiteMod.id("heavy_quark_enriched_mixture"))
-            .plasma(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(400_000_000)
-                .customStill())
-            .build()
+        HeavyQuarkEnrichedMixture = addMaterial(2281, "heavy_quark_enriched_mixture")
+        {
+            plasma(FluidBuilder().translation("gregtech.fluid.generic").temperature(400_000_000).customStill())
+        }
 
         // 2282 Deuterium-Superheavy Mixture
-        DeuteriumSuperheavyMixture = Material.Builder(2282, GTLiteMod.id("deuterium_superheavy_mixture"))
-            .liquid(FluidBuilder()
-                .temperature(18240))
-            .color(0x7B9EF8)
-            .components(Deuterium, 2, MetastableHassium, 1, MetastableFlerovium, 1, MetastableOganesson, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DeuteriumSuperheavyMixture = addMaterial(2282, "deuterium_superheavy_mixture")
+        {
+            liquid(FluidBuilder().temperature(18240))
+            color(0x7B9EF8)
+            components(Deuterium, 2, MetastableHassium, 1, MetastableFlerovium, 1, MetastableOganesson, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2283 Heavy Quark Degenerate Matter (HQDM)
-        HeavyQuarkDegenerateMatter = Material.Builder(2283, GTLiteMod.id("heavy_quark_degenerate_matter"))
-            .ingot()
-            .liquid()
-            .plasma(FluidBuilder()
-                .temperature(1_600_000_000)
-                .customStill())
+        HeavyQuarkDegenerateMatter = addMaterial(2283, "heavy_quark_degenerate_matter")
+        {
+            ingot()
+            liquid()
+            plasma(FluidBuilder().temperature(1_600_000_000).customStill())
             .color(0x5DBD3A).iconSet(BRIGHT)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR,
-                GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .rotorStats(48.0f, 16.0f, 983040)
-            .fluidPipeProperties(200_000, 10000, true, true, true, true)
-            .build()
+            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_GEAR,
+                   GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                   GENERATE_FOIL, GENERATE_FINE_WIRE)
+            rotorProp(48.0f, 16.0f, 983040)
+            fluidPipeProp(200_000, 10000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 2284 Quantumchromodynamically ConfinedMatter (QCM)
-        QuantumchromodynamicallyConfinedMatter = Material.Builder(2284, GTLiteMod.id("quantumchromodynamically_confined_matter"))
-            .ingot()
-            .liquid()
-            .color(0xF0A745).iconSet(BRIGHT)
-            .flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE, GENERATE_FRAME)
-            .cableProperties(V[UIV], 24, 12)
-            .fluidPipeProperties(400_000, 20000, true, true, true, true)
-            .build()
+        QuantumchromodynamicallyConfinedMatter = addMaterial(2284, "quantumchromodynamically_confined_matter")
+        {
+            ingot()
+            liquid()
+            color(0xF0A745).iconSet(BRIGHT)
+            flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE, GENERATE_FRAME)
+            cableProp(V[UIV], 24, 12)
+            fluidPipeProp(400_000, 20000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 2285 Sodium Ethoxide
-        SodiumEthoxide = Material.Builder(2285, GTLiteMod.id("sodium_ethoxide"))
-            .dust()
-            .color(Sodium.materialRGB + Ethanol.materialRGB)
-            .components(Carbon, 2, Hydrogen, 5, Oxygen, 1, Sodium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumEthoxide = addMaterial(2285, "sodium_ethoxide")
+        {
+            dust()
+            color(Sodium.materialRGB + Ethanol.materialRGB)
+            components(Carbon, 2, Hydrogen, 5, Oxygen, 1, Sodium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2286 Iron (II) Chloride
-        Iron2Chloride = Material.Builder(2286, GTLiteMod.id("iron_2_chloride"))
-            .liquid()
-            .color(Iron3Chloride.materialRGB - 10)
-            .components(Iron, 1, Chlorine, 2)
-            .build()
+        Iron2Chloride = addMaterial(2286, "iron_2_chloride")
+        {
+            liquid()
+            color(Iron3Chloride.materialRGB - 10)
+            components(Iron, 1, Chlorine, 2)
+        }
 
         // 2287 Palladium Fullerene Matrix
-        PalladiumFullereneMatrix = Material.Builder(2287, GTLiteMod.id("palladium_fullerene_matrix"))
-            .dust()
-            .color(0x40AEE0).iconSet(SHINY)
-            .components(Carbon, 73, Hydrogen, 15, Nitrogen, 1, Iron, 1, Palladium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C73H15NFe)Pd", true)
+        PalladiumFullereneMatrix = addMaterial(2287, "palladium_fullerene_matrix")
+        {
+            dust()
+            color(0x40AEE0).iconSet(SHINY)
+            components(Carbon, 73, Hydrogen, 15, Nitrogen, 1, Iron, 1, Palladium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2288 Lutetium-Thulium-Yttrium Chlorides Solution
-        LuTmYChloridesSolution = Material.Builder(2288, GTLiteMod.id("lu_tm_y_chlorides_solution"))
-            .liquid()
-            .colorAverage()
-            .components(Lutetium, 2, Thulium, 2, Yttrium, 6, Chlorine, 30, Water, 15)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(LuCl3)2(TmCl3)2(YCl3)6(H2O)15", true)
+        LuTmYChloridesSolution = addMaterial(2288, "lu_tm_y_chlorides_solution")
+        {
+            liquid()
+            colorAverage()
+            components(Lutetium, 2, Thulium, 2, Yttrium, 6, Chlorine, 30, Water, 15)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2289 Sodium Vanadate
-        SodiumVanadate = Material.Builder(2289, GTLiteMod.id("sodium_vanadate"))
-            .dust()
-            .color(0xCC9933).iconSet(SHINY)
-            .components(Sodium, 3, Vanadium, 1, Oxygen, 4)
-            .build()
+        SodiumVanadate = addMaterial(2289, "sodium_vanadate")
+        {
+            dust()
+            color(0xCC9933).iconSet(SHINY)
+            components(Sodium, 3, Vanadium, 1, Oxygen, 4)
+        }
 
         // 2290 Lu/Tm-doped Yttrium Vanadate Deposition
-        LuTmDopedYttriumVanadateDeposition = Material.Builder(2290, GTLiteMod.id("lu_tm_doped_yttrium_vanadate_deposition"))
-            .dust()
-            .colorAverage().iconSet(FINE)
-            .components(Lutetium, 1, Thulium, 1, SodiumVanadate, 1, RareEarth, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Lu/Tm:YVO?", false)
+        LuTmDopedYttriumVanadateDeposition = addMaterial(2290, "lu_tm_doped_yttrium_vanadate_deposition")
+        {
+            dust()
+            colorAverage().iconSet(FINE)
+            components(Lutetium, 1, Thulium, 1, SodiumVanadate, 1, RareEarth, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2291 Lu/Tm:YVO
-        LuTmYVO = Material.Builder(2291, GTLiteMod.id("lu_tm_yvo"))
-            .gem()
-            .color(0x8C1B23).iconSet(GEM_HORIZONTAL)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .components(Yttrium, 1, Vanadium, 1, Oxygen, 1, Lutetium, 1, Thulium, 1)
-            .build()
-            .setFormula("Lu/Tm:YVO", false)
+        LuTmYVO = addMaterial(2291, "lu_tm_yvo")
+        {
+            gem()
+            color(0x8C1B23).iconSet(GEM_HORIZONTAL)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+            components(Yttrium, 1, Vanadium, 1, Oxygen, 1, Lutetium, 1, Thulium, 1)
+        }
 
         // 2292 Hexagonal Silicon Nitride
-        HexagonalSiliconNitride = Material.Builder(2292, GTLiteMod.id("hexagonal_silicon_nitride"))
-            .gem()
-            .color(0x8C7BB6).iconSet(GEM_HORIZONTAL)
-            .components(Silicon, 3, Nitrogen, 4)
-            .flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("h-Si3N4", true)
+        HexagonalSiliconNitride = addMaterial(2292, "hexagonal_silicon_nitride")
+        {
+            gem()
+            color(0x8C7BB6).iconSet(GEM_HORIZONTAL)
+            components(Silicon, 3, Nitrogen, 4)
+            flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2293 Cubic Silicon Nitride
-        CubicSiliconNitride = Material.Builder(2293, GTLiteMod.id("cubic_silicon_nitride"))
-            .gem()
-            .color(0x415B70).iconSet(RUBY)
-            .components(Silicon, 3, Nitrogen, 4)
-            .flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
-            .build()
-            .setFormula("c-Si3N4", true)
+        CubicSiliconNitride = addMaterial(2293, "cubic_silicon_nitride")
+        {
+            gem()
+            color(0x415B70).iconSet(RUBY)
+            components(Silicon, 3, Nitrogen, 4)
+            flags(DISABLE_DECOMPOSITION, DISABLE_CRYSTALLIZATION, GENERATE_PLATE, GENERATE_LENS)
+        }
 
         // 2294 Cerium Carbonate
-        CeriumCarbonate = Material.Builder(2294, GTLiteMod.id("cerium_carbonate"))
-            .dust()
-            .color(0x57855C).iconSet(SHINY)
-            .components(Cerium, 2, Carbon, 3, Oxygen, 9)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Ce2(CO3)3", true)
+        CeriumCarbonate = addMaterial(2294, "cerium_carbonate")
+        {
+            dust()
+            color(0x57855C).iconSet(SHINY)
+            components(Cerium, 2, Carbon, 3, Oxygen, 9)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2295 Dielectric Formation Mixture
-        DielectricFormationMixture = Material.Builder(2295, GTLiteMod.id("dielectric_formation_mixture"))
-            .liquid(FluidBuilder().temperature(209))
-            .color(0xE62A35)
-            .components(ManganeseDifluoride, 1, ZincSulfide, 1, TantalumPentoxide, 1, Rutile, 1, Ethanol, 1)
-            .flags(DISABLE_DECOMPOSITION) // Add centrifuging decomposition by OpticalCircuits.
-            .build()
+        // Add centrifuging decomposition by OpticalCircuits.
+        DielectricFormationMixture = addMaterial(2295, "dielectric_formation_mixture")
+        {
+            liquid(FluidBuilder().temperature(209))
+            color(0xE62A35)
+            components(ManganeseDifluoride, 1, ZincSulfide, 1, TantalumPentoxide, 1, Rutile, 1, Ethanol, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2296 Chloroauric Acid
-        ChloroauricAcid = Material.Builder(2296, GTLiteMod.id("chloroauric_acid"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0xD1B62C)
-            .components(Hydrogen, 1, Gold, 1, Chlorine, 4)
-            .build()
+        ChloroauricAcid = addMaterial(2296, "chloroauric_acid")
+        {
+            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            color(0xD1B62C)
+            components(Hydrogen, 1, Gold, 1, Chlorine, 4)
+        }
 
         // 2297 Cadmium Sulfide
-        CadmiumSulfide = Material.Builder(2297, GTLiteMod.id("cadmium_sulfide"))
-            .dust()
-            .color(0xC8C43C).iconSet(METALLIC)
-            .components(Cadmium, 1, Sulfur, 1)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING, GENERATE_PLATE)
-            .build()
+        CadmiumSulfide = addMaterial(2297, "cadmium_sulfide")
+        {
+            dust()
+            color(0xC8C43C).iconSet(METALLIC)
+            components(Cadmium, 1, Sulfur, 1)
+            flags(DECOMPOSITION_BY_ELECTROLYZING, GENERATE_PLATE)
+        }
 
         // 2298 Bismuth Chalcogenide
-        BismuthChalcogenide = Material.Builder(2298, GTLiteMod.id("bismuth_chalcogenide"))
-            .ingot()
-            .color(0x91994D).iconSet(SHINY)
-            .components(Bismuth, 1, Antimony, 1, Tellurium, 2, Sulfur, 1)
-            .flags(STD_METAL, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_FOIL)
-            .build()
+        BismuthChalcogenide = addMaterial(2298, "bismuth_chalcogenide")
+        {
+            ingot()
+            color(0x91994D).iconSet(SHINY)
+            components(Bismuth, 1, Antimony, 1, Tellurium, 2, Sulfur, 1)
+            flags(STD_METAL, DECOMPOSITION_BY_ELECTROLYZING, GENERATE_FOIL)
+        }
 
         // 2299 Plutonium Trihydride
-        PlutoniumTrihydride = Material.Builder(2299, GTLiteMod.id("plutonium_trihydride"))
-            .dust()
-            .color(0x140002).iconSet(SHINY)
-            .components(Plutonium244, 1, Hydrogen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("PuH3", true)
+        PlutoniumTrihydride = addMaterial(2299, "plutonium_trihydride")
+        {
+            dust()
+            color(0x140002).iconSet(SHINY)
+            components(Plutonium244, 1, Hydrogen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2300 Plutonium Phosphide
-        PlutoniumPhosphide = Material.Builder(2300, GTLiteMod.id("plutonium_phosphide"))
-            .ingot()
-            .color(0x1F0104).iconSet(MAGNETIC)
-            .components(Plutonium244, 1, Phosphorus, 1)
-            .flags(STD_METAL)
-            .build()
-            .setFormula("PuP", true)
+        PlutoniumPhosphide = addMaterial(2300, "plutonium_phosphide")
+        {
+            ingot()
+            color(0x1F0104).iconSet(MAGNETIC)
+            components(Plutonium244, 1, Phosphorus, 1)
+            flags(STD_METAL)
+        }
 
         // 2301 Phosphine
-        Phosphine = Material.Builder(2301, GTLiteMod.id("phosphine"))
-            .gas()
-            .color(0xACB330)
-            .components(Phosphorus, 1, Hydrogen, 3)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING, FLAMMABLE)
-            .build()
+        Phosphine = addMaterial(2301, "phosphine")
+        {
+            gas()
+            color(0xACB330)
+            components(Phosphorus, 1, Hydrogen, 3)
+            flags(DECOMPOSITION_BY_ELECTROLYZING, FLAMMABLE)
+        }
 
         // 2302 Mellion
-        Mellion = Material.Builder(2302, GTLiteMod.id("mellion"))
-            .ingot()
-            .liquid()
-            .color(0x3C0505).iconSet(SHINY)
-            .components(Rubidium, 11, Tritanium, 11, Adamantium, 7, Firestone, 13, MetastableOganesson, 13, ActiniumSuperhydride, 8)
-            .flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FINE_WIRE, GENERATE_NANITE)
-            .blast { b ->
-                b.temp(22000, BlastProperty.GasTier.HIGHEST) // Error
-                    .blastStats(VA[UXV], 20 * SECOND)
-                    .vacuumStats(VA[UIV], 10 * SECOND)
-            }
-            .cableProperties(V[UXV], 48, 12)
-            .itemPipeProperties(16, 2048F)
-            .build()
+        Mellion = addMaterial(2302, "mellion")
+        {
+            ingot()
+            liquid()
+            color(0x3C0505).iconSet(SHINY)
+            components(Rubidium, 11, Tritanium, 11, Adamantium, 7, Firestone, 13, MetastableOganesson, 13,
+                       ActiniumSuperhydride, 8)
+            flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE,
+                  GENERATE_NANITE)
+            blastProp(22000, GasTier.HIGHEST, // Eternity Plus
+                      VA[UXV], 20 * SECOND,
+                      VA[UIV], 10 * SECOND)
+            cableProp(V[UXV], 48, 12)
+            itemPipeProp(16, 2048F)
+        }
 
         // 2303 Lanthanum Fullerene Mixture
-        LanthanumFullereneMixture = Material.Builder(2303, GTLiteMod.id("lanthanum_fullerene_mixture"))
-            .dust()
-            .color(0xD26D8E).iconSet(BRIGHT)
-            .components(Carbon, 120, Hydrogen, 60, Lanthanum, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C60H30)2La2", true)
+        LanthanumFullereneMixture = addMaterial(2303, "lanthanum_fullerene_mixture")
+        {
+            dust()
+            color(0xD26D8E).iconSet(BRIGHT)
+            components(Carbon, 120, Hydrogen, 60, Lanthanum, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2304 Lanthanum Embedded Fullerene
-        LanthanumEmbeddedFullerene = Material.Builder(2304, GTLiteMod.id("lanthanum_embedded_fullerene"))
-            .dust()
-            .color(0x84FFAC).iconSet(BRIGHT)
-            .components(Carbon, 120, Lanthanum, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C60)2La2", true)
+        LanthanumEmbeddedFullerene = addMaterial(2304, "lanthanum_embedded_fullerene")
+        {
+            dust()
+            color(0x84FFAC).iconSet(BRIGHT)
+            components(Carbon, 120, Lanthanum, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2305 Lanthanum Fullerene Nanotube
-        LanthanumFullereneNanotube = Material.Builder(2305, GTLiteMod.id("lanthanum_fullerene_nanotube"))
-            .polymer()
-            .color(0xD24473).iconSet(BRIGHT)
-            .components(Carbon, 108, Lanthanum, 1)
-            .flags(EXT2_METAL, DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C48C60La", true)
+        LanthanumFullereneNanotube = addMaterial(2305, "lanthanum_fullerene_nanotube")
+        {
+            polymer()
+            color(0xD24473).iconSet(BRIGHT)
+            components(Carbon, 108, Lanthanum, 1)
+            flags(EXT2_METAL, DISABLE_DECOMPOSITION)
+        }
 
         // 2306 Seaborgium-doped Carbon Nanotube
-        SeaborgiumDopedCarbonNanotube = Material.Builder(2306, GTLiteMod.id("seaborgium_doped_carbon_nanotube"))
-            .polymer()
-            .color(0x2C2C8C).iconSet(SHINY)
-            .components(Carbon, 48, Seaborgium, 1)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        SeaborgiumDopedCarbonNanotube = addMaterial(2306, "seaborgium_doped_carbon_nanotube")
+        {
+            polymer()
+            color(0x2C2C8C).iconSet(SHINY)
+            components(Carbon, 48, Seaborgium, 1)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 2307 Praseodymium-Holmium-Yttrium Nitrates Solution
-        PrHoYNitratesSolution = Material.Builder(2307, GTLiteMod.id("pr_ho_y_nitrates_solution"))
-            .liquid()
-            .colorAverage()
-            .components(Praseodymium, 2, Nitrogen, 30, Oxygen, 105, Holmium, 2, Yttrium, 6, Hydrogen, 30)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(Pr(NO3)3)2(Ho(NO3)3)2(Y(NO3)3)6(H2O)15", true)
+        PrHoYNitratesSolution = addMaterial(2307, "pr_ho_y_nitrates_solution")
+        {
+            liquid()
+            colorAverage()
+            components(Praseodymium, 2, Nitrogen, 30, Oxygen, 105, Holmium, 2, Yttrium, 6, Hydrogen, 30)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2308 Pr/Ho:YLF
-        PrHoYLF = Material.Builder(2308, GTLiteMod.id("pr_ho_ylf"))
-            .gem()
-            .color(Praseodymium.materialRGB + Holmium.materialRGB + Yttrium.materialRGB
-                    + Lithium.materialRGB).iconSet(RUBY)
-            .components(Praseodymium, 1, Holmium, 1, Lithium, 1, Yttrium, 1, Fluorine, 4)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
-            .setFormula("Pr/Ho:YLF", true)
+        PrHoYLF = addMaterial(2308, "pr_ho_ylf")
+        {
+            gem()
+            color(Praseodymium.materialRGB + Holmium.materialRGB + Yttrium.materialRGB + Lithium.materialRGB).iconSet(RUBY)
+            components(Praseodymium, 1, Holmium, 1, Lithium, 1, Yttrium, 1, Fluorine, 4)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2309 Harmonic Phonon Matter
-        HarmonicPhononMatter = Material.Builder(2309, GTLiteMod.id("harmonic_phonon_matter"))
-            .ingot()
-            .liquid(FluidBuilder()
-                .temperature(2_000_000_000)
-                .translation("gregtech.fluid.generic"))
-            .iconSet(GLITCH)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                GENERATE_FRAME)
-            .cableProperties(V[UXV], 72, 18)
-            .blast { b ->
-                b.temp(26000, BlastProperty.GasTier.HIGHEST) // Error
-                    .blastStats(VA[UXV], 2 * MINUTE)
-                    .vacuumStats(VA[UXV], 30 * SECOND)
-            }
-            .fluidPipeProperties(1_600_000, 80000, true, true, true, true)
-            .build()
+        HarmonicPhononMatter = addMaterial(2309, "harmonic_phonon_matter")
+        {
+            ingot()
+            liquid(FluidBuilder().temperature(2_000_000_000).translation("gregtech.fluid.generic"))
+            iconSet(GLITCH)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME)
+            blastProp(26000, GasTier.HIGHEST, // Eternity Plus
+                      VA[UXV], 2 * MINUTE,
+                      VA[UXV], 30 * SECOND)
+            cableProp(V[UXV], 72, 18)
+            fluidPipeProp(1_600_000, 80000, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 2310 Trichlorocyclopentadienyl Titanium
-        TrichlorocyclopentadienylTitanium = Material.Builder(2310, GTLiteMod.id("trichlorocyclopentadienyl_titanium"))
-            .dust()
-            .color(0xE600F2).iconSet(SHINY)
-            .components(Carbon, 10, Hydrogen, 10, Chlorine, 3, Titanium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C5H5)2Cl3Ti", true)
+        TrichlorocyclopentadienylTitanium = addMaterial(2310, "trichlorocyclopentadienyl_titanium")
+        {
+            dust()
+            color(0xE600F2).iconSet(SHINY)
+            components(Carbon, 10, Hydrogen, 10, Chlorine, 3, Titanium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2311 Silver Perchlorate
-        SilverPerchlorate = Material.Builder(2311, GTLiteMod.id("silver_perchlorate"))
-            .dust()
-            .color(0xFFFFFF).iconSet(SHINY)
-            .components(Silver, 1, Chlorine, 1, Oxygen, 4)
-            .build()
+        SilverPerchlorate = addMaterial(2311, "silver_perchlorate")
+        {
+            dust()
+            color(0xFFFFFF).iconSet(SHINY)
+            components(Silver, 1, Chlorine, 1, Oxygen, 4)
+        }
 
         // 2312 Photopolymer Solution
-        PhotopolymerSolution = Material.Builder(2312, GTLiteMod.id("photopolymer_solution"))
-            .liquid()
-            .color(0x5E1D29)
-            .components(Carbon, 149, Hydrogen, 97, Nitrogen, 10, Oxygen, 2, Titanium, 1, Boron, 1, Fluorine, 20)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C149H97N10O2(TiBF20)", true)
+        PhotopolymerSolution = addMaterial(2312, "photopolymer_solution")
+        {
+            liquid()
+            color(0x5E1D29)
+            components(Carbon, 149, Hydrogen, 97, Nitrogen, 10, Oxygen, 2, Titanium, 1, Boron, 1, Fluorine, 20)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2313 Sodium Bromide
-        SodiumBromide = Material.Builder(2313, GTLiteMod.id("sodium_bromide"))
-            .dust()
-            .color(0xE3B9F7).iconSet(ROUGH)
-            .components(Sodium, 1, Bromine, 1)
-            .build()
+        SodiumBromide = addMaterial(2313, "sodium_bromide")
+        {
+            dust()
+            color(0xE3B9F7).iconSet(ROUGH)
+            components(Sodium, 1, Bromine, 1)
+        }
 
         // 2314 Black Dwarf Matter
-        BlackDwarfMatter = Material.Builder(2314, GTLiteMod.id("black_dwarf_matter"))
-            .ingot()
-            .fluid()
-            .color(0x000000).iconSet(METALLIC)
-            .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
-                GENERATE_RING, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_ROUND,
-                GENERATE_NANITE)
-            .build()
+        BlackDwarfMatter = addMaterial(2314, "black_dwarf_matter")
+        {
+            ingot()
+            fluid()
+            color(0x000000).iconSet(METALLIC)
+            flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_RING, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_ROUND,
+                  GENERATE_NANITE)
+        }
 
         // 2315 White Dwarf Matter
-        WhiteDwarfMatter = Material.Builder(2315, GTLiteMod.id("white_dwarf_matter"))
-            .ingot()
-            .fluid()
-            .iconSet(WHITE_DWARF)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR,
-                   GENERATE_FRAME, GENERATE_NANITE, GENERATE_ROTOR)
-            .cableProperties(V[OpV], 108, 36)
-            .build()
+        WhiteDwarfMatter = addMaterial(2315, "white_dwarf_matter")
+        {
+            ingot()
+            fluid()
+            iconSet(WHITE_DWARF)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME, GENERATE_NANITE,
+                  GENERATE_ROTOR)
+            cableProp(V[OpV], 108, 36)
+        }
 
         // 2316 Potassium Ferrocyanide Trihydrate
-        PotassiumFerrocyanideTrihydrate = Material.Builder(2316, GTLiteMod.id("potassium_ferrocyanide_trihydrate"))
-            .dust()
-            .color(0x0069B2).iconSet(ROUGH)
-            .components(Potassium, 4, Iron, 1, Carbon, 6, Nitrogen, 6, Water, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("K4Fe(CN)6(H2O)3", true)
+        PotassiumFerrocyanideTrihydrate = addMaterial(2316, "potassium_ferrocyanide_trihydrate")
+        {
+            dust()
+            color(0x0069B2).iconSet(ROUGH)
+            components(Potassium, 4, Iron, 1, Carbon, 6, Nitrogen, 6, Water, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2317 Prussian Blue
-        PrussianBlue = Material.Builder(2317, GTLiteMod.id("prussian_blue"))
-            .dust()
-            .color(0x003153).iconSet(SHINY)
-            .components(Iron, 7, Carbon, 18, Nitrogen, 18)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Fe4[Fe(CN)6]3", true)
+        PrussianBlue = addMaterial(2317, "prussian_blue")
+        {
+            dust()
+            color(0x003153).iconSet(SHINY)
+            components(Iron, 7, Carbon, 18, Nitrogen, 18)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2318 Copper Arsenite
-        CopperArsenite = Material.Builder(2318, GTLiteMod.id("copper_arsenite"))
-            .dust()
-            .color(0x66FF66).iconSet(ROUGH)
-            .components(Copper, 3, Arsenic, 2, Oxygen, 8)
-            .build()
-            .setFormula("Cu3(AsO4)2", true)
+        CopperArsenite = addMaterial(2318, "copper_arsenite")
+        {
+            dust()
+            color(0x66FF66).iconSet(ROUGH)
+            components(Copper, 3, Arsenic, 2, Oxygen, 8)
+        }
 
         // 2319 Scheeles' Green
-        ScheelesGreen = Material.Builder(2319, GTLiteMod.id("scheeles_green"))
-            .dust()
-            .liquid()
-            .color(0x00FF00).iconSet(DULL)
-            .components(Arsenic, 1, Copper, 1, Hydrogen, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ScheelesGreen = addMaterial(2319, "scheeles_green")
+        {
+            dust()
+            liquid()
+            color(0x00FF00).iconSet(DULL)
+            components(Arsenic, 1, Copper, 1, Hydrogen, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2320 Caesium Iodide
-        CaesiumIodide = Material.Builder(2320, GTLiteMod.id("caesium_iodide"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Caesium, 1, Iodine, 1)
-            .build()
+        CaesiumIodide = addMaterial(2320, "caesium_iodide")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Caesium, 1, Iodine, 1)
+        }
 
         // 2321 Thallium/Thulium-doped Caesium Iodide
-        ThalliumThuliumDopedCaesiumIodide = Material.Builder(2321, GTLiteMod.id("thallium_thulium_doped_caesium_iodide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(CaesiumIodide, 1, Thallium, 1, Thulium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Tl/Tm:CsI", false)
+        ThalliumThuliumDopedCaesiumIodide = addMaterial(2321, "thallium_thulium_doped_caesium_iodide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(CaesiumIodide, 1, Thallium, 1, Thulium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2322 Cadmium Tungstate
-        CadmiumTungstate = Material.Builder(2322, GTLiteMod.id("cadmium_tungstate"))
-            .dust()
-            .colorAverage(Cadmium.materialRGB, Tungsten.materialRGB).iconSet(SHINY)
-            .components(Cadmium, 1, Tungsten, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        CadmiumTungstate = addMaterial(2322, "cadmium_tungstate")
+        {
+            dust()
+            colorAverage(Cadmium.materialRGB, Tungsten.materialRGB).iconSet(SHINY)
+            components(Cadmium, 1, Tungsten, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2323 Bismuth Germanate
-        BismuthGermanate = Material.Builder(2323, GTLiteMod.id("bismuth_germanate"))
-            .dust()
-            .colorAverage(Bismuth, Germanium).iconSet(ROUGH)
-            .components(Bismuth, 4, Germanium, 3, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BismuthGermanate = addMaterial(2323, "bismuth_germanate")
+        {
+            dust()
+            colorAverage(Bismuth, Germanium).iconSet(ROUGH)
+            components(Bismuth, 4, Germanium, 3, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2324 Lanthanum Zirconate
-        LanthanumZirconate = Material.Builder(2324, GTLiteMod.id("lanthanum_zirconate"))
-            .ingot()
-            .fluid()
-            .color(0xEA9A05).iconSet(METALLIC)
-            .components(Lanthanum, 2, Zirconium, 2, Oxygen, 7)
-            .flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(11900, BlastProperty.GasTier.HIGHEST) // Adamantium (Tritanium)
-                    .blastStats(VA[UHV], 35 * SECOND)
-                    .vacuumStats(VA[UV], 17 * SECOND + 10 * TICK)
-            }
-            .build()
+        LanthanumZirconate = addMaterial(2324, "lanthanum_zirconate")
+        {
+            ingot()
+            fluid()
+            color(0xEA9A05).iconSet(METALLIC)
+            components(Lanthanum, 2, Zirconium, 2, Oxygen, 7)
+            flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(11900, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 35 * SECOND,
+                      VA[UV], 17 * SECOND + 10 * TICK)
+        }
 
         // 2325 Moscovium Iridiate
-        MoscoviumIridiate = Material.Builder(2325, GTLiteMod.id("moscovium_iridiate"))
-            .ingot()
-            .fluid()
-            .color(0x478A6B).iconSet(SHINY)
-            .components(Moscovium, 2, Iridium, 2, Oxygen, 7)
-            .flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(12200, BlastProperty.GasTier.HIGHEST) // Adamantium (Tritanium)
-                    .blastStats(VA[UHV], 28 * SECOND)
-                    .vacuumStats(VA[UV], 14 * SECOND)
-            }
-            .build()
+        MoscoviumIridiate = addMaterial(2325, "moscovium_iridiate")
+        {
+            ingot()
+            fluid()
+            color(0x478A6B).iconSet(SHINY)
+            components(Moscovium, 2, Iridium, 2, Oxygen, 7)
+            flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(12200, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 28 * SECOND,
+                      VA[UV], 14 * SECOND)
+        }
 
         // 2326 Hydromoscovic Acid
-        HydromoscovicAcid = Material.Builder(2326,  GTLiteMod.id("hydromoscovic_acid"))
-            .liquid(FluidBuilder()
-                .attribute(FluidAttributes.ACID))
-            .components(Hydrogen, 1, Moscovium, 1, Oxygen, 4)
-            .build()
+        HydromoscovicAcid = addMaterial(2326, "hydromoscovic_acid")
+        {
+            liquid(FluidBuilder().attribute(FluidAttributes.ACID))
+            components(Hydrogen, 1, Moscovium, 1, Oxygen, 4)
+        }
 
         // 2327 Strontium Europium Nihonate
-        StrontiumEuropiumNihonate = Material.Builder(2327, GTLiteMod.id("strontium_europium_nihonate"))
-            .ingot()
-            .fluid()
-            .color(0xBE2B49).iconSet(METALLIC)
-            .components(Strontium, 1, Europium, 1, Nihonium, 2, Oxygen, 4)
-            .flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(12400, BlastProperty.GasTier.HIGHEST) // Adamantium (Tritanium)
-                    .blastStats(VA[UHV], 33 * SECOND)
-                    .vacuumStats(VA[UV], 12 * SECOND + 15 * TICK)
-            }
-            .build()
+        StrontiumEuropiumNihonate = addMaterial(2327, "strontium_europium_nihonate")
+        {
+            ingot()
+            fluid()
+            color(0xBE2B49).iconSet(METALLIC)
+            components(Strontium, 1, Europium, 1, Nihonium, 2, Oxygen, 4)
+            flags(STD_METAL, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(12400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 33 * SECOND,
+                      VA[UV], 12 * SECOND + 15 * TICK)
+        }
 
         // 2328 Neutronium-doped Carbon Nanotube
-        NeutroniumDopedCarbonNanotube = Material.Builder(2328, GTLiteMod.id("neutronium_doped_carbon_nanotube"))
-            .polymer()
-            .liquid()
-            .color(0xDFDFDF).iconSet(SHINY)
-            .components(Carbon, 48, Neutronium, 1)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        NeutroniumDopedCarbonNanotube = addMaterial(2328, "neutronium_doped_carbon_nanotube")
+        {
+            polymer()
+            liquid()
+            color(0xDFDFDF).iconSet(SHINY)
+            components(Carbon, 48, Neutronium, 1)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 2329 Cosmic Fabric
-        CosmicFabric = Material.Builder(2329, GTLiteMod.id("cosmic_fabric"))
-            .polymer()
-            .liquid()
-            .plasma()
-            .color(0x9E19CF)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_FOIL,
-                GENERATE_FINE_WIRE)
-            .build()
+        CosmicFabric = addMaterial(2329, "cosmic_fabric")
+        {
+            polymer()
+            liquid()
+            plasma()
+            color(0x9E19CF)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_FOIL, GENERATE_FINE_WIRE)
+        }
 
         // 2330 Silicon Nanoparticles
-        SiliconNanoparticles = Material.Builder(2330, GTLiteMod.id("silicon_nanoparticles"))
-            .dust()
-            .color(Silicon.materialRGB).iconSet(NANOPARTICLES)
-            .components(Silicon, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SiliconNanoparticles = addMaterial(2330, "silicon_nanoparticles")
+        {
+            dust()
+            color(Silicon.materialRGB).iconSet(NANOPARTICLES)
+            components(Silicon, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2331 Sodium Alginate
-        SodiumAlginate = Material.Builder(2331, GTLiteMod.id("sodium_alginate"))
-            .dust()
-            .color(0x663333).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 7, Oxygen, 6, Sodium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C5H7O4COONa", true)
+        SodiumAlginate = addMaterial(2331, "sodium_alginate")
+        {
+            dust()
+            color(0x663333).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 7, Oxygen, 6, Sodium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2332 Calcium Alginate
-        CalciumAlginate = Material.Builder(2332, GTLiteMod.id("calcium_alginate"))
-            .dust()
-            .color(0x654321).iconSet(ROUGH)
-            .components(Carbon, 12, Hydrogen, 14, Oxygen, 12, Calcium, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C5H7O4COO)2Ca", true)
+        CalciumAlginate = addMaterial(2332, "calcium_alginate")
+        {
+            dust()
+            color(0x654321).iconSet(ROUGH)
+            components(Carbon, 12, Hydrogen, 14, Oxygen, 12, Calcium, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 2333 Chromatic Glass
-        ChromaticGlass = Material.Builder(2333, GTLiteMod.id("chromatic_glass"))
-            .ingot()
-            .iconSet(CHROMATIC)
-            .components(Glass, 64)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_LENS,
-                   GENERATE_FRAME)
-            .build()
-            .setFormula("(SiO2)64", true)
+        ChromaticGlass = addMaterial(2333, "chromatic_glass")
+        {
+            ingot()
+            iconSet(CHROMATIC)
+            components(Glass, 64)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_LENS, GENERATE_FRAME)
+        }
 
         // 2334 Lanthanum Hexaboride
-        LanthanumHexaboride = Material.Builder(2334, GTLiteMod.id("lanthanum_hexaboride"))
-            .gem()
-            .color(0x8C6E78).iconSet(GEM_HORIZONTAL)
-            .components(Lanthanum, 1, Boron, 6)
-            .flags(GENERATE_PLATE, GENERATE_LENS, CRYSTALLIZABLE)
-            .build()
+        LanthanumHexaboride = addMaterial(2334, "lanthanum_hexaboride")
+        {
+            gem()
+            color(0x8C6E78).iconSet(GEM_HORIZONTAL)
+            components(Lanthanum, 1, Boron, 6)
+            flags(STD_METAL, GENERATE_LENS, CRYSTALLIZABLE)
+        }
 
         // 2335 Francium Carbide
-        FranciumCarbide = Material.Builder(2335, GTLiteMod.id("francium_carbide"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(Francium, 2, Carbon, 2)
-            .build()
+        FranciumCarbide = addMaterial(2335, "francium_carbide")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(Francium, 2, Carbon, 2)
+        }
 
         // 2336 Boron Carbide
-        BoronCarbide = Material.Builder(2336, GTLiteMod.id("boron_carbide"))
-            .gem()
-            .colorAverage().iconSet(GEM_HORIZONTAL)
-            .components(Boron, 4, Carbon, 1)
-            .flags(GENERATE_PLATE, GENERATE_LENS)
-            .build()
+        BoronCarbide = addMaterial(2336, "boron_carbide")
+        {
+            gem()
+            colorAverage().iconSet(GEM_HORIZONTAL)
+            components(Boron, 4, Carbon, 1)
+            flags(STD_METAL, GENERATE_LENS)
+        }
 
         // 2337 Astatine Azide
-        AstatineAzide = Material.Builder(2337, GTLiteMod.id("astatine_azide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(Astatine, 1, Nitrogen, 3)
-            .build()
+        AstatineAzide = addMaterial(2337, "astatine_azide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(Astatine, 1, Nitrogen, 3)
+        }
 
         // 2338 Holmium Iodide
-        HolmiumIodide = Material.Builder(2338, GTLiteMod.id("holmium_iodide"))
-            .dust()
-            .color(0xEDAE17).iconSet(METALLIC)
-            .components(Holmium, 1, Iodine, 3)
-            .build()
+        HolmiumIodide = addMaterial(2338, "holmium_iodide")
+        {
+            dust()
+            color(0xEDAE17).iconSet(METALLIC)
+            components(Holmium, 1, Iodine, 3)
+        }
 
         // 2339 Heavy Conductive Mixture
-        HeavyConductiveMixture = Material.Builder(2339, GTLiteMod.id("heavy_conductive_mixture"))
-            .dust()
-            .color(0x1264FF).iconSet(MAGNETIC)
-            .components(FranciumCarbide, 1, BoronCarbide, 1, AstatineAzide, 1,
-                        HolmiumIodide, 1)
-            .build()
+        HeavyConductiveMixture = addMaterial(2339, "heavy_conductive_mixture")
+        {
+            dust()
+            color(0x1264FF).iconSet(MAGNETIC)
+            components(FranciumCarbide, 1, BoronCarbide, 1, AstatineAzide, 1, HolmiumIodide, 1)
+        }
 
         // 2340 Plutonium Dioxide
-        PlutoniumDioxide = Material.Builder(2340, GTLiteMod.id("plutonium_dioxide"))
-            .dust()
-            .color(0xB02E41).iconSet(SHINY)
-            .components(Plutonium241, 1, Oxygen, 2)
-            .build()
-            .setFormula("PuO2", true)
+        PlutoniumDioxide = addMaterial(2340, "plutonium_dioxide")
+        {
+            dust()
+            color(0xB02E41).iconSet(SHINY)
+            components(Plutonium241, 1, Oxygen, 2)
+        }
 
         // 2341 MOX
-        MOX = Material.Builder(2341, GTLiteMod.id("mox"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(PlutoniumDioxide, 1, Uraninite, 2)
-            .build()
-            .setFormula("(PuO2)(UO2)2", true)
+        MOX = addMaterial(2341, "mox")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(PlutoniumDioxide, 1, Uraninite, 2)
+        }
 
         // 2342 Barium Manganate
-        BariumManganate = Material.Builder(2342, GTLiteMod.id("barium_manganate"))
-            .dust()
-            .colorAverage().iconSet(ROUGH)
-            .components(Barium, 1, Manganese, 1, Oxygen, 4)
-            .build()
+        BariumManganate = addMaterial(2342, "barium_manganate")
+        {
+            dust()
+            colorAverage().iconSet(ROUGH)
+            components(Barium, 1, Manganese, 1, Oxygen, 4)
+        }
 
         // 2343 Barium Dichloride
-        BariumDichloride = Material.Builder(2343, GTLiteMod.id("barium_dichloride"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Barium, 1, Chlorine, 2)
-            .build()
+        BariumDichloride = addMaterial(2343, "barium_dichloride")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Barium, 1, Chlorine, 2)
+        }
 
         // 2344 Thallium Chloride
-        ThalliumChloride = Material.Builder(2344, GTLiteMod.id("thallium_chloride"))
-            .dust()
-            .color(0xFF7409).iconSet(METALLIC)
-            .components(Thallium, 1, Chlorine, 1)
-            .build()
+        ThalliumChloride = addMaterial(2344, "thallium_chloride")
+        {
+            dust()
+            color(0xFF7409).iconSet(METALLIC)
+            components(Thallium, 1, Chlorine, 1)
+        }
 
         // 2345 Hassium Tetrachloride
-        HassiumTetrachloride = Material.Builder(2345, GTLiteMod.id("hassium_tetrachloride"))
-            .dust()
-            .color(0x032551).iconSet(SHINY)
-            .components(MetastableHassium, 1, Chlorine, 4)
-            .build()
+        HassiumTetrachloride = addMaterial(2345, "hassium_tetrachloride")
+        {
+            dust()
+            color(0x032551).iconSet(SHINY)
+            components(MetastableHassium, 1, Chlorine, 4)
+        }
 
         // 2346 Rhenium Pentachloride
-        RheniumPentachloride = Material.Builder(2346, GTLiteMod.id("rhenium_pentachloride"))
-            .dust()
-            .color(0x5B1780).iconSet(SHINY)
-            .components(Rhenium, 1, Chlorine, 5)
-            .build()
+        RheniumPentachloride = addMaterial(2346, "rhenium_pentachloride")
+        {
+            dust()
+            color(0x5B1780).iconSet(SHINY)
+            components(Rhenium, 1, Chlorine, 5)
+        }
 
         // 2347 Hexafluorophosphoric Acid
-        HexafluorophosphoricAcid = Material.Builder(2347, GTLiteMod.id("hexafluorophosphoric_acid"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0xFCC782)
-            .components(Hydrogen, 1, Phosphorus, 1, Fluorine, 6)
-            .build()
+        HexafluorophosphoricAcid = addMaterial(2347, "hexafluorophosphoric_acid")
+        {
+            liquid(FluidBuilder().attributes(FluidAttributes.ACID))
+            color(0xFCC782)
+            components(Hydrogen, 1, Phosphorus, 1, Fluorine, 6)
+        }
 
         // 2348 Sodium Thiocyanate
-        SodiumThiocyanate = Material.Builder(2348, GTLiteMod.id("sodium_thiocyanate"))
-            .dust()
-            .color(0x818052)
-            .components(Sodium, 1, Sulfur, 1, Carbon, 1, Nitrogen, 1)
-            .build()
+        SodiumThiocyanate = addMaterial(2348, "sodium_thiocyanate")
+        {
+            dust()
+            color(0x818052)
+            components(Sodium, 1, Sulfur, 1, Carbon, 1, Nitrogen, 1)
+        }
 
-        // 2349 Rhenium Hassium Thallium Isophtaloylbisdiethylthiourea Hexafluorophosphate
-        RheniumHassiumThalliumIsophtaloylbisdiethylthioureaHexafluorophosphate = Material.Builder(2349, GTLiteMod.id("rhenium_hassium_thallium_isophtaloylbisdiethylthiourea_hexafluorophosphate"))
-            .dust()
-            .color(0x5F5F82).iconSet(BRIGHT)
-            .components(Carbon, 60, Hydrogen, 84, Oxygen, 12, Nitrogen, 12, Sulfur, 6, Fluorine, 6, Phosphorus, 1, Rhenium, 1, MetastableHassium, 1, Thallium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        // 2349 Rhenium Hassium Thallium Isophtaloylbisdiethylthiourea Hexafluorophosphate (RHTIH)
+        RheniumHassiumThalliumIsophtaloylbisdiethylthioureaHexafluorophosphate = addMaterial(2349, "rhenium_hassium_thallium_isophtaloylbisdiethylthiourea_hexafluorophosphate")
+        {
+            dust()
+            color(0x5F5F82).iconSet(BRIGHT)
+            components(Carbon, 60, Hydrogen, 84, Oxygen, 12, Nitrogen, 12, Sulfur, 6, Fluorine, 6, Phosphorus, 1,
+                       Rhenium, 1, MetastableHassium, 1, Thallium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteOrganicChemistryMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteOrganicChemistryMaterials.kt
@@ -59,7 +59,10 @@ import gregtech.api.unification.material.info.MaterialIconSet.METALLIC
 import gregtech.api.unification.material.info.MaterialIconSet.ROUGH
 import gregtech.api.unification.material.info.MaterialIconSet.SHINY
 import gregtechlite.gtlitecore.GTLiteMod
+import gregtechlite.gtlitecore.api.extension.cableProp
 import gregtechlite.gtlitecore.api.extension.colorAverage
+import gregtechlite.gtlitecore.api.extension.fluidPipeProp
+import gregtechlite.gtlitecore.api.extension.liquid
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetaldehyde
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetamide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AceticAnhydride
@@ -303,1862 +306,2032 @@ object GTLiteOrganicChemistryMaterials
     fun init()
     {
         // 8001 Dicyclopentadiene
-        Dicyclopentadiene = Material.Builder(8001, GTLiteMod.id("dicyclopentadiene"))
-            .liquid(FluidBuilder().temperature(306))
-            .color(0x9C388B)
-            .components(Carbon, 10, Hydrogen, 12)
-            .build()
+        Dicyclopentadiene = addMaterial(8001, "dicyclopentadiene")
+        {
+            liquid()
+            {
+                temperature(306)
+            }
+            color(0x9C388B)
+            components(Carbon, 10, Hydrogen, 12)
+        }
 
         // 8002 Pentane
-        Pentane = Material.Builder(8002, GTLiteMod.id("pentane"))
-            .liquid()
-            .color(0xE8E7BE)
-            .components(Carbon, 5, Hydrogen, 12)
-            .build()
+        Pentane = addMaterial(8002, "pentane")
+        {
+            liquid()
+            color(0xE8E7BE)
+            components(Carbon, 5, Hydrogen, 12)
+        }
 
         // 8003 Polyisoprene
-        Polyisoprene = Material.Builder(8003, GTLiteMod.id("polyisoprene"))
-            .polymer()
-            .liquid()
-            .color(0x575757).iconSet(SHINY)
-            .components(Carbon, 5, Hydrogen, 8)
-            .flags(NO_SMASHING, NO_SMELTING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        Polyisoprene = addMaterial(8003, "polyisoprene")
+        {
+            polymer()
+            liquid()
+            color(0x575757).iconSet(SHINY)
+            components(Carbon, 5, Hydrogen, 8)
+            flags(NO_SMASHING, NO_SMELTING, DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8004 Para Xylene
-        ParaXylene = Material.Builder(8004, GTLiteMod.id("para_xylene"))
-            .liquid()
-            .color(0x666040)
-            .components(Carbon, 8, Hydrogen, 10)
-            .build()
-            .setFormula("C6H4(CH3)2", true)
+        ParaXylene = addMaterial(8004, "para_xylene")
+        {
+            liquid()
+            color(0x666040)
+            components(Carbon, 8, Hydrogen, 10)
+        }
 
         // 8005 Nitrotoluene
-        Nitrotoluene = Material.Builder(8005, GTLiteMod.id("nitrotoluene"))
-            .liquid()
-            .color(0x99236E)
-            .components(Carbon, 7, Hydrogen, 7, Nitrogen, 1, Oxygen, 2)
-            .build()
-            .setFormula("C6H4CH3NO2", true)
+        Nitrotoluene = addMaterial(8005, "nitrotoluene")
+        {
+            liquid()
+            color(0x99236E)
+            components(Carbon, 7, Hydrogen, 7, Nitrogen, 1, Oxygen, 2)
+        }
 
         // 8006 Diaminostilbenedisulfonic Acid (DSDA)
-        DiaminostilbenedisulfonicAcid = Material.Builder(8006, GTLiteMod.id("diaminostilbenedisulfonic_acid"))
-            .dust()
-            .color(0xF2F2F2).iconSet(ROUGH)
-            .components(Carbon, 14, Hydrogen, 14, Nitrogen, 2, Oxygen, 6, Sulfur, 2)
-            .build()
+        DiaminostilbenedisulfonicAcid = addMaterial(8006, "diaminostilbenedisulfonic_acid")
+        {
+            dust()
+            color(0xF2F2F2).iconSet(ROUGH)
+            components(Carbon, 14, Hydrogen, 14, Nitrogen, 2, Oxygen, 6, Sulfur, 2)
+        }
 
         // 8007 Succinic Acid
-        SuccinicAcid = Material.Builder(8007, GTLiteMod.id("succinic_acid"))
-            .dust()
-            .color(0x0C3A5B).iconSet(DULL)
-            .components(Carbon, 4, Hydrogen, 6, Oxygen, 4)
-            .build()
+        SuccinicAcid = addMaterial(8007, "succinic_acid")
+        {
+            dust()
+            color(0x0C3A5B).iconSet(DULL)
+            components(Carbon, 4, Hydrogen, 6, Oxygen, 4)
+        }
 
         // 8008 Butanediol
-        Butanediol = Material.Builder(8008, GTLiteMod.id("butanediol"))
-            .liquid()
-            .color(0xAAC4DA)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION) // Re-added electrolysis reaction by PedotChain.
-            .build()
-            .setFormula("C4H8(OH)2", true)
+        // Add Electrolysis Reaction by PEDOTChain.
+        Butanediol = addMaterial(8008, "butanediol")
+        {
+            liquid()
+            color(0xAAC4DA)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8009 Tetrahydrofuran
-        Tetrahydrofuran = Material.Builder(8009, GTLiteMod.id("tetrahydrofuran"))
-            .liquid()
-            .color(0x0BCF52)
-            .components(Carbon, 4, Hydrogen, 8, Oxygen, 1)
-            .build()
-            .setFormula("(CH2)4O", true)
+        Tetrahydrofuran = addMaterial(8009, "tetrahydrofuran")
+        {
+            liquid()
+            color(0x0BCF52)
+            components(Carbon, 4, Hydrogen, 8, Oxygen, 1)
+        }
 
         // 8010 Ethylene Dibromide
-        EthyleneDibromide = Material.Builder(8010, GTLiteMod.id("ethylene_dibromide"))
-            .liquid()
-            .color(0x4F1743)
-            .components(Carbon, 2, Hydrogen, 4, Bromine, 2)
-            .build()
+        EthyleneDibromide = addMaterial(8010, "ethylene_dibromide")
+        {
+            liquid()
+            color(0x4F1743)
+            components(Carbon, 2, Hydrogen, 4, Bromine, 2)
+        }
 
         // 8011 Grignard Reagent
-        GrignardReagent = Material.Builder(8011, GTLiteMod.id("grignard_reagent"))
-            .liquid()
-            .color(0xA12AA1)
-            .components(Carbon, 1, Hydrogen, 3, HRAMagnesium, 1, Bromine, 1)
-            .build()
+        GrignardReagent = addMaterial(8011, "grignard_reagent")
+        {
+            liquid()
+            color(0xA12AA1)
+            components(Carbon, 1, Hydrogen, 3, HRAMagnesium, 1, Bromine, 1)
+        }
 
         // 8012 Ethylhexanol
-        Ethylhexanol = Material.Builder(8012, GTLiteMod.id("ethylhexanol"))
-            .liquid()
-            .color(0xFEEA9A)
-            .components(Carbon, 8, Hydrogen, 10, Oxygen, 1)
-            .build()
+        Ethylhexanol = addMaterial(8012, "ethylhexanol")
+        {
+            liquid()
+            color(0xFEEA9A)
+            components(Carbon, 8, Hydrogen, 10, Oxygen, 1)
+        }
 
         // 8013 Di-(2-Ethylhexyl) Phosphoric Acid
-        DiethylhexylPhosphoricAcid = Material.Builder(8013, GTLiteMod.id("diethylhexyl_phosphoric_acid"))
-            .liquid()
-            .color(0xFFFF99)
-            .components(Carbon, 16, Hydrogen, 35, Oxygen, 4, Phosphorus, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C8H7O)2PO2H", true)
+        DiethylhexylPhosphoricAcid = addMaterial(8013, "diethylhexyl_phosphoric_acid")
+        {
+            liquid()
+            color(0xFFFF99)
+            components(Carbon, 16, Hydrogen, 35, Oxygen, 4, Phosphorus, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8014 Formic Acid
-        FormicAcid = Material.Builder(8014, GTLiteMod.id("formic_acid"))
-            .liquid(FluidBuilder().attribute(FluidAttributes.ACID))
-            .color(0xFFAA77)
-            .components(Hydrogen, 2, Carbon, 1, Oxygen, 2)
-            .build()
-            .setFormula("HCOOH", true)
+        FormicAcid = addMaterial(8014, "formic_acid")
+        {
+            liquid()
+            {
+                attribute(FluidAttributes.ACID)
+            }
+            color(0xFFAA77)
+            components(Hydrogen, 2, Carbon, 1, Oxygen, 2)
+        }
 
         // 8015 Methyl Formate
-        MethylFormate = Material.Builder(8015, GTLiteMod.id("methyl_formate"))
-            .liquid()
-            .color(0xFFAAAA)
-            .components(Hydrogen, 4, Carbon, 2, Oxygen, 2)
-            .build()
-            .setFormula("HCO2CH3", true)
+        MethylFormate = addMaterial(8015, "methyl_formate")
+        {
+            liquid()
+            color(0xFFAAAA)
+            components(Hydrogen, 4, Carbon, 2, Oxygen, 2)
+        }
 
         // 8016 Thionyl Chloride
-        ThionylChloride = Material.Builder(8016, GTLiteMod.id("thionyl_chloride"))
-            .liquid()
-            .color(0xEBE863)
-            .components(Sulfur, 1, Oxygen, 1, Chlorine, 2)
-            .build()
+        ThionylChloride = addMaterial(8016, "thionyl_chloride")
+        {
+            liquid()
+            color(0xEBE863)
+            components(Sulfur, 1, Oxygen, 1, Chlorine, 2)
+        }
 
         // 8017 Phthalic Anhydride
-        PhthalicAnhydride = Material.Builder(8017, GTLiteMod.id("phthalic_anhydride"))
-            .dust()
-            .color(0xEEAAEE)
-            .components(Carbon, 8, Hydrogen, 4, Oxygen, 3)
-            .build()
-            .setFormula("C6H4(CO)2O", true)
+        PhthalicAnhydride = addMaterial(8017, "phthalic_anhydride")
+        {
+            dust()
+            color(0xEEAAEE)
+            components(Carbon, 8, Hydrogen, 4, Oxygen, 3)
+        }
 
         // 8018 Ethylanthraquinone
-        Ethylanthraquinone = Material.Builder(8018, GTLiteMod.id("ethylanthraquinone"))
-            .liquid()
-            .color(0xCC865A)
-            .components(Carbon, 16, Hydrogen, 12, Oxygen, 2)
-            .build()
-            .setFormula("C6H4(CO)2C6H3Et", true)
+        Ethylanthraquinone = addMaterial(8018, "ethylanthraquinone")
+        {
+            liquid()
+            color(0xCC865A)
+            components(Carbon, 16, Hydrogen, 12, Oxygen, 2)
+        }
 
         // 8019 Ethylanthrahydroquinone
-        Ethylanthrahydroquinone = Material.Builder(8019, GTLiteMod.id("ethylanthrahydroquinone"))
-            .liquid()
-            .color(0xAD531A)
-            .components(Carbon, 16, Hydrogen, 18, Oxygen, 2)
-            .build()
-            .setFormula("C6H4(CH2OH)2C6H3Et", true)
+        Ethylanthrahydroquinone = addMaterial(8019, "ethylanthrahydroquinone")
+        {
+            liquid()
+            color(0xAD531A)
+            components(Carbon, 16, Hydrogen, 18, Oxygen, 2)
+        }
 
         // 8020 Hydrazine
-        Hydrazine = Material.Builder(8020, GTLiteMod.id("hydrazine"))
-            .liquid()
-            .color(0xB50707)
-            .components(Nitrogen, 2, Hydrogen, 4)
-            .build()
+        Hydrazine = addMaterial(8020, "hydrazine")
+        {
+            liquid()
+            color(0xB50707)
+            components(Nitrogen, 2, Hydrogen, 4)
+        }
 
         // 8021 Citric Acid
-        CitricAcid = Material.Builder(8021, GTLiteMod.id("citric_acid"))
-            .liquid()
-            .color(0xFFCC00)
-            .components(Carbon, 6, Hydrogen, 8, Oxygen, 7)
-            .build()
+        CitricAcid = addMaterial(8021, "citric_acid")
+        {
+            liquid()
+            color(0xFFCC00)
+            components(Carbon, 6, Hydrogen, 8, Oxygen, 7)
+        }
 
         // 8022 Glutamine
-        Glutamine = Material.Builder(8022, GTLiteMod.id("glutamine"))
-            .dust()
-            .color(0xEDE9B4).iconSet(DULL)
-            .components(Carbon, 5, Hydrogen, 10, Nitrogen, 2, Oxygen, 3)
-            .build()
+        Glutamine = addMaterial(8022, "glutamine")
+        {
+            dust()
+            color(0xEDE9B4).iconSet(DULL)
+            components(Carbon, 5, Hydrogen, 10, Nitrogen, 2, Oxygen, 3)
+        }
 
         // 8023 Linoleic Acid
-        LinoleicAcid = Material.Builder(8023, GTLiteMod.id("linoleic_acid"))
-            .liquid()
-            .color(0xD5D257)
-            .components(Carbon, 18, Hydrogen, 32, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        LinoleicAcid = addMaterial(8023, "linoleic_acid")
+        {
+            liquid()
+            color(0xD5D257)
+            components(Carbon, 18, Hydrogen, 32, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8024 Biotin
-        Biotin = Material.Builder(8024, GTLiteMod.id("biotin"))
-            .dust()
-            .color(0x68CC6A)
-            .components(Carbon, 10, Hydrogen, 16, Nitrogen, 2, Oxygen, 3, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Biotin = addMaterial(8024, "biotin")
+        {
+            dust()
+            color(0x68CC6A)
+            components(Carbon, 10, Hydrogen, 16, Nitrogen, 2, Oxygen, 3, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8025 Durene
-        Durene = Material.Builder(8025, GTLiteMod.id("durene"))
-            .dust()
-            .color(0x336040).iconSet(FINE)
-            .components(Carbon, 10, Hydrogen, 14)
-            .build()
-            .setFormula("C6H2(CH3)4", true)
+        Durene = addMaterial(8025, "durene")
+        {
+            dust()
+            color(0x336040).iconSet(FINE)
+            components(Carbon, 10, Hydrogen, 14)
+        }
 
         // 8026 Pyromellitic Dianhydride (PDMA)
-        PyromelliticDianhydride = Material.Builder(8026, GTLiteMod.id("pyromellitic_dianhydride"))
-            .dust()
-            .color(0xF0EAD6).iconSet(ROUGH)
-            .components(Carbon, 10, Hydrogen, 2, Oxygen, 6)
-            .build()
-            .setFormula("C6H2(C2O3)2", true)
+        PyromelliticDianhydride = addMaterial(8026, "pyromellitic_dianhydride")
+        {
+            dust()
+            color(0xF0EAD6).iconSet(ROUGH)
+            components(Carbon, 10, Hydrogen, 2, Oxygen, 6)
+        }
 
         // 8027 Aminophenol
-        Aminophenol = Material.Builder(8027, GTLiteMod.id("aminophenol"))
-            .dust()
-            .color(0xFFFFFF).iconSet(SHINY)
-            .components(Carbon, 6, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
-            .build()
+        Aminophenol = addMaterial(8027, "aminophenol")
+        {
+            dust()
+            color(0xFFFFFF).iconSet(SHINY)
+            components(Carbon, 6, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
+        }
 
         // 8028 Aniline
-        Aniline = Material.Builder(8028, GTLiteMod.id("aniline"))
-            .liquid()
-            .color(0x4c911d)
-            .components(Carbon, 6, Hydrogen, 7, Nitrogen, 1)
-            .build()
-            .setFormula("C6H5NH2", true)
+        Aniline = addMaterial(8028, "aniline")
+        {
+            liquid()
+            color(0x4c911d)
+            components(Carbon, 6, Hydrogen, 7, Nitrogen, 1)
+        }
 
         // 8029 Oxydianiline (ODA)
-        Oxydianiline = Material.Builder(8029, GTLiteMod.id("oxydianiline"))
-            .dust()
-            .color(0xF0E130)
-            .components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
-            .build()
-            .setFormula("O(C6H4NH2)2", true)
+        Oxydianiline = addMaterial(8029, "oxydianiline")
+        {
+            dust()
+            color(0xF0E130)
+            components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
+        }
 
         // 8030 Kapton-K (Poly 4,4'-Oxydiphenylene-Pyromellitimide)
-        KaptonK = Material.Builder(8030, GTLiteMod.id("kapton_k"))
-            .polymer()
-            .liquid()
-            .color(0xFFCE52)
-            .components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
-            .setFormula("(C7H2N2O4)(O(C6H4)2)", true)
+        KaptonK = addMaterial(8030, "kapton_k")
+        {
+            polymer()
+            liquid()
+            color(0xFFCE52)
+            components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8031 Biphenyl Tetracarboxylic Acid Dianhydride (BTAD)
-        BiphenylTetracarboxylicAcidDianhydride = Material.Builder(8031, GTLiteMod.id("biphenyl_tetracarboxylic_acid_dianhydride"))
-            .dust()
-            .color(0xFF7F50)
-            .components(Carbon, 16, Hydrogen, 6, Oxygen, 6)
-            .build()
-            .setFormula("(C8H3O3)2", true)
+        BiphenylTetracarboxylicAcidDianhydride = addMaterial(8031, "biphenyl_tetracarboxylic_acid_dianhydride")
+        {
+            dust()
+            color(0xFF7F50)
+            components(Carbon, 16, Hydrogen, 6, Oxygen, 6)
+        }
 
         // 8032 Nitroaniline
-        Nitroaniline = Material.Builder(8032, GTLiteMod.id("nitroaniline"))
-            .liquid()
-            .color(0x2A6E68)
-            .components(Carbon, 6, Hydrogen, 6, Nitrogen, 2, Oxygen, 2)
-            .build()
-            .setFormula("H2NC6H4NO2", true)
+        Nitroaniline = addMaterial(8032, "nitroaniline")
+        {
+            liquid()
+            color(0x2A6E68)
+            components(Carbon, 6, Hydrogen, 6, Nitrogen, 2, Oxygen, 2)
+        }
 
         // 8033 Para-Phenylenediamine
-        ParaPhenylenediamine = Material.Builder(8033, GTLiteMod.id("para_phenylenediamine"))
-            .dust()
-            .color(0x4A8E7B).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 8, Nitrogen, 2)
-            .build()
-            .setFormula("H2NC6H4NH2", true)
+        ParaPhenylenediamine = addMaterial(8033, "para_phenylenediamine")
+        {
+            dust()
+            color(0x4A8E7B).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 8, Nitrogen, 2)
+        }
 
         // 8034 Kapton-E
-        KaptonE = Material.Builder(8034, GTLiteMod.id("kapton_e"))
-            .polymer()
-            .liquid()
-            .color(0xFFDF8C)
-            .components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, NO_SMASHING, NO_SMELTING, GENERATE_FOIL)
-            .build()
-            .setFormula("O(C6H4NH2)2", true)
+        KaptonE = addMaterial(8034, "kapton_e")
+        {
+            polymer()
+            liquid()
+            color(0xFFDF8C)
+            components(Carbon, 12, Hydrogen, 12, Nitrogen, 2, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, NO_SMASHING, NO_SMELTING, GENERATE_FOIL)
+        }
 
         // 8035 Hydroxyquinoline
-        Hydroxyquinoline = Material.Builder(8035, GTLiteMod.id("hydroxyquinoline"))
-            .dust()
-            .color(0x3A9A71).iconSet(METALLIC)
-            .components(Carbon, 9, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
-            .build()
+        Hydroxyquinoline = addMaterial(8035, "hydroxyquinoline")
+        {
+            dust()
+            color(0x3A9A71).iconSet(METALLIC)
+            components(Carbon, 9, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
+        }
 
         // 8036 Hydrogen Cyanide
-        HydrogenCyanide = Material.Builder(8036, GTLiteMod.id("hydrogen_cyanide"))
-            .liquid()
-            .color(0x6E6A5E)
-            .components(Hydrogen, 1, Carbon, 1, Nitrogen, 1)
-            .build()
+        HydrogenCyanide = addMaterial(8036, "hydrogen_cyanide")
+        {
+            liquid()
+            color(0x6E6A5E)
+            components(Hydrogen, 1, Carbon, 1, Nitrogen, 1)
+        }
 
         // 8037 Acetone Cyanohydrin
-        AcetoneCyanohydrin = Material.Builder(8037, GTLiteMod.id("acetone_cyanohydrin"))
-            .liquid()
-            .color(0xA1FFD0)
-            .components(Carbon, 4, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
-            .build()
+        AcetoneCyanohydrin = addMaterial(8037, "acetone_cyanohydrin")
+        {
+            liquid()
+            color(0xA1FFD0)
+            components(Carbon, 4, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
+        }
 
         // 8038 Polymethylmethacrylate (PMMA)
-        Polymethylmethacrylate = Material.Builder(8038, GTLiteMod.id("polymethylmethacrylate"))
-            .ingot()
-            .liquid()
-            .color(0x91CAE1)
-            .components(Carbon, 5, Hydrogen, 8, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
+        Polymethylmethacrylate = addMaterial(8038, "polymethylmethacrylate")
+        {
+            ingot()
+            liquid()
+            color(0x91CAE1)
+            components(Carbon, 5, Hydrogen, 8, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE,
                    GENERATE_LENS)
-            .build()
+        }
 
         // 8039 Diacetyl
-        Diacetyl = Material.Builder(8039,  GTLiteMod.id("diacetyl"))
-            .liquid()
-            .color(0xF7FF65)
-            .components(Carbon, 4, Hydrogen, 6, Oxygen, 2)
-            .build()
+        Diacetyl = addMaterial(8039, "diacetyl")
+        {
+            liquid()
+            color(0xF7FF65)
+            components(Carbon, 4, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8040 Ethylene Oxide
-        EthyleneOxide = Material.Builder(8040, GTLiteMod.id("ethylene_oxide"))
-            .gas()
-            .color(0xDCBFE1)
-            .components(Carbon, 2, Hydrogen, 4, Oxygen, 1)
-            .build()
+        EthyleneOxide = addMaterial(8040, "ethylene_oxide")
+        {
+            gas()
+            color(0xDCBFE1)
+            components(Carbon, 2, Hydrogen, 4, Oxygen, 1)
+        }
 
         // 8041 Ethylene Glycol
-        EthyleneGlycol = Material.Builder(8041, GTLiteMod.id("ethylene_glycol"))
-            .liquid()
-            .color(0x286632)
-            .components(Carbon, 2, Hydrogen, 6, Oxygen, 2)
-            .build()
-            .setFormula("C2H4(OH)2", true)
+        EthyleneGlycol = addMaterial(8041, "ethylene_glycol")
+        {
+            liquid()
+            color(0x286632)
+            components(Carbon, 2, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8042 3,4-Ethylenedioxythiophene (EDOT)
-        Edot = Material.Builder(8042, GTLiteMod.id("edot"))
-            .liquid()
-            .color(0xB1FFD7)
-            .components(Carbon, 6, Hydrogen, 6, Oxygen, 2, Sulfur, 1)
-            .build()
+        Edot = addMaterial(8042, "edot")
+        {
+            liquid()
+            color(0xB1FFD7)
+            components(Carbon, 6, Hydrogen, 6, Oxygen, 2, Sulfur, 1)
+        }
 
         // 8043 Polystyrene (PS)
-        Polystyrene = Material.Builder(8043, GTLiteMod.id("polystyrene"))
-            .polymer()
-            .liquid()
-            .color(0xE1C2C2)
-            .components(Carbon, 8, Hydrogen, 8)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        Polystyrene = addMaterial(8043, "polystyrene")
+        {
+            polymer()
+            liquid()
+            color(0xE1C2C2)
+            components(Carbon, 8, Hydrogen, 8)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8044 Polystyrene Sulfonate (PSS)
-        PolystyreneSulfonate = Material.Builder(8044, GTLiteMod.id("polystyrene_sulfonate"))
-            .polymer()
-            .liquid()
-            .color(0xE17C72)
-            .components(Carbon, 8, Hydrogen, 8, Sulfur, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
-            .setFormula("C8H7SO3H", true)
+        PolystyreneSulfonate = addMaterial(8044, "polystyrene_sulfonate")
+        {
+            polymer()
+            liquid()
+            color(0xE17C72)
+            components(Carbon, 8, Hydrogen, 8, Sulfur, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8045 PEDOT:PSS
-        PedotPSS = Material.Builder(8045, GTLiteMod.id("pedot_pss"))
-            .polymer()
-            .liquid()
-            .color(0xE165A7)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .components(Edot, 1, PolystyreneSulfonate, 1)
-            .cableProperties(V[ZPM], 6, 1)
-            .build()
+        PedotPSS = addMaterial(8045, "pedot_pss")
+        {
+            polymer()
+            liquid()
+            color(0xE165A7)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+            components(Edot, 1, PolystyreneSulfonate, 1)
+            cableProp(V[ZPM], 6, 1)
+        }
 
         // 8046 PEDOT-TMA
-        PedotTMA = Material.Builder(8046, GTLiteMod.id("pedot_tma"))
-            .polymer()
-            .liquid()
-            .color(0x5E9EE1)
-            .components(Edot, 1, Polymethylmethacrylate, 2)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .cableProperties(V[UV], 8, 4)
-            .build()
+        PedotTMA = addMaterial(8046, "pedot_tma")
+        {
+            polymer()
+            liquid()
+            color(0x5E9EE1)
+            components(Edot, 1, Polymethylmethacrylate, 2)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            cableProp(V[UV], 8, 4)
+        }
 
         // 8047 Methylamine
-        Methylamine = Material.Builder(8047, GTLiteMod.id("methylamine"))
-            .gas()
-            .color(0xAA6600)
-            .components(Carbon, 1, Hydrogen, 5, Nitrogen, 1)
-            .build()
-            .setFormula("CH3NH2", true)
+        Methylamine = addMaterial(8047, "methylamine")
+        {
+            gas()
+            color(0xAA6600)
+            components(Carbon, 1, Hydrogen, 5, Nitrogen, 1)
+        }
 
         // 8048 Trimethylamine
-        Trimethylamine = Material.Builder(8048, GTLiteMod.id("trimethylamine"))
-            .gas()
-            .color(0xBB7700)
-            .components(Carbon, 3, Hydrogen, 9, Nitrogen, 1)
-            .build()
-            .setFormula("(CH3)3N", true)
+        Trimethylamine = addMaterial(8048, "trimethylamine")
+        {
+            gas()
+            color(0xBB7700)
+            components(Carbon, 3, Hydrogen, 9, Nitrogen, 1)
+        }
 
         // 8049 Tetramethylammonium Chloride
-        TetramethylammoniumChloride = Material.Builder(8049, GTLiteMod.id("tetramethylammonium_chloride"))
-            .dust()
-            .color(0x27FF81).iconSet(METALLIC)
-            .components(Carbon, 4, Hydrogen, 12, Nitrogen, 1, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("N(CH3)4Cl", true)
+        TetramethylammoniumChloride = addMaterial(8049, "tetramethylammonium_chloride")
+        {
+            dust()
+            color(0x27FF81).iconSet(METALLIC)
+            components(Carbon, 4, Hydrogen, 12, Nitrogen, 1, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8050 Tetramethylammonium Hydroxide (TMAH)
-        TetramethylammoniumHydroxide = Material.Builder(8050, GTLiteMod.id("tetramethylammonium_hydroxide"))
-            .liquid()
-            .color(0x40FFD6)
-            .components(Nitrogen, 1, Carbon, 4, Hydrogen, 12, Oxygen, 1, Hydrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("N(CH3)4OH", true)
+        TetramethylammoniumHydroxide = addMaterial(8050, "tetramethylammonium_hydroxide")
+        {
+            liquid()
+            color(0x40FFD6)
+            components(Nitrogen, 1, Carbon, 4, Hydrogen, 12, Oxygen, 1, Hydrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8051 Pyrocatechol
-        Pyrocatechol = Material.Builder(8051, GTLiteMod.id("pyrocatechol"))
-            .dust()
-            .color(0x784421).iconSet(DULL)
-            .components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
-            .build()
+        Pyrocatechol = addMaterial(8051, "pyrocatechol")
+        {
+            dust()
+            color(0x784421).iconSet(DULL)
+            components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8052 1,2-Dichloroethane
-        Dichloroethane = Material.Builder(8052, GTLiteMod.id("dichloroethane"))
-            .liquid()
-            .color(0xDAAED3)
-            .components(Carbon, 2, Hydrogen, 4, Chlorine, 2)
-            .build()
+        Dichloroethane = addMaterial(8052, "dichloroethane")
+        {
+            liquid()
+            color(0xDAAED3)
+            components(Carbon, 2, Hydrogen, 4, Chlorine, 2)
+        }
 
         // 8053 Ethylenediamine
-        Ethylenediamine = Material.Builder(8053, GTLiteMod.id("ethylenediamine"))
-            .liquid()
-            .color(0xD00ED0)
-            .components(Carbon, 2, Hydrogen, 8, Nitrogen, 2)
-            .build()
-            .setFormula("C2H4(NH2)2", true)
+        Ethylenediamine = addMaterial(8053, "ethylenediamine")
+        {
+            liquid()
+            color(0xD00ED0)
+            components(Carbon, 2, Hydrogen, 8, Nitrogen, 2)
+        }
 
         // 8054 Ethylenediamine Pyrocatechol (EDP)
-        EthylenediaminePyrocatechol = Material.Builder(8054, GTLiteMod.id("ethylenediamine_pyrocatechol"))
-            .liquid()
-            .color(0xFBFF17)
-            .components(Ethylenediamine, 1, Pyrocatechol, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        EthylenediaminePyrocatechol = addMaterial(8054, "ethylenediamine_pyrocatechol")
+        {
+            liquid()
+            color(0xFBFF17)
+            components(Ethylenediamine, 1, Pyrocatechol, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8055 Formaldehyde
-        Formaldehyde = Material.Builder(8055, GTLiteMod.id("formaldehyde"))
-            .liquid()
-            .color(0x858F40)
-            .components(Carbon, 1, Hydrogen, 2, Oxygen, 1)
-            .build()
+        Formaldehyde = addMaterial(8055, "formaldehyde")
+        {
+            liquid()
+            color(0x858F40)
+            components(Carbon, 1, Hydrogen, 2, Oxygen, 1)
+        }
 
         // 8056 Tetrasodium EDTA
-        TetrasodiumEDTA = Material.Builder(8056, GTLiteMod.id("tetrasodium_ethylenediaminetetraacetic_acid"))
-            .dust()
-            .color(0x8890E0).iconSet(SHINY)
-            .components(Carbon, 10, Hydrogen, 12, Nitrogen, 2, Oxygen, 8, Sodium, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TetrasodiumEDTA = addMaterial(8056, "tetrasodium_ethylenediaminetetraacetic_acid")
+        {
+            dust()
+            color(0x8890E0).iconSet(SHINY)
+            components(Carbon, 10, Hydrogen, 12, Nitrogen, 2, Oxygen, 8, Sodium, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8057 Ethylenediaminetetraacetic Acid (EDTA)
-        EDTA = Material.Builder(8057, GTLiteMod.id("ethylenediaminetetraacetic_acid"))
-            .dust()
-            .liquid()
-            .color(0x87E6D9).iconSet(ROUGH)
-            .components(Carbon, 10, Hydrogen, 16, Nitrogen, 2, Oxygen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        EDTA = addMaterial(8057, "ethylenediaminetetraacetic_acid")
+        {
+            dust()
+            liquid()
+            color(0x87E6D9).iconSet(ROUGH)
+            components(Carbon, 10, Hydrogen, 16, Nitrogen, 2, Oxygen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8058 Hexafluoropropylene
-        Hexafluoropropylene = Material.Builder(8058, GTLiteMod.id("hexafluoropropylene"))
-            .liquid()
-            .color(0x141D6F)
-            .components(Carbon, 3, Fluorine, 6)
-            .build()
+        Hexafluoropropylene = addMaterial(8058, "hexafluoropropylene")
+        {
+            liquid()
+            color(0x141D6F)
+            components(Carbon, 3, Fluorine, 6)
+        }
 
         // 8059 Fluorinated Ethylene Propylene (FEP)
-        FluorinatedEthylenePropylene = Material.Builder(8059, GTLiteMod.id("fluorinated_ethylene_propylene"))
-            .liquid()
-            .color(0xC8C8C8).iconSet(DULL)
-            .components(Carbon, 5, Fluorine, 10)
-            .build()
+        FluorinatedEthylenePropylene = addMaterial(8059, "fluorinated_ethylene_propylene")
+        {
+            liquid()
+            color(0xC8C8C8).iconSet(DULL)
+            components(Carbon, 5, Fluorine, 10)
+        }
 
         // 8060 Trichloroethylene
-        Trichloroethylene = Material.Builder(8060, GTLiteMod.id("trichloroethylene"))
-            .liquid()
-            .color(0xB685B1)
-            .components(Carbon, 2, Hydrogen, 1, Chlorine, 3)
-            .build()
+        Trichloroethylene = addMaterial(8060, "trichloroethylene")
+        {
+            liquid()
+            color(0xB685B1)
+            components(Carbon, 2, Hydrogen, 1, Chlorine, 3)
+        }
 
         // 8061 Chloroacetic Acid
-        ChloroaceticAcid = Material.Builder(8061, GTLiteMod.id("chloroacetic_acid"))
-            .dust()
-            .color(0x38541A).iconSet(SHINY)
-            .components(Carbon, 2, Hydrogen, 3, Chlorine, 1, Oxygen, 2)
-            .build()
+        ChloroaceticAcid = addMaterial(8061, "chloroacetic_acid")
+        {
+            dust()
+            color(0x38541A).iconSet(SHINY)
+            components(Carbon, 2, Hydrogen, 3, Chlorine, 1, Oxygen, 2)
+        }
 
         // 8062 Malonic Acid
-        MalonicAcid = Material.Builder(8062, GTLiteMod.id("malonic_acid"))
-            .dust()
-            .color(0x61932E).iconSet(SHINY)
-            .components(Carbon, 3, Hydrogen, 4, Oxygen, 4)
-            .build()
+        MalonicAcid = addMaterial(8062, "malonic_acid")
+        {
+            dust()
+            color(0x61932E).iconSet(SHINY)
+            components(Carbon, 3, Hydrogen, 4, Oxygen, 4)
+        }
 
         // 8063 Phosphoryl Chloride
-        PhosphorylChloride = Material.Builder(8063, GTLiteMod.id("phosphoryl_chloride"))
-            .liquid()
-            .color(0xE8BB5B)
-            .components(Phosphorus, 1, Oxygen, 1, Chlorine, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhosphorylChloride = addMaterial(8063, "phosphoryl_chloride")
+        {
+            liquid()
+            color(0xE8BB5B)
+            components(Phosphorus, 1, Oxygen, 1, Chlorine, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8064 Phosphonitrilic Chloride Trimer
-        PhosphonitrilicChlorideTrimer = Material.Builder(8064, GTLiteMod.id("phosphonitrilic_chloride_trimer"))
-            .liquid()
-            .color(0x082C38)
-            .components(Chlorine, 6, Nitrogen, 3, Phosphorus, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhosphonitrilicChlorideTrimer = addMaterial(8064, "phosphonitrilic_chloride_trimer")
+        {
+            liquid()
+            color(0x082C38)
+            components(Chlorine, 6, Nitrogen, 3, Phosphorus, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8065 Fluorobenzene
-        Fluorobenzene = Material.Builder(8065, GTLiteMod.id("fluorobenzene"))
-            .liquid()
-            .color(0x7CCA88)
-            .components(Carbon, 6, Hydrogen, 5, Fluorine, 1)
-            .build()
+        Fluorobenzene = addMaterial(8065, "fluorobenzene")
+        {
+            liquid()
+            color(0x7CCA88)
+            components(Carbon, 6, Hydrogen, 5, Fluorine, 1)
+        }
 
         // 8066 Octafluoro Pentanol
-        OctafluoroPentanol = Material.Builder(8066, GTLiteMod.id("octafluoro_pentanol"))
-            .liquid()
-            .color(0xE5EBDE)
-            .components(Carbon, 5, Hydrogen, 4, Fluorine, 8, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        OctafluoroPentanol = addMaterial(8066, "octafluoro_pentanol")
+        {
+            liquid()
+            color(0xE5EBDE)
+            components(Carbon, 5, Hydrogen, 4, Fluorine, 8, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8067 Raw Polyphosphonitrile Fluoro Rubber
-        RawPolyphosphonitrileFluoroRubber = Material.Builder(8067, GTLiteMod.id("raw_polyphosphonitrile_fluoro_rubber"))
-            .dust()
-            .color(0x585858)
-            .components(Carbon, 24, Hydrogen, 16, Oxygen, 8, Nitrogen, 4, Phosphorus, 4, Fluorine, 40)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH2CF3)6(CH2C3F7)2(C2F4)2(NPO)4O4", true)
+        RawPolyphosphonitrileFluoroRubber = addMaterial(8067, "raw_polyphosphonitrile_fluoro_rubber")
+        {
+            dust()
+            color(0x585858)
+            components(Carbon, 24, Hydrogen, 16, Oxygen, 8, Nitrogen, 4, Phosphorus, 4, Fluorine, 40)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8068 Polyphosphonitrile Fluoro Rubber
-        PolyphosphonitrileFluoroRubber = Material.Builder(8068, GTLiteMod.id("polyphosphonitrile_fluoro_rubber"))
-            .polymer()
-            .liquid()
-            .color(0x372B28)
-            .components(Carbon, 24, Hydrogen, 16, Oxygen, 8, Nitrogen, 4, Phosphorus, 4, Fluorine, 40)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_ROD, GENERATE_RING, GENERATE_FOIL)
-            .build()
-            .setFormula("(CH2CF3)6(CH2C3F7)2(C2F4)2(NPO)4O4", true)
+        PolyphosphonitrileFluoroRubber = addMaterial(8068, "polyphosphonitrile_fluoro_rubber")
+        {
+            polymer()
+            liquid()
+            color(0x372B28)
+            components(Carbon, 24, Hydrogen, 16, Oxygen, 8, Nitrogen, 4, Phosphorus, 4, Fluorine, 40)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_ROD, GENERATE_RING, GENERATE_FOIL)
+        }
 
         // 8069 Polytetrahydrofuran
-        Polytetrahydrofuran = Material.Builder(8069, GTLiteMod.id("polytetrahydrofuran"))
-            .liquid()
-            .color(0x089B3E)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C4H8O)OH2", true)
+        Polytetrahydrofuran = addMaterial(8069, "polytetrahydrofuran")
+        {
+            liquid()
+            color(0x089B3E)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8070 Dinitrotoluene
-        Dinitrotoluene = Material.Builder(8070, GTLiteMod.id("dinitrotoluene"))
-            .liquid()
-            .color(0xEAEFC9)
-            .components(Carbon, 7, Hydrogen, 6, Nitrogen, 2, Oxygen, 4)
-            .build()
+        Dinitrotoluene = addMaterial(8070, "dinitrotoluene")
+        {
+            liquid()
+            color(0xEAEFC9)
+            components(Carbon, 7, Hydrogen, 6, Nitrogen, 2, Oxygen, 4)
+        }
 
         // 8071 Diaminotoluene
-        Diaminotoluene = Material.Builder(8071, GTLiteMod.id("diaminotoluene"))
-            .liquid()
-            .color(0xEA8204)
-            .components(Carbon, 7, Hydrogen, 7, Nitrogen, 2)
-            .build()
-            .setFormula("C6H3(NH2)2CH3", true)
+        Diaminotoluene = addMaterial(8071, "diaminotoluene")
+        {
+            liquid()
+            color(0xEA8204)
+            components(Carbon, 7, Hydrogen, 7, Nitrogen, 2)
+        }
 
         // 8072 Phosgene
-        Phosgene = Material.Builder(8072, GTLiteMod.id("phosgene"))
-            .gas()
-            .color(0x48927C)
-            .components(Carbon, 1, Oxygen, 1, Chlorine, 2)
-            .build()
+        Phosgene = addMaterial(8072, "phosgene")
+        {
+            gas()
+            color(0x48927C)
+            components(Carbon, 1, Oxygen, 1, Chlorine, 2)
+        }
 
         // 8073 Toluene Diisocyanate
-        TolueneDiisocyanate = Material.Builder(8073, GTLiteMod.id("toluene_diisocyanate"))
-            .liquid()
-            .color(0xCCCC66)
-            .components(Carbon, 9, Hydrogen, 8, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("CH3C6H3(NCO)2", true)
+        TolueneDiisocyanate = addMaterial(8073, "toluene_diisocyanate")
+        {
+            liquid()
+            color(0xCCCC66)
+            components(Carbon, 9, Hydrogen, 8, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8074 Toluene Tetramethyl Diisocyanate
-        TolueneTetramethylDiisocyanate = Material.Builder(8074, GTLiteMod.id("toluene_tetramethyl_diisocyanate"))
-            .liquid()
-            .color(0xBFBFBF)
-            .components(Carbon, 19, Hydrogen, 12, Oxygen, 3, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CONH)2(C6H4)2CH2(C4O)", true)
+        TolueneTetramethylDiisocyanate = addMaterial(8074, "toluene_tetramethyl_diisocyanate")
+        {
+            liquid()
+            color(0xBFBFBF)
+            components(Carbon, 19, Hydrogen, 12, Oxygen, 3, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8075 Raw Polytetramethylene Glycol Rubber
-        RawPolytetramethyleneGlycolRubber = Material.Builder(8075, GTLiteMod.id("raw_polytetramethylene_glycol_rubber"))
-            .dust()
-            .color(0xFFFFFF).iconSet(ROUGH)
-            .components(Carbon, 23, Hydrogen, 23, Oxygen, 5, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CONH)2(C6H4)2CH2(C4O)HO(CH2)4OH", true)
+        RawPolytetramethyleneGlycolRubber = addMaterial(8075, "raw_polytetramethylene_glycol_rubber")
+        {
+            dust()
+            color(0xFFFFFF).iconSet(ROUGH)
+            components(Carbon, 23, Hydrogen, 23, Oxygen, 5, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8076 Polytetramethylene Glycol Rubber
-        PolytetramethyleneGlycolRubber = Material.Builder(8076, GTLiteMod.id("polytetramethylene_glycol_rubber"))
-            .polymer()
-            .liquid()
-            .color(0xFFFFFF)
-            .components(Carbon, 23, Hydrogen, 23, Oxygen, 5, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_ROD, GENERATE_RING, GENERATE_FOIL)
-            .build()
-            .setFormula("(CONH)2(C6H4)2CH2(C4O)HO(CH2)4OH", true)
+        PolytetramethyleneGlycolRubber = addMaterial(8076, "polytetramethylene_glycol_rubber")
+        {
+            polymer()
+            liquid()
+            color(0xFFFFFF)
+            components(Carbon, 23, Hydrogen, 23, Oxygen, 5, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_ROD, GENERATE_RING, GENERATE_FOIL)
+        }
 
         // 8077 Dense Hydrazine Rocket Fuel
-        DenseHydrazineRocketFuel = Material.Builder(8077, GTLiteMod.id("dense_hydrazine_rocket_fuel"))
-            .liquid()
-            .color(0x912565)
-            .components(Dimethylhydrazine, 1, Methanol, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DenseHydrazineRocketFuel = addMaterial(8077, "dense_hydrazine_rocket_fuel")
+        {
+            liquid()
+            color(0x912565)
+            components(Dimethylhydrazine, 1, Methanol, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8078 Methylhydrazine
-        Methylhydrazine = Material.Builder(8078, GTLiteMod.id("methylhydrazine"))
-            .liquid()
-            .color(0x321452)
-            .components(Carbon, 1, Hydrogen, 6, Nitrogen, 2)
-            .build()
+        Methylhydrazine = addMaterial(8078, "methylhydrazine")
+        {
+            liquid()
+            color(0x321452)
+            components(Carbon, 1, Hydrogen, 6, Nitrogen, 2)
+        }
 
         // 8079 Methylhydrazine Nitrate Rocket Fuel
-        MethylhydrazineNitrateRocketFuel = Material.Builder(8079, GTLiteMod.id("methylhydrazine_nitrate_rocket_fuel"))
-            .liquid()
-            .color(0x607186)
-            .components(Methylhydrazine, 1, Tetranitromethane, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        MethylhydrazineNitrateRocketFuel = addMaterial(8079, "methylhydrazine_nitrate_rocket_fuel")
+        {
+            liquid()
+            color(0x607186)
+            components(Methylhydrazine, 1, Tetranitromethane, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8080 Resorcinol
-        Resorcinol = Material.Builder(8080, GTLiteMod.id("resorcinol"))
-            .liquid()
-            .color(0x9DA38D)
-            .components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
-            .build()
+        Resorcinol = addMaterial(8080, "resorcinol")
+        {
+            liquid()
+            color(0x9DA38D)
+            components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8081 Fluorotoluene
-        Fluorotoluene = Material.Builder(8081, GTLiteMod.id("fluorotoluene"))
-            .liquid()
-            .color(0x6EC5B8)
-            .components(Carbon, 7, Hydrogen, 7, Fluorine, 1)
-            .build()
+        Fluorotoluene = addMaterial(8081, "fluorotoluene")
+        {
+            liquid()
+            color(0x6EC5B8)
+            components(Carbon, 7, Hydrogen, 7, Fluorine, 1)
+        }
 
         // 8082 Difluorobenzophenone
-        Difluorobenzophenone = Material.Builder(8082, GTLiteMod.id("difluorobenzophenone"))
-            .dust()
-            .color(0xC44DA5).iconSet(SHINY)
-            .components(Carbon, 13, Hydrogen, 8, Oxygen, 1, Fluorine, 2)
-            .build()
-            .setFormula("(FC6H4)2CO", true)
+        Difluorobenzophenone = addMaterial(8082, "difluorobenzophenone")
+        {
+            dust()
+            color(0xC44DA5).iconSet(SHINY)
+            components(Carbon, 13, Hydrogen, 8, Oxygen, 1, Fluorine, 2)
+        }
 
         // 8083 Hydroquinone
-        Hydroquinone = Material.Builder(8083, GTLiteMod.id("hydroquinone"))
-            .liquid()
-            .color(0x83251A)
-            .components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
-            .build()
-            .setFormula("C6H4(OH)2", true)
+        Hydroquinone = addMaterial(8083, "hydroquinone")
+        {
+            liquid()
+            color(0x83251A)
+            components(Carbon, 6, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8084 Polyetheretherketone (PEEK)
-        Polyetheretherketone = Material.Builder(8084, GTLiteMod.id("polyetheretherketone"))
-            .polymer()
-            .liquid()
-            .color(0x45433D)
-            .components(Carbon, 20, Hydrogen, 12, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        Polyetheretherketone = addMaterial(8084, "polyetheretherketone")
+        {
+            polymer()
+            liquid()
+            color(0x45433D)
+            components(Carbon, 20, Hydrogen, 12, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8085 Fluorescein
-        Fluorescein = Material.Builder(8085, GTLiteMod.id("fluorescein"))
-            .dust()
-            .color(0xE0E660).iconSet(SHINY)
-            .components(Carbon, 20, Hydrogen, 12, Oxygen, 5)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Fluorescein = addMaterial(8085, "fluorescein")
+        {
+            dust()
+            color(0xE0E660).iconSet(SHINY)
+            components(Carbon, 20, Hydrogen, 12, Oxygen, 5)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8086 Erythrosine
-        Erythrosine = Material.Builder(8086, GTLiteMod.id("erythrosine"))
-            .dust()
-            .color(0xC63611).iconSet(DULL)
-            .components(Carbon, 20, Hydrogen, 6, Oxygen, 5, Sodium, 2, Iodine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Erythrosine = addMaterial(8086, "erythrosine")
+        {
+            dust()
+            color(0xC63611).iconSet(DULL)
+            components(Carbon, 20, Hydrogen, 6, Oxygen, 5, Sodium, 2, Iodine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8087 Isochloropropane
-        Isochloropropane = Material.Builder(8087, GTLiteMod.id("isochloropropane"))
-            .liquid()
-            .color(0xC3AC65)
-            .components(Carbon, 3, Hydrogen, 7, Chlorine, 1)
-            .build()
-            .setFormula("CH3CHClCH3", true)
+        Isochloropropane = addMaterial(8087, "isochloropropane")
+        {
+            liquid()
+            color(0xC3AC65)
+            components(Carbon, 3, Hydrogen, 7, Chlorine, 1)
+        }
 
         // 8088 Acetic Anhydride
-        AceticAnhydride = Material.Builder(8088, GTLiteMod.id("acetic_anhydride"))
-            .liquid()
-            .color(0xE2EBD9)
-            .components(Carbon, 4, Hydrogen, 6, Oxygen, 3)
-            .build()
+        AceticAnhydride = addMaterial(8088, "acetic_anhydride")
+        {
+            liquid()
+            color(0xE2EBD9)
+            components(Carbon, 4, Hydrogen, 6, Oxygen, 3)
+        }
 
         // 8089 Dinitrodipropanyloxybenzene
-        Dinitrodipropanyloxybenzene = Material.Builder(8089, GTLiteMod.id("dinitrodipropanyloxybenzene"))
-            .liquid()
-            .color(0x9FAD1D)
-            .components(Carbon, 12, Hydrogen, 16, Oxygen, 6, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C12H16O2(NO2)2", true)
+        Dinitrodipropanyloxybenzene = addMaterial(8089, "dinitrodipropanyloxybenzene")
+        {
+            liquid()
+            color(0x9FAD1D)
+            components(Carbon, 12, Hydrogen, 16, Oxygen, 6, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8090 Dibromomethylbenzene
-        Dibromomethylbenzene = Material.Builder(8090, GTLiteMod.id("dibromomethylbenzene"))
-            .liquid()
-            .color(0x9F4839)
-            .components(Carbon, 7, Hydrogen, 6, Bromine, 2)
-            .build()
+        Dibromomethylbenzene = addMaterial(8090, "dibromomethylbenzene")
+        {
+            liquid()
+            color(0x9F4839)
+            components(Carbon, 7, Hydrogen, 6, Bromine, 2)
+        }
 
         // 8091 Terephthalaldehyde
-        Terephthalaldehyde = Material.Builder(8091, GTLiteMod.id("terephthalaldehyde"))
-            .dust()
-            .color(0x567C2D).iconSet(ROUGH)
-            .components(Carbon, 8, Hydrogen, 6, Oxygen, 2)
-            .build()
+        Terephthalaldehyde = addMaterial(8091, "terephthalaldehyde")
+        {
+            dust()
+            color(0x567C2D).iconSet(ROUGH)
+            components(Carbon, 8, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8092 Pretreated Zylon
-        PretreatedZylon = Material.Builder(8092, GTLiteMod.id("pretreated_zylon"))
-            .dust()
-            .color(0x623250).iconSet(DULL)
-            .components(Carbon, 20, Hydrogen, 22, Nitrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PretreatedZylon = addMaterial(8092, "pretreated_zylon")
+        {
+            dust()
+            color(0x623250).iconSet(DULL)
+            components(Carbon, 20, Hydrogen, 22, Nitrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8093 Zylon
-        Zylon = Material.Builder(8093, GTLiteMod.id("zylon"))
-            .polymer()
-            .liquid()
-            .color(0xFFE000).iconSet(SHINY)
-            .components(Carbon, 14, Hydrogen, 6, Nitrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        Zylon = addMaterial(8093, "zylon")
+        {
+            polymer()
+            liquid()
+            color(0xFFE000).iconSet(SHINY)
+            components(Carbon, 14, Hydrogen, 6, Nitrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8094 Diborane
-        Diborane = Material.Builder(8094, GTLiteMod.id("diborane"))
-            .gas()
-            .color(0x3F3131)
-            .components(Boron, 2, Hydrogen, 6)
-            .build()
+        Diborane = addMaterial(8094, "diborane")
+        {
+            gas()
+            color(0x3F3131)
+            components(Boron, 2, Hydrogen, 6)
+        }
 
         // 8095 Borazine
-        Borazine = Material.Builder(8095, GTLiteMod.id("borazine"))
-            .liquid()
-            .color(0x542828)
-            .components(Boron, 3, Hydrogen, 6, Nitrogen, 3)
-            .build()
+        Borazine = addMaterial(8095, "borazine")
+        {
+            liquid()
+            color(0x542828)
+            components(Boron, 3, Hydrogen, 6, Nitrogen, 3)
+        }
 
         // 8096 Trichloroborazine
-        Trichloroborazine = Material.Builder(8096, GTLiteMod.id("trichloroborazine"))
-            .liquid()
-            .color(0xD62929)
-            .components(Boron, 3, Chlorine, 3, Hydrogen, 3, Nitrogen, 3)
-            .build()
+        Trichloroborazine = addMaterial(8096, "trichloroborazine")
+        {
+            liquid()
+            color(0xD62929)
+            components(Boron, 3, Chlorine, 3, Hydrogen, 3, Nitrogen, 3)
+        }
 
         // 8097 γ-Butyrolactone
-        GammaButyrolactone = Material.Builder(8097, GTLiteMod.id("gamma_butyrolactone"))
-            .liquid()
-            .color(0xAF04D6)
-            .components(Carbon, 4, Hydrogen, 6, Oxygen, 2)
-            .build()
+        GammaButyrolactone = addMaterial(8097, "gamma_butyrolactone")
+        {
+            liquid()
+            color(0xAF04D6)
+            components(Carbon, 4, Hydrogen, 6, Oxygen, 2)
+        }
 
         // 8098 N-Methyl-2-Pyrrolidone
-        NMethylPyrrolidone = Material.Builder(8098, GTLiteMod.id("n_methyl_pyrrolidone"))
-            .liquid()
-            .color(0xA504D6)
-            .components(Carbon, 5, Hydrogen, 9, Nitrogen, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NMethylPyrrolidone = addMaterial(8098, "n_methyl_pyrrolidone")
+        {
+            liquid()
+            color(0xA504D6)
+            components(Carbon, 5, Hydrogen, 9, Nitrogen, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8099 Acetylene
-        Acetylene = Material.Builder(8099, GTLiteMod.id("acetylene"))
-            .liquid()
-            .color(0x959C60)
-            .components(Carbon, 2, Hydrogen, 2)
-            .build()
+        Acetylene = addMaterial(8099, "acetylene")
+        {
+            liquid()
+            color(0x959C60)
+            components(Carbon, 2, Hydrogen, 2)
+        }
 
         // 8100 Tetrabromoethane
-        Tetrabromoethane = Material.Builder(8100, GTLiteMod.id("tetrabromoethane"))
-            .liquid()
-            .color(0x5AAADA)
-            .components(Carbon, 2, Hydrogen, 2, Bromine, 4)
-            .build()
+        Tetrabromoethane = addMaterial(8100, "tetrabromoethane")
+        {
+            liquid()
+            color(0x5AAADA)
+            components(Carbon, 2, Hydrogen, 2, Bromine, 4)
+        }
 
         // 8101 Terephthalic Acid
-        TerephthalicAcid = Material.Builder(8101, GTLiteMod.id("terephthalic_acid"))
-            .dust()
-            .color(0x5ACCDA).iconSet(ROUGH)
-            .components(Carbon, 8, Hydrogen, 6, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H4(CO2H)2", true)
+        TerephthalicAcid = addMaterial(8101, "terephthalic_acid")
+        {
+            dust()
+            color(0x5ACCDA).iconSet(ROUGH)
+            components(Carbon, 8, Hydrogen, 6, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8102 Bistrichloromethylbenzene
-        Bistrichloromethylbenzene = Material.Builder(8102, GTLiteMod.id("bistrichloromethylbenzene"))
-            .liquid()
-            .color(0xCF8498)
-            .components(Carbon, 8, Hydrogen, 4, Chlorine, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H4(CCl3)2", true)
+        Bistrichloromethylbenzene = addMaterial(8102, "bistrichloromethylbenzene")
+        {
+            liquid()
+            color(0xCF8498)
+            components(Carbon, 8, Hydrogen, 4, Chlorine, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8103 Terephthaloyl Chloride
-        TerephthaloylChloride = Material.Builder(8103, GTLiteMod.id("terephthaloyl_chloride"))
-            .dust()
-            .color(0xFAC4DA).iconSet(SHINY)
-            .components(Carbon, 8, Hydrogen, 4, Oxygen, 2, Chlorine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H4(COCl)2", true)
+        TerephthaloylChloride = addMaterial(8103, "terephthaloyl_chloride")
+        {
+            dust()
+            color(0xFAC4DA).iconSet(SHINY)
+            components(Carbon, 8, Hydrogen, 4, Oxygen, 2, Chlorine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8104 Kevlar
-        Kevlar = Material.Builder(8104, GTLiteMod.id("kevlar"))
-            .polymer()
-            .liquid()
-            .color(0xF0F078)
-            .components(Carbon, 14, Hydrogen, 10, Nitrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .fluidPipeProperties(2000, 700, true)
-            .build()
-            .setFormula("(C6H4)2(CO)2(NH)2", true)
+        Kevlar = addMaterial(8104, "kevlar")
+        {
+            polymer()
+            liquid()
+            color(0xF0F078)
+            components(Carbon, 14, Hydrogen, 10, Nitrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+            fluidPipeProp(2000, 700, true)
+        }
 
         // 8105 Para Toluic Acid
-        ParaToluicAcid = Material.Builder(8105, GTLiteMod.id("para_toluic_acid"))
-            .liquid(FluidBuilder().attribute(FluidAttributes.ACID))
-            .color(0x4FA597)
-            .components(Carbon, 8, Hydrogen, 8, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ParaToluicAcid = addMaterial(8105, "para_toluic_acid")
+        {
+            liquid()
+            {
+                attribute(FluidAttributes.ACID)
+            }
+            color(0x4FA597)
+            components(Carbon, 8, Hydrogen, 8, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8106 Methylparatoluate
-        Methylparatoluate = Material.Builder(8106, GTLiteMod.id("methylparatoluate"))
-            .liquid()
-            .color(0x76BCB0)
-            .components(Carbon, 9, Hydrogen, 10, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Methylparatoluate = addMaterial(8106, "methylparatoluate")
+        {
+            liquid()
+            color(0x76BCB0)
+            components(Carbon, 9, Hydrogen, 10, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8107 Dimethyl Terephthalate
-        DimethylTerephthalate = Material.Builder(8107, GTLiteMod.id("dimethyl_terephthalate"))
-            .liquid()
-            .color(0x05D8AF)
-            .components(Carbon, 10, Hydrogen, 10, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DimethylTerephthalate = addMaterial(8107, "dimethyl_terephthalate")
+        {
+            liquid()
+            color(0x05D8AF)
+            components(Carbon, 10, Hydrogen, 10, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8108 Polyethylene Terephthalate (PET)
-        PolyethyleneTerephthalate = Material.Builder(8108, GTLiteMod.id("polyethylene_terephthalate"))
-            .polymer()
-            .liquid()
-            .color(0x1E5C58)
-            .components(Carbon, 10, Hydrogen, 6, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        PolyethyleneTerephthalate = addMaterial(8108, "polyethylene_terephthalate")
+        {
+            polymer()
+            liquid()
+            color(0x1E5C58)
+            components(Carbon, 10, Hydrogen, 6, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8109 Trimethylaluminium
-        Trimethylaluminium = Material.Builder(8109, GTLiteMod.id("trimethylaluminium"))
-            .liquid()
-            .color(0x6ECCFF)
-            .components(Aluminium, 2, Carbon, 6, Hydrogen, 18)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Al2(CH3)6", true)
+        Trimethylaluminium = addMaterial(8109, "trimethylaluminium")
+        {
+            liquid()
+            color(0x6ECCFF)
+            components(Aluminium, 2, Carbon, 6, Hydrogen, 18)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8110 Trimethylgallium
-        Trimethylgallium = Material.Builder(8110, GTLiteMod.id("trimethylgallium"))
-            .liquid()
-            .color(0x4F92FF)
-            .components(Gallium, 1, Carbon, 3, Hydrogen, 9)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("Ga(CH3)3", true)
+        Trimethylgallium = addMaterial(8110, "trimethylgallium")
+        {
+            liquid()
+            color(0x4F92FF)
+            components(Gallium, 1, Carbon, 3, Hydrogen, 9)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8111 Ammonium Cyanate
-        AmmoniumCyanate = Material.Builder(8111, GTLiteMod.id("ammonium_cyanate"))
-            .liquid()
-            .color(0x3a5dcf)
-            .components(Hydrogen, 4, Nitrogen, 2, Carbon, 1, Oxygen, 1)
-            .build()
-            .setFormula("NH4CNO", true)
+        AmmoniumCyanate = addMaterial(8111, "ammonium_cyanate")
+        {
+            liquid()
+            color(0x3a5dcf)
+            components(Hydrogen, 4, Nitrogen, 2, Carbon, 1, Oxygen, 1)
+        }
 
         // 8112 Carbamide
-        Carbamide = Material.Builder(8112, GTLiteMod.id("carbamide"))
-            .dust()
-            .color(0x16EF57).iconSet(ROUGH)
-            .components(Carbon, 1, Hydrogen, 4, Nitrogen, 2, Oxygen, 1)
-            .build()
+        Carbamide = addMaterial(8112, "carbamide")
+        {
+            dust()
+            color(0x16EF57).iconSet(ROUGH)
+            components(Carbon, 1, Hydrogen, 4, Nitrogen, 2, Oxygen, 1)
+        }
 
         // 8113 Butanol
-        Butanol = Material.Builder(8113, GTLiteMod.id("butanol"))
-            .liquid()
-            .color(0xC7AF2E)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
-            .build()
-            .setFormula("C4H9OH", true)
+        Butanol = addMaterial(8113, "butanol")
+        {
+            liquid()
+            color(0xC7AF2E)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
+        }
 
         // 8114 Tributylamine
-        Tributylamine = Material.Builder(8114, GTLiteMod.id("tributylamine"))
-            .liquid()
-            .color(0x801A80)
-            .components(Carbon, 12, Hydrogen, 27, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C4H9)3N", true)
+        Tributylamine = addMaterial(8114, "tributylamine")
+        {
+            liquid()
+            color(0x801A80)
+            components(Carbon, 12, Hydrogen, 27, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8115 Dichloromethane
-        Dichloromethane = Material.Builder(8115, GTLiteMod.id("dichloromethane"))
-            .liquid()
-            .color(0xB87FC7)
-            .components(Carbon, 1, Hydrogen, 2, Chlorine, 2)
-            .build()
+        Dichloromethane = addMaterial(8115, "dichloromethane")
+        {
+            liquid()
+            color(0xB87FC7)
+            components(Carbon, 1, Hydrogen, 2, Chlorine, 2)
+        }
 
         // 8116 Diethyl Ether
-        DiethylEther = Material.Builder(8116, GTLiteMod.id("diethyl_ether"))
-            .liquid()
-            .color(0xFFA4A3)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C2H5)2O", true)
+        DiethylEther = addMaterial(8116, "diethyl_ether")
+        {
+            liquid()
+            color(0xFFA4A3)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8117 2-Aminooxyacetic Acid
-        AminooxyaceticAcid = Material.Builder(8117, GTLiteMod.id("aminooxyacetic_acid"))
-            .liquid()
-            .color(0xECFF1E)
-            .components(Carbon, 2, Hydrogen, 5, Nitrogen, 1, Oxygen, 3)
-            .build()
+        AminooxyaceticAcid = addMaterial(8117, "aminooxyacetic_acid")
+        {
+            liquid()
+            color(0xECFF1E)
+            components(Carbon, 2, Hydrogen, 5, Nitrogen, 1, Oxygen, 3)
+        }
 
         // 8118 BenzylBromide
-        BenzylBromide = Material.Builder(8118, GTLiteMod.id("benzyl_bromide"))
-            .gas()
-            .color(0xCF9D8C)
-            .components(Carbon, 7, Hydrogen, 7, Bromine, 1)
-            .build()
-            .setFormula("C6H5CH2Br", true)
+        BenzylBromide = addMaterial(8118, "benzyl_bromide")
+        {
+            gas()
+            color(0xCF9D8C)
+            components(Carbon, 7, Hydrogen, 7, Bromine, 1)
+        }
 
         // 8119 Benzyltrimethylammonium Bromide
-        BenzyltrimethylammoniumBromide = Material.Builder(8119, GTLiteMod.id("benzyltrimethylammonium_bromide"))
-            .dust()
-            .colorAverage().iconSet(SHINY)
-            .components(BenzylBromide, 1, Trimethylamine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H5CH2N(CH3)3Br", true)
+        BenzyltrimethylammoniumBromide = addMaterial(8119, "benzyltrimethylammonium_bromide")
+        {
+            dust()
+            colorAverage().iconSet(SHINY)
+            components(BenzylBromide, 1, Trimethylamine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8120 2-Chlorobutane
-        Chlorobutane = Material.Builder(8120, GTLiteMod.id("chlorobutane"))
-            .liquid()
-            .color(0xE6772D)
-            .components(Carbon, 4, Hydrogen, 9, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Chlorobutane = addMaterial(8120, "chlorobutane")
+        {
+            liquid()
+            color(0xE6772D)
+            components(Carbon, 4, Hydrogen, 9, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8121 Tertbutyl Alcohol
-        TertbutylAlcohol = Material.Builder(8121, GTLiteMod.id("tertbutyl_alcohol"))
-            .liquid()
-            .color(0xBC8F44)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        TertbutylAlcohol = addMaterial(8121, "tertbutyl_alcohol")
+        {
+            liquid()
+            color(0xBC8F44)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8122 Indene
-        Indene = Material.Builder(8122, GTLiteMod.id("indene"))
-            .liquid()
-            .color(0x171429)
-            .components(Carbon, 9, Hydrogen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H4C3H4", true)
+        Indene = addMaterial(8122, "indene")
+        {
+            liquid()
+            color(0x171429)
+            components(Carbon, 9, Hydrogen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8123 Indanone
-        Indanone = Material.Builder(8123, GTLiteMod.id("indanone"))
-            .dust()
-            .color(0x2E1616).iconSet(SHINY)
-            .components(Carbon, 9, Hydrogen, 8, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H4C3H4O", true)
+        Indanone = addMaterial(8123, "indanone")
+        {
+            dust()
+            color(0x2E1616).iconSet(SHINY)
+            components(Carbon, 9, Hydrogen, 8, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8124 Truxene
-        Truxene = Material.Builder(8124, GTLiteMod.id("truxene"))
-            .liquid()
-            .color(0x1A3336)
-            .components(Carbon, 27, Hydrogen, 18)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Truxene = addMaterial(8124, "truxene")
+        {
+            liquid()
+            color(0x1A3336)
+            components(Carbon, 27, Hydrogen, 18)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8125 Bromomethane
-        Bromomethane = Material.Builder(8125, GTLiteMod.id("bromomethane"))
-            .gas()
-            .color(0xC82C31)
-            .components(Carbon, 1, Hydrogen, 3, Bromine, 1)
-            .build()
+        Bromomethane = addMaterial(8125, "bromomethane")
+        {
+            gas()
+            color(0xC82C31)
+            components(Carbon, 1, Hydrogen, 3, Bromine, 1)
+        }
 
         // 8126 1-Bromo-2-(Bromomethyl) Naphthalene
-        BromoBromomethylNaphthalene = Material.Builder(8126, GTLiteMod.id("bromo_bromomethyl_naphthalene"))
-            .liquid()
-            .color(0x52122E)
-            .components(Carbon, 11, Hydrogen, 8, Bromine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BromoBromomethylNaphthalene = addMaterial(8126, "bromo_bromomethyl_naphthalene")
+        {
+            liquid()
+            color(0x52122E)
+            components(Carbon, 11, Hydrogen, 8, Bromine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8127 1-Bromobutane
-        Bromobutane = Material.Builder(8127, GTLiteMod.id("bromobutane"))
-            .gas()
-            .color(0xE6E8A2)
-            .components(Butene, 1, HydrobromicAcid, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C4H9Br", true)
+        Bromobutane = addMaterial(8127, "bromobutane")
+        {
+            gas()
+            color(0xE6E8A2)
+            components(Butene, 1, HydrobromicAcid, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8128 Butyllithium
-        Butyllithium = Material.Builder(8128, GTLiteMod.id("butyllithium"))
-            .liquid()
-            .color(0xE683B6B)
-            .components(Butene, 1, Hydrogen, 1, Lithium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C4H9Li", true)
+        Butyllithium = addMaterial(8128, "butyllithium")
+        {
+            liquid()
+            color(0xE683B6B)
+            components(Butene, 1, Hydrogen, 1, Lithium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8129 Acetyl Chloride
-        AcetylChloride = Material.Builder(8129, GTLiteMod.id("acetyl_chloride"))
-            .liquid()
-            .color(0xC3C3C3)
-            .components(Carbon, 2, Hydrogen, 3, Oxygen, 1, Chlorine, 1)
-            .build()
-            .setFormula("CH3COCl", true)
+        AcetylChloride = addMaterial(8129, "acetyl_chloride")
+        {
+            liquid()
+            color(0xC3C3C3)
+            components(Carbon, 2, Hydrogen, 3, Oxygen, 1, Chlorine, 1)
+        }
 
         // 8130 Dimethylacetamide
-        Dimethylacetamide = Material.Builder(8130, GTLiteMod.id("dimethylacetamide"))
-            .liquid()
-            .color(0x18AEA5)
-            .components(Carbon, 4, Hydrogen, 9, Nitrogen, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)2NC(O)CH3", true)
+        Dimethylacetamide = addMaterial(8130, "dimethylacetamide")
+        {
+            liquid()
+            color(0x18AEA5)
+            components(Carbon, 4, Hydrogen, 9, Nitrogen, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8131 GeodesicPolyarene
-        GeodesicPolyarene = Material.Builder(8131, GTLiteMod.id("geodesic_polyarene"))
-            .dust()
-            .color(0x9E81A8).iconSet(METALLIC)
-            .components(Carbon, 60, Hydrogen, 30)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        GeodesicPolyarene = addMaterial(8131, "geodesic_polyarene")
+        {
+            dust()
+            color(0x9E81A8).iconSet(METALLIC)
+            components(Carbon, 60, Hydrogen, 30)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8132 Fullerene
-        Fullerene = Material.Builder(8132, GTLiteMod.id("fullerene"))
-            .polymer()
-            .liquid()
-            .color(0x72556A).iconSet(BRIGHT)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMELTING, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .components(Carbon, 60)
-            .build()
+        Fullerene = addMaterial(8132, "fullerene")
+        {
+            polymer()
+            liquid()
+            color(0x72556A).iconSet(BRIGHT)
+            components(Carbon, 60)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMELTING, GENERATE_FOIL, GENERATE_FINE_WIRE)
+        }
 
         // 8133 Glucose
-        Glucose = Material.Builder(8133, GTLiteMod.id("glucose"))
-            .dust()
-            .color(Sugar.materialRGB + 5).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Glucose = addMaterial(8133, "glucose")
+        {
+            dust()
+            color(Sugar.materialRGB + 5).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8134 Fructose
-        Fructose = Material.Builder(8134, GTLiteMod.id("fructose"))
-            .dust()
-            .color(Sugar.materialRGB + 10).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Fructose = addMaterial(8134, "fructose")
+        {
+            dust()
+            color(Sugar.materialRGB + 10).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8135 Oxalic Acid
-        OxalicAcid = Material.Builder(8135, GTLiteMod.id("oxalic_acid"))
-            .liquid()
-            .color(0x4AAAE2)
-            .components(Carbon, 2, Hydrogen, 2, Oxygen, 4)
-            .build() // (HOOC)(COOH)
+        OxalicAcid = addMaterial(8135, "oxalic_acid")
+        {
+            liquid()
+            color(0x4AAAE2)
+            components(Carbon, 2, Hydrogen, 2, Oxygen, 4)
+        }
 
         // 8136 Dibromoacrolein
-        Dibromoacrolein = Material.Builder(8136, GTLiteMod.id("dibromoacrolein"))
-            .liquid()
-            .color(0x7C4660)
-            .components(Carbon, 2, Hydrogen, 2, Bromine, 2, Oxygen, 2)
-            .build()
+        Dibromoacrolein = addMaterial(8136, "dibromoacrolein")
+        {
+            liquid()
+            color(0x7C4660)
+            components(Carbon, 2, Hydrogen, 2, Bromine, 2, Oxygen, 2)
+        }
 
         // 8137 Bromodihydrothiine
-        Bromodihydrothiine = Material.Builder(8137, GTLiteMod.id("bromodihydrothiine"))
-            .liquid()
-            .color(0x66F36E)
-            .components(Carbon, 4, Hydrogen, 4, Sulfur, 2, Bromine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Bromodihydrothiine = addMaterial(8137, "bromodihydrothiine")
+        {
+            liquid()
+            color(0x66F36E)
+            components(Carbon, 4, Hydrogen, 4, Sulfur, 2, Bromine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8138 Bis-(Ethylenedithio)-Tetraselenafulvalene (BETS)
-        BETS = Material.Builder(8138, GTLiteMod.id("bisethylenedithiotetraselenafulvalene"))
-            .dust()
-            .color(0x98E993).iconSet(ROUGH)
-            .flags(DISABLE_DECOMPOSITION)
-            .components(Carbon, 10, Hydrogen, 8, Sulfur, 4, Selenium, 4)
-            .build()
+        BETS = addMaterial(8138, "bisethylenedithiotetraselenafulvalene")
+        {
+            dust()
+            color(0x98E993).iconSet(ROUGH)
+            flags(DISABLE_DECOMPOSITION)
+            components(Carbon, 10, Hydrogen, 8, Sulfur, 4, Selenium, 4)
+        }
 
         // 8139 Benzaldehyde
-        Benzaldehyde = Material.Builder(8139, GTLiteMod.id("benzaldehyde"))
-            .liquid()
-            .color(0x957D53)
-            .components(Carbon, 7, Hydrogen, 6, Oxygen, 1)
-            .build()
+        Benzaldehyde = addMaterial(8139, "benzaldehyde")
+        {
+            liquid()
+            color(0x957D53)
+            components(Carbon, 7, Hydrogen, 6, Oxygen, 1)
+        }
 
         // 8140 SuccinicAnhydride
-        SuccinicAnhydride = Material.Builder(8140, GTLiteMod.id("succinic_anhydride"))
-            .dust()
-            .color(0xA2569D)
-            .components(Carbon, 4, Hydrogen, 4, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH2CO)2O", true)
+        SuccinicAnhydride = addMaterial(8140, "succinic_anhydride")
+        {
+            dust()
+            color(0xA2569D)
+            components(Carbon, 4, Hydrogen, 4, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8141 N-Hydroxysuccinimide
-        NHydroxysuccinimide = Material.Builder(8141, GTLiteMod.id("n_hydroxysuccinimide"))
-            .dust()
-            .color(0x33BAFB).iconSet(METALLIC)
-            .components(Carbon, 4, Hydrogen, 5, Nitrogen, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH2CO)2NOH", true)
+        NHydroxysuccinimide = addMaterial(8141, "n_hydroxysuccinimide")
+        {
+            dust()
+            color(0x33BAFB).iconSet(METALLIC)
+            components(Carbon, 4, Hydrogen, 5, Nitrogen, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8142 Succinimidyl Acetate
-        SuccinimidylAcetate = Material.Builder(8142, GTLiteMod.id("succinimidyl_acetate"))
-            .dust()
-            .color(0x1D3605).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 7, Nitrogen, 1, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuccinimidylAcetate = addMaterial(8142, "succinimidyl_acetate")
+        {
+            dust()
+            color(0x1D3605).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 7, Nitrogen, 1, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8143 Dimethylamine Hydrochloride
-        DimethylamineHydrochloride = Material.Builder(8143, GTLiteMod.id("dimethylamine_hydrochloride"))
-            .liquid()
-            .color(0xE3EBDC)
-            .components(Dimethylamine, 1, HydrochloricAcid, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C2H8NCl", true)
+        DimethylamineHydrochloride = addMaterial(8143, "dimethylamine_hydrochloride")
+        {
+            liquid()
+            color(0xE3EBDC)
+            components(Dimethylamine, 1, HydrochloricAcid, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8144 Dimethylformamide (DMF)
-        Dimethylformamide = Material.Builder(8144, GTLiteMod.id("dimethylformamide"))
-            .liquid()
-            .color(0x42BDFF)
-            .components(Carbon, 3, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)2NC(O)H", true)
+        Dimethylformamide = addMaterial(8144, "dimethylformamide")
+        {
+            liquid()
+            color(0x42BDFF)
+            components(Carbon, 3, Hydrogen, 7, Nitrogen, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8145 Succinimide
-        Succinimide = Material.Builder(8145, GTLiteMod.id("succinimide"))
-            .dust()
-            .color(0x1774B6).iconSet(ROUGH)
-            .components(Carbon, 4, Hydrogen, 5, Nitrogen, 1, Oxygen, 2)
-            .build()
+        Succinimide = addMaterial(8145, "succinimide")
+        {
+            dust()
+            color(0x1774B6).iconSet(ROUGH)
+            components(Carbon, 4, Hydrogen, 5, Nitrogen, 1, Oxygen, 2)
+        }
 
         // 8146 Acetonitrile
-        Acetonitrile = Material.Builder(8146, GTLiteMod.id("acetonitrile"))
-            .liquid()
-            .color(0x7D82A3)
-            .components(Carbon, 2, Hydrogen, 3, Nitrogen, 1)
-            .build()
-            .setFormula("CH3CN", true)
+        Acetonitrile = addMaterial(8146, "acetonitrile")
+        {
+            liquid()
+            color(0x7D82A3)
+            components(Carbon, 2, Hydrogen, 3, Nitrogen, 1)
+        }
 
         // 8147 Acetamide
-        Acetamide = Material.Builder(8147, GTLiteMod.id("acetamide"))
-            .dust()
-            .color(0x7D82A3)
-            .components(Carbon, 2, Hydrogen, 5, Nitrogen, 1, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("CH3CONH2", true)
+        Acetamide = addMaterial(8147, "acetamide")
+        {
+            dust()
+            color(0x7D82A3)
+            components(Carbon, 2, Hydrogen, 5, Nitrogen, 1, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8148 Acetaldehyde
-        Acetaldehyde = Material.Builder(8148, GTLiteMod.id("acetaldehyde"))
-            .liquid()
-            .color(0xF3F2F1)
-            .components(Carbon, 2, Hydrogen, 4, Oxygen, 1)
-            .build()
+        Acetaldehyde = addMaterial(8148, "acetaldehyde")
+        {
+            liquid()
+            color(0xF3F2F1)
+            components(Carbon, 2, Hydrogen, 4, Oxygen, 1)
+        }
 
         // 8149 Glyoxal
-        Glyoxal = Material.Builder(8149, GTLiteMod.id("glyoxal"))
-            .liquid()
-            .color(0xC9C7AB)
-            .components(Carbon, 2, Hydrogen, 2, Oxygen, 2)
-            .build()
+        Glyoxal = addMaterial(8149, "glyoxal")
+        {
+            liquid()
+            color(0xC9C7AB)
+            components(Carbon, 2, Hydrogen, 2, Oxygen, 2)
+        }
 
         // 8150 Benzylamine
-        Benzylamine = Material.Builder(8150, GTLiteMod.id("benzylamine"))
-            .liquid()
-            .color(0x527A92)
-            .components(Carbon, 7, Hydrogen, 9, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Benzylamine = addMaterial(8150, "benzylamine")
+        {
+            liquid()
+            color(0x527A92)
+            components(Carbon, 7, Hydrogen, 9, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8151 Benzyl Chloride
-        BenzylChloride = Material.Builder(8151, GTLiteMod.id("benzyl_chloride"))
-            .gas()
-            .color(0x6699CC)
-            .components(Carbon, 7, Hydrogen, 7, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        BenzylChloride = addMaterial(8151, "benzyl_chloride")
+        {
+            gas()
+            color(0x6699CC)
+            components(Carbon, 7, Hydrogen, 7, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8152 Hexabenzylhexaazaisowurtzitane (HBHIW)
-        Hexabenzylhexaazaisowurtzitane = Material.Builder(8152, GTLiteMod.id("hexabenzylhexaazaisowurtzitane"))
-            .dust()
-            .color(0x48561E)
-            .components(Carbon, 48, Hydrogen, 48 ,Nitrogen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Hexabenzylhexaazaisowurtzitane = addMaterial(8152, "hexabenzylhexaazaisowurtzitane")
+        {
+            dust()
+            color(0x48561E)
+            components(Carbon, 48, Hydrogen, 48 ,Nitrogen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8153 Dibenzyltetraacetylhexaazaisowurtzitane (DBTAHIW)
-        Dibenzyltetraacetylhexaazaisowurtzitane = Material.Builder(8153, GTLiteMod.id("dibenzyltetraacetylhexaazaisowurtzitane"))
-            .dust()
-            .color(0xB7E8EE)
-            .components(Carbon, 28, Hydrogen, 32, Nitrogen, 6, Oxygen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Dibenzyltetraacetylhexaazaisowurtzitane = addMaterial(8153, "dibenzyltetraacetylhexaazaisowurtzitane")
+        {
+            dust()
+            color(0xB7E8EE)
+            components(Carbon, 28, Hydrogen, 32, Nitrogen, 6, Oxygen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8154 Tetraacetyldinitrosohexaazaisowurtzitane (TADNHIW)
-        Tetraacetyldinitrosohexaazaisowurtzitane = Material.Builder(8154, GTLiteMod.id("tetraacetyldinitrosohexaazaisowurtzitane"))
-            .dust()
-            .color(0xEA7584).iconSet(ROUGH)
-            .components(Carbon, 14, Hydrogen, 18, Nitrogen, 8, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Tetraacetyldinitrosohexaazaisowurtzitane = addMaterial(8154, "tetraacetyldinitrosohexaazaisowurtzitane")
+        {
+            dust()
+            color(0xEA7584).iconSet(ROUGH)
+            components(Carbon, 14, Hydrogen, 18, Nitrogen, 8, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8155 Crude Hexanitrohexaaxaisowurtzitane
-        CrudeHexanitrohexaaxaisowurtzitane = Material.Builder(8155, GTLiteMod.id("crude_hexanitrohexaaxaisowurtzitane"))
-            .dust()
-            .color(0x5799EC)
-            .components(Carbon, 6, Hydrogen, 6, Nitrogen, 12, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        CrudeHexanitrohexaaxaisowurtzitane = addMaterial(8155, "crude_hexanitrohexaaxaisowurtzitane")
+        {
+            dust()
+            color(0x5799EC)
+            components(Carbon, 6, Hydrogen, 6, Nitrogen, 12, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8156 Hexanitrohexaaxaisowurtzitane (HNIW)
-        Hexanitrohexaaxaisowurtzitane = Material.Builder(8156, GTLiteMod.id("hexanitrohexaaxaisowurtzitane"))
-            .dust()
-            .color(0x0B7222).iconSet(BRIGHT)
-            .components(Carbon, 6, Hydrogen, 6, Nitrogen, 12, Oxygen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Hexanitrohexaaxaisowurtzitane = addMaterial(8156, "hexanitrohexaaxaisowurtzitane")
+        {
+            dust()
+            color(0x0B7222).iconSet(BRIGHT)
+            components(Carbon, 6, Hydrogen, 6, Nitrogen, 12, Oxygen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8157 Hexamethylenetetramine
-        Hexamethylenetetramine = Material.Builder(8157, GTLiteMod.id("hexamethylenetetramine"))
-            .dust()
-            .color(0x53576D)
-            .components(Carbon, 6, Hydrogen, 12, Nitrogen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH2)6N4", true)
+        Hexamethylenetetramine = addMaterial(8157, "hexamethylenetetramine")
+        {
+            dust()
+            color(0x53576D)
+            components(Carbon, 6, Hydrogen, 12, Nitrogen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8158 Cyclotetramethylene Tetranitroamine (HMX)
-        CyclotetramethyleneTetranitroamine = Material.Builder(8158, GTLiteMod.id("cyclotetramethylene_tetranitroamine"))
-            .liquid()
-            .color(0xD0A57B).iconSet(SHINY)
-            .components(Carbon, 4, Hydrogen, 8, Nitrogen, 8, Oxygen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        CyclotetramethyleneTetranitroamine = addMaterial(8158, "cyclotetramethylene_tetranitroamine")
+        {
+            liquid()
+            color(0xD0A57B).iconSet(SHINY)
+            components(Carbon, 4, Hydrogen, 8, Nitrogen, 8, Oxygen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8159 Octaazacubane
-        Octaazacubane = Material.Builder(8159, GTLiteMod.id("octaazacubane"))
-            .dust()
-            .color(Nitrogen.materialRGB).iconSet(SHINY)
-            .components(Nitrogen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Octaazacubane = addMaterial(8159, "octaazacubane")
+        {
+            dust()
+            color(Nitrogen.materialRGB).iconSet(SHINY)
+            components(Nitrogen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8160 Dibenzylideneacetone
-        Dibenzylideneacetone = Material.Builder(8160, GTLiteMod.id("dibenzylideneacetone"))
-            .liquid()
-            .color(0xCC6699)
-            .components(Carbon, 17, Hydrogen, 14, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Dibenzylideneacetone = addMaterial(8160, "dibenzylideneacetone")
+        {
+            liquid()
+            color(0xCC6699)
+            components(Carbon, 17, Hydrogen, 14, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8161 Pyridine
-        Pyridine = Material.Builder(8161, GTLiteMod.id("pyridine"))
-            .liquid()
-            .colorAverage(Ammonia, Formaldehyde)
-            .components(Carbon, 5, Nitrogen, 5, Nitrogen, 1)
-            .build()
+        Pyridine = addMaterial(8161, "pyridine")
+        {
+            liquid()
+            colorAverage(Ammonia, Formaldehyde)
+            components(Carbon, 5, Nitrogen, 5, Nitrogen, 1)
+        }
 
         // 8162 Bipyridine
-        Bipyridine = Material.Builder(8162, GTLiteMod.id("bipyridine"))
-            .dust()
-            .color(0x978662)
-            .components(Carbon, 10, Hydrogen, 8, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Bipyridine = addMaterial(8162, "bipyridine")
+        {
+            dust()
+            color(0x978662)
+            components(Carbon, 10, Hydrogen, 8, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8163 Cyclooctadiene
-        Cyclooctadiene = Material.Builder(8163, GTLiteMod.id("cyclooctadiene"))
-            .liquid()
-            .color(0x40AC40)
-            .components(Carbon, 8, Hydrogen, 12)
-            .build()
+        Cyclooctadiene = addMaterial(8163, "cyclooctadiene")
+        {
+            liquid()
+            color(0x40AC40)
+            components(Carbon, 8, Hydrogen, 12)
+        }
 
         // 8164 Dichlorocyclooctadieneplatinium
-        Dichlorocyclooctadieneplatinium = Material.Builder(8164, GTLiteMod.id("dichlorocyclooctadieneplatinium"))
-            .dust()
-            .color(0xD4E982).iconSet(BRIGHT)
-            .components(Carbon, 8, Hydrogen, 12, Chlorine, 2, Platinum, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Dichlorocyclooctadieneplatinium = addMaterial(8164, "dichlorocyclooctadieneplatinium")
+        {
+            dust()
+            color(0xD4E982).iconSet(BRIGHT)
+            components(Carbon, 8, Hydrogen, 12, Chlorine, 2, Platinum, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8165 Diiodobiphenyl
-        Diiodobiphenyl = Material.Builder(8165, GTLiteMod.id("diiodobiphenyl"))
-            .dust()
-            .color(0x000C52).iconSet(METALLIC)
-            .components(Carbon, 12, Hydrogen, 8, Iodine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Diiodobiphenyl = addMaterial(8165, "diiodobiphenyl")
+        {
+            dust()
+            color(0x000C52).iconSet(METALLIC)
+            components(Carbon, 12, Hydrogen, 8, Iodine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8166 Trimethyltin Chloride
-        TrimethyltinChloride = Material.Builder(8166, GTLiteMod.id("trimethyltin_chloride"))
-            .liquid()
-            .color(0x7F776F)
-            .components(Carbon, 3, Hydrogen, 6, Tin, 1, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)3SnCl", true)
+        TrimethyltinChloride = addMaterial(8166, "trimethyltin_chloride")
+        {
+            liquid()
+            color(0x7F776F)
+            components(Carbon, 3, Hydrogen, 6, Tin, 1, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8167 Cycloparaphenylene (CPP)
-        Cycloparaphenylene = Material.Builder(8167, GTLiteMod.id("cycloparaphenylene"))
-            .liquid()
-            .color(0x60545A)
-            .components(Carbon, 6, Hydrogen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Cycloparaphenylene = addMaterial(8167, "cycloparaphenylene")
+        {
+            liquid()
+            color(0x60545A)
+            components(Carbon, 6, Hydrogen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8168 Octene
-        Octene = Material.Builder(8168, GTLiteMod.id("octene"))
-            .liquid()
-            .color(0x7E8778)
-            .components(Carbon, 8, Hydrogen, 16)
-            .build()
+        Octene = addMaterial(8168, "octene")
+        {
+            liquid()
+            color(0x7E8778)
+            components(Carbon, 8, Hydrogen, 16)
+        }
 
-        // 8169 Carbon Nanotube
-        CarbonNanotube = Material.Builder(8169, GTLiteMod.id("carbon_nanotube"))
-            .ingot()
-            .liquid()
-            .color(0x05090C).iconSet(BRIGHT)
-            .components(Carbon, 48)
-            .flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_SMELTING, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                GENERATE_LONG_ROD, GENERATE_SPRING, GENERATE_SPRING_SMALL)
-            .cableProperties(V[UIV], 8, 6)
-            .build()
+        // 8169 Carbon Nanotube (CNT)
+        CarbonNanotube = addMaterial(8169, "carbon_nanotube")
+        {
+            ingot()
+            liquid()
+            color(0x05090C).iconSet(BRIGHT)
+            components(Carbon, 48)
+            flags(EXT_METAL, DISABLE_DECOMPOSITION, NO_SMELTING, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_LONG_ROD,
+                  GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            cableProp(V[UIV], 8, 6)
+        }
 
         // 8170 Sarcosine
-        Sarcosine = Material.Builder(8170, GTLiteMod.id("sarcosine"))
-            .dust()
-            .color(0x339933).iconSet(SHINY)
-            .components(Carbon, 3, Hydrogen, 7, Nitrogen, 1, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Sarcosine = addMaterial(8170, "sarcosine")
+        {
+            dust()
+            color(0x339933).iconSet(SHINY)
+            components(Carbon, 3, Hydrogen, 7, Nitrogen, 1, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8171 Ferrocene
-        Ferrocene = Material.Builder(8171, GTLiteMod.id("ferrocene"))
-            .liquid()
-            .color(0x6569A6)
-            .components(Carbon, 10, Hydrogen, 10, Iron, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Ferrocene = addMaterial(8171, "ferrocene")
+        {
+            liquid()
+            color(0x6569A6)
+            components(Carbon, 10, Hydrogen, 10, Iron, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8172 Ferrocenylfulleropyrddolidine
-        Ferrocenylfulleropyrddolidine = Material.Builder(8172, GTLiteMod.id("ferrocenylfulleropyrddolidine"))
-            .liquid()
-            .color(0x1D894A)
-            .components(Carbon, 74, Hydrogen, 19, Nitrogen, 1, Iron, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Ferrocenylfulleropyrddolidine = addMaterial(8172, "ferrocenylfulleropyrddolidine")
+        {
+            liquid()
+            color(0x1D894A)
+            components(Carbon, 74, Hydrogen, 19, Nitrogen, 1, Iron, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8173 Dimethylaminopyridine
-        Dimethylaminopyridine = Material.Builder(8173, GTLiteMod.id("dimethylaminopyridine"))
-            .dust()
-            .color(0x679887).iconSet(ROUGH)
-            .components(Carbon, 7, Hydrogen, 10, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)2NC5H4N", true)
+        Dimethylaminopyridine = addMaterial(8173, "dimethylaminopyridine")
+        {
+            dust()
+            color(0x679887).iconSet(ROUGH)
+            components(Carbon, 7, Hydrogen, 10, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8174 Triphenylphosphine (TPP)
-        Triphenylphosphine = Material.Builder(8174, GTLiteMod.id("triphenylphosphine"))
-            .dust()
-            .color(0xE8DE3A).iconSet(ROUGH)
-            .components(Carbon, 18, Hydrogen, 15, Phosphorus, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C6H5)3P", true)
+        Triphenylphosphine = addMaterial(8174, "triphenylphosphine")
+        {
+            dust()
+            color(0xE8DE3A).iconSet(ROUGH)
+            components(Carbon, 18, Hydrogen, 15, Phosphorus, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8175 Isopropyl Alcohol
-        IsopropylAlcohol = Material.Builder(8175, GTLiteMod.id("isopropyl_alcohol"))
-            .liquid()
-            .color(0x1EAC4C)
-            .components(Carbon, 3, Hydrogen, 8, Oxygen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        IsopropylAlcohol = addMaterial(8175, "isopropyl_alcohol")
+        {
+            liquid()
+            color(0x1EAC4C)
+            components(Carbon, 3, Hydrogen, 8, Oxygen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8176 Diisopropylcarbodiimide
-        Diisopropylcarbodiimide = Material.Builder(8176, GTLiteMod.id("diisopropylcarbodiimide"))
-            .liquid()
-            .color(0xA0CFFE)
-            .components(Carbon, 7, Hydrogen, 14, Nitrogen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Diisopropylcarbodiimide = addMaterial(8176, "diisopropylcarbodiimide")
+        {
+            liquid()
+            color(0xA0CFFE)
+            components(Carbon, 7, Hydrogen, 14, Nitrogen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8177 Phenylpentanoic Acid
-        PhenylpentanoicAcid = Material.Builder(8177, GTLiteMod.id("phenylpentanoic_acid"))
-            .liquid(FluidBuilder().attributes(FluidAttributes.ACID))
-            .color(0x1B5154)
-            .components(Carbon, 11, Hydrogen, 14, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhenylpentanoicAcid = addMaterial(8177, "phenylpentanoic_acid")
+        {
+            liquid()
+            {
+                attributes(FluidAttributes.ACID)
+            }
+            color(0x1B5154)
+            components(Carbon, 11, Hydrogen, 14, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8178 Dimethyl Sulfide
-        DimethylSulfide = Material.Builder(8178, GTLiteMod.id("dimethyl_sulfide"))
-            .liquid()
-            .color(0x781111)
-            .components(Carbon, 2, Hydrogen, 6, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)2S", true)
+        DimethylSulfide = addMaterial(8178, "dimethyl_sulfide")
+        {
+            liquid()
+            color(0x781111)
+            components(Carbon, 2, Hydrogen, 6, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8179 Phenyl-C61-Butyric Acid (PCBA)
-        PhenylC61ButyricAcid = Material.Builder(8179, GTLiteMod.id("phenyl_c_61_butyric_acid"))
-            .liquid()
-            .color(0xCAC1F4)
-            .components(Carbon, 72, Hydrogen, 14, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhenylC61ButyricAcid = addMaterial(8179, "phenyl_c_61_butyric_acid")
+        {
+            liquid()
+            color(0xCAC1F4)
+            components(Carbon, 72, Hydrogen, 14, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8180 Phenyl-C61-Butyric Styrene (PCBS)
-        PhenylC61ButyricStyrene = Material.Builder(8180, GTLiteMod.id("phenyl_c_61_butyric_styrene"))
-            .liquid()
-            .color(0x11B557)
-            .components(Carbon, 80, Hydrogen, 21, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhenylC61ButyricStyrene = addMaterial(8180, "phenyl_c_61_butyric_styrene")
+        {
+            liquid()
+            color(0x11B557)
+            components(Carbon, 80, Hydrogen, 21, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8181 Fullerene Polymer Matrix (FPM)
-        FullerenePolymerMatrix = Material.Builder(8181, GTLiteMod.id("fullerene_polymer_matrix"))
-            .polymer()
-            .liquid(FluidBuilder().temperature(500))
-            .color(0x2F0B01).iconSet(SHINY)
-            .components(Carbon, 153, Hydrogen, 36, Nitrogen, 1, Oxygen, 2, Lead, 1, Iron, 1)
-            .flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .build()
-            .setFormula("(C153H36NO2)PdFe", true)
+        FullerenePolymerMatrix = addMaterial(8181, "fullerene_polymer_matrix")
+        {
+            polymer()
+            liquid()
+            {
+                temperature(500)
+            }
+            color(0x2F0B01).iconSet(SHINY)
+            components(Carbon, 153, Hydrogen, 36, Nitrogen, 1, Oxygen, 2, Lead, 1, Iron, 1)
+            flags(DISABLE_DECOMPOSITION, NO_SMASHING, NO_SMELTING, GENERATE_PLATE, GENERATE_FOIL, GENERATE_FINE_WIRE)
+        }
 
         // 8182 Phosphorene
-        Phosphorene = Material.Builder(8182, GTLiteMod.id("phosphorene"))
-            .polymer()
-            .liquid()
-            .color(0x273239).iconSet(SHINY)
-            .components(Phosphorus, 4)
-            .flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
-            .build()
+        Phosphorene = addMaterial(8182, "phosphorene")
+        {
+            polymer()
+            liquid()
+            color(0x273239).iconSet(SHINY)
+            components(Phosphorus, 4)
+            flags(DISABLE_DECOMPOSITION, GENERATE_PLATE, GENERATE_FOIL)
+        }
 
         // 8183 Methyltrichlorosilane
-        Methyltrichlorosilane = Material.Builder(8183, GTLiteMod.id("methyltrichlorosilane"))
-            .liquid()
-            .color(0x4D7CB4)
-            .components(Carbon, 1, Hydrogen, 3, Chlorine, 3, Silicon, 1)
-            .build()
-            .setFormula("Si(CH3)Cl3", true)
+        Methyltrichlorosilane = addMaterial(8183, "methyltrichlorosilane")
+        {
+            liquid()
+            color(0x4D7CB4)
+            components(Carbon, 1, Hydrogen, 3, Chlorine, 3, Silicon, 1)
+        }
 
         // 8184 Diethyl Sulfide
-        DiethylSulfide = Material.Builder(8184, GTLiteMod.id("diethyl_sulfide"))
-            .liquid()
-            .color(0xFF7E4B)
-            .components(Ethylene, 2, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C2H5)2S", true)
+        DiethylSulfide = addMaterial(8184, "diethyl_sulfide")
+        {
+            liquid()
+            color(0xFF7E4B)
+            components(Ethylene, 2, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8185 Guaiacol
-        Guaiacol = Material.Builder(8185, GTLiteMod.id("guaiacol"))
-            .liquid()
-            .color(0xA63A00)
-            .components(Carbon, 7, Hydrogen, 8, Oxygen, 2)
-            .build()
+        Guaiacol = addMaterial(8185, "guaiacol")
+        {
+            liquid()
+            color(0xA63A00)
+            components(Carbon, 7, Hydrogen, 8, Oxygen, 2)
+        }
 
         // 8186 Xylenol
-        Xylenol = Material.Builder(8186, GTLiteMod.id("xylenol"))
-            .liquid()
-            .color(0xCF7D10)
-            .components(Carbon, 8, Hydrogen, 10, Oxygen, 1)
-            .build()
+        Xylenol = addMaterial(8186, "xylenol")
+        {
+            liquid()
+            color(0xCF7D10)
+            components(Carbon, 8, Hydrogen, 10, Oxygen, 1)
+        }
 
         // 8187 Creosol
-        Creosol = Material.Builder(8187, GTLiteMod.id("creosol"))
-            .liquid()
-            .color(0x704E46)
-            .components(Carbon, 7, Hydrogen, 8, Oxygen, 1)
-            .build()
+        Creosol = addMaterial(8187, "creosol")
+        {
+            liquid()
+            color(0x704E46)
+            components(Carbon, 7, Hydrogen, 8, Oxygen, 1)
+        }
 
         // 8188 Methoxycreosol
-        Methoxycreosol = Material.Builder(8188, GTLiteMod.id("methoxycreosol"))
-            .liquid()
-            .color(0xAF4617)
-            .components(Carbon, 8, Hydrogen, 10, Oxygen, 2)
-            .build()
+        Methoxycreosol = addMaterial(8188, "methoxycreosol")
+        {
+            liquid()
+            color(0xAF4617)
+            components(Carbon, 8, Hydrogen, 10, Oxygen, 2)
+        }
 
         // 8189 Phenothiazine
-        Phenothiazine = Material.Builder(8189, GTLiteMod.id("phenothiazine"))
-            .dust()
-            .color(0x67735C).iconSet(FINE)
-            .components(Carbon, 12, Hydrogen, 9, Nitrogen, 1, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C12H9NS", true)
+        Phenothiazine = addMaterial(8189, "phenothiazine")
+        {
+            dust()
+            color(0x67735C).iconSet(FINE)
+            components(Carbon, 12, Hydrogen, 9, Nitrogen, 1, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8190 Isopropyl Chloride
-        IsopropylChloride = Material.Builder(8190, GTLiteMod.id("isopropyl_chloride"))
-            .liquid()
-            .color(0x17B868)
-            .components(Carbon, 3, Hydrogen, 7, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(CH3)2CHCl", true)
+        IsopropylChloride = addMaterial(8190, "isopropyl_chloride")
+        {
+            liquid()
+            color(0x17B868)
+            components(Carbon, 3, Hydrogen, 7, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8191 10-Phenothiazine-2-Propyl Chloride
-        PhenothiazinePropylChloride = Material.Builder(8191, GTLiteMod.id("phenothiazine_propyl_chloride"))
-            .liquid()
-            .color(0x444E1D)
-            .components(Carbon, 15, Hydrogen, 14, Nitrogen, 1, Sulfur, 1, Chlorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        PhenothiazinePropylChloride = addMaterial(8191, "phenothiazine_propyl_chloride")
+        {
+            liquid()
+            color(0x444E1D)
+            components(Carbon, 15, Hydrogen, 14, Nitrogen, 1, Sulfur, 1, Chlorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8192 Promethazine
-        Promethazine = Material.Builder(8192, GTLiteMod.id("promethazine"))
-            .dust()
-            .color(0x92E829).iconSet(SHINY)
-            .components(Carbon, 17, Hydrogen, 20, Nitrogen, 2, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Promethazine = addMaterial(8192, "promethazine")
+        {
+            dust()
+            color(0x92E829).iconSet(SHINY)
+            components(Carbon, 17, Hydrogen, 20, Nitrogen, 2, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8193 Codeine
-        Codeine = Material.Builder(8193, GTLiteMod.id("codeine"))
-            .dust()
-            .color(0xFADEF2)
-            .components(Carbon, 18, Hydrogen, 21, Nitrogen, 1, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Codeine = addMaterial(8193, "codeine")
+        {
+            dust()
+            color(0xFADEF2)
+            components(Carbon, 18, Hydrogen, 21, Nitrogen, 1, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8194 Ammonium Fluoride
-        AmmoniumFluoride = Material.Builder(8194, GTLiteMod.id("ammonium_fluoride"))
-            .dust()
-            .colorAverage(Ammonia, Fluorine)
-            .components(Nitrogen, 1, Hydrogen, 4, Fluorine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        AmmoniumFluoride = addMaterial(8194, "ammonium_fluoride")
+        {
+            dust()
+            colorAverage(Ammonia, Fluorine)
+            components(Nitrogen, 1, Hydrogen, 4, Fluorine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8195 Ammonium Bifluoride
-        AmmoniumBifluoride = Material.Builder(8195, GTLiteMod.id("ammonium_bifluoride"))
-            .dust()
-            .color(0x055370).iconSet(FINE)
-            .components(Nitrogen, 1, Hydrogen, 5, Fluorine, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("NH4HF2", true)
+        AmmoniumBifluoride = addMaterial(8195, "ammonium_bifluoride")
+        {
+            dust()
+            color(0x055370).iconSet(FINE)
+            components(Nitrogen, 1, Hydrogen, 5, Fluorine, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8196 N-Difluorophenylpyrrole
-        NDifluorophenylpyrrole = Material.Builder(8196, GTLiteMod.id("n_difluorophenylpyrrole"))
-            .liquid()
-            .color(0x6D837E)
-            .components(Carbon, 10, Hydrogen, 7, Fluorine, 2, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NDifluorophenylpyrrole = addMaterial(8196, "n_difluorophenylpyrrole")
+        {
+            liquid()
+            color(0x6D837E)
+            components(Carbon, 10, Hydrogen, 7, Fluorine, 2, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8197 Tetraethylammonium Bromide
-        TetraethylammoniumBromide = Material.Builder(8197, GTLiteMod.id("tetraethylammonium_bromide"))
-            .liquid()
-            .color(0xCC3399)
-            .components(Carbon, 8, Hydrogen, 20, Nitrogen, 1, Bromine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("N(CH2CH3)4Br", true)
+        TetraethylammoniumBromide = addMaterial(8197, "tetraethylammonium_bromide")
+        {
+            liquid()
+            color(0xCC3399)
+            components(Carbon, 8, Hydrogen, 20, Nitrogen, 1, Bromine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8198 Phenylsodium
-        Phenylsodium = Material.Builder(8198, GTLiteMod.id("phenylsodium"))
-            .liquid()
-            .colorAverage()
-            .components(Benzene, 1, Sodium, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C6H5Na", true)
+        Phenylsodium = addMaterial(8198, "phenylsodium")
+        {
+            liquid()
+            colorAverage()
+            components(Benzene, 1, Sodium, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8199 Indigo
-        Indigo = Material.Builder(8199, GTLiteMod.id("indigo"))
-            .dust()
-            .color(0x0000FF).iconSet(DULL)
-            .components(Carbon, 16, Hydrogen, 10, Nitrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Indigo = addMaterial(8199, "indigo")
+        {
+            dust()
+            color(0x0000FF).iconSet(DULL)
+            components(Carbon, 16, Hydrogen, 10, Nitrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8200 Tetrabromoindigo
-        Tetrabromoindigo = Material.Builder(8200, GTLiteMod.id("tetrabromoindigo"))
-            .dust()
-            .colorAverage().iconSet(DULL)
-            .components(Indigo, 1, Bromine, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("C16H6Br4N2O2", true)
+        Tetrabromoindigo = addMaterial(8200, "tetrabromoindigo")
+        {
+            dust()
+            colorAverage().iconSet(DULL)
+            components(Indigo, 1, Bromine, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8201 Cyan Indigo
-        CyanIndigo = Material.Builder(8201, GTLiteMod.id("cyan_indigo"))
-            .dust()
-            .color(0x1661AB).iconSet(DULL)
-            .components(Indigo, 1, Tetrabromoindigo, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C16H10N2O2)2Br4", true)
+        CyanIndigo = addMaterial(8201, "cyan_indigo")
+        {
+            dust()
+            color(0x1661AB).iconSet(DULL)
+            components(Indigo, 1, Tetrabromoindigo, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8202 Nigrosin
-        Nigrosin = Material.Builder(8202, GTLiteMod.id("nigrosin"))
-            .dust()
-            .color(0x000000).iconSet(DULL)
-            .components(Carbon, 36, Hydrogen, 26, Nitrogen, 5, Chlorine, 1, Sodium, 2, Sulfur, 2, Oxygen, 6)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Nigrosin = addMaterial(8202, "nigrosin")
+        {
+            dust()
+            color(0x000000).iconSet(DULL)
+            components(Carbon, 36, Hydrogen, 26, Nitrogen, 5, Chlorine, 1, Sodium, 2, Sulfur, 2, Oxygen, 6)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8203 Sodium Sulfanilate
-        SodiumSulfanilate = Material.Builder(8203, GTLiteMod.id("sodium_sulfanilate"))
-            .dust()
-            .color(0xE49879).iconSet(SHINY)
-            .components(Carbon, 6, Hydrogen, 6, Nitrogen, 1, Sodium, 1, Oxygen, 3, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SodiumSulfanilate = addMaterial(8203, "sodium_sulfanilate")
+        {
+            dust()
+            color(0xE49879).iconSet(SHINY)
+            components(Carbon, 6, Hydrogen, 6, Nitrogen, 1, Sodium, 1, Oxygen, 3, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8204 Naphthylamine
-        Naphthylamine = Material.Builder(8204, GTLiteMod.id("naphthylamine"))
-            .liquid()
-            .color(0xE3E81C)
-            .components(Carbon, 10, Hydrogen, 9, Nitrogen, 1)
-            .build()
-            .setFormula("C10H8NH", true)
+        Naphthylamine = addMaterial(8204, "naphthylamine")
+        {
+            liquid()
+            color(0xE3E81C)
+            components(Carbon, 10, Hydrogen, 9, Nitrogen, 1)
+        }
 
         // 8205 Direct Brown 77
-        DirectBrown77 = Material.Builder(8205, GTLiteMod.id("direct_brown_77"))
-            .dust()
-            .color(0x663300).iconSet(DULL)
-            .components(Carbon, 26, Hydrogen, 19, Nitrogen, 6, Sodium, 1, Oxygen, 3, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DirectBrown77 = addMaterial(8205, "direct_brown_77")
+        {
+            dust()
+            color(0x663300).iconSet(DULL)
+            components(Carbon, 26, Hydrogen, 19, Nitrogen, 6, Sodium, 1, Oxygen, 3, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8206 Tetracene
-        Tetracene = Material.Builder(8206, GTLiteMod.id("tetracene"))
-            .dust()
-            .color(0x99801A).iconSet(SHINY)
-            .components(Carbon, 18, Hydrogen, 12)
-            .build()
+        Tetracene = addMaterial(8206, "tetracene")
+        {
+            dust()
+            color(0x99801A).iconSet(SHINY)
+            components(Carbon, 18, Hydrogen, 12)
+        }
 
         // 8207 Rhodamine B
-        RhodamineB = Material.Builder(8207, GTLiteMod.id("rhodamine_b"))
-            .dust()
-            .color(0xFC2020).iconSet(SHINY)
-            .components(Carbon, 28, Hydrogen, 31, Chlorine, 1, Nitrogen, 2, Oxygen, 3)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RhodamineB = addMaterial(8207, "rhodamine_b")
+        {
+            dust()
+            color(0xFC2020).iconSet(SHINY)
+            components(Carbon, 28, Hydrogen, 31, Chlorine, 1, Nitrogen, 2, Oxygen, 3)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8208 Cetane Trimethyl Ammonium Bromide
-        CetaneTrimethylAmmoniumBromide = Material.Builder(8208, GTLiteMod.id("cetane_trimethyl_ammonium_bromide"))
-            .liquid()
-            .color(0x949494)
-            .components(Carbon, 19, Hydrogen, 42, Bromine, 1, Nitrogen, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        CetaneTrimethylAmmoniumBromide = addMaterial(8208, "cetane_trimethyl_ammonium_bromide")
+        {
+            liquid()
+            color(0x949494)
+            components(Carbon, 19, Hydrogen, 42, Bromine, 1, Nitrogen, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8209 Sorbose
-        Sorbose = Material.Builder(8209, GTLiteMod.id("sorbose"))
-            .dust()
-            .color(0xFFFFFF).iconSet(METALLIC)
-            .components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
-            .build()
+        Sorbose = addMaterial(8209, "sorbose")
+        {
+            dust()
+            color(0xFFFFFF).iconSet(METALLIC)
+            components(Carbon, 6, Hydrogen, 12, Oxygen, 6)
+        }
 
         // 8210 Ascorbic Acid
-        AscorbicAcid = Material.Builder(8210, GTLiteMod.id("ascorbic_acid"))
-            .liquid()
-            .color(0xE6CD00)
-            .components(Carbon, 6, Hydrogen, 8, Oxygen, 6)
-            .build()
+        AscorbicAcid = addMaterial(8210, "ascorbic_acid")
+        {
+            liquid()
+            color(0xE6CD00)
+            components(Carbon, 6, Hydrogen, 8, Oxygen, 6)
+        }
 
         // 8211 Dehydroascorbic Acid
-        DehydroascorbicAcid = Material.Builder(8211, GTLiteMod.id("dehydroascorbic_acid"))
-            .liquid()
-            .color(AscorbicAcid.materialRGB - 10)
-            .components(Carbon, 6, Hydrogen, 6, Oxygen, 6)
-            .build()
+        DehydroascorbicAcid = addMaterial(8211, "dehydroascorbic_acid")
+        {
+            liquid()
+            color(AscorbicAcid.materialRGB - 10)
+            components(Carbon, 6, Hydrogen, 6, Oxygen, 6)
+        }
 
         // 8212 Cellulose
-        Cellulose = Material.Builder(8212, GTLiteMod.id("cellulose"))
-            .dust()
-            .color(0xE2EBD9).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 10, Oxygen, 5)
-            .build()
+        Cellulose = addMaterial(8212, "cellulose")
+        {
+            dust()
+            color(0xE2EBD9).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 10, Oxygen, 5)
+        }
 
         // 8213 Xylose
-        Xylose = Material.Builder(8213, GTLiteMod.id("xylose"))
-            .dust()
-            .color(0xDFDFDF).iconSet(ROUGH)
-            .components(Carbon, 5, Hydrogen, 10, Oxygen, 5)
-            .build()
+        Xylose = addMaterial(8213, "xylose")
+        {
+            dust()
+            color(0xDFDFDF).iconSet(ROUGH)
+            components(Carbon, 5, Hydrogen, 10, Oxygen, 5)
+        }
 
         // 8214 Saccharic Acid
-        SacchariaAcid = Material.Builder(8214, GTLiteMod.id("saccharic_acid"))
-            .dust()
-            .color(Sugar.materialRGB + 5).iconSet(METALLIC)
-            .components(Carbon, 6, Hydrogen, 10, Oxygen, 8)
-            .build()
+        SacchariaAcid = addMaterial(8214, "saccharic_acid")
+        {
+            dust()
+            color(Sugar.materialRGB + 5).iconSet(METALLIC)
+            components(Carbon, 6, Hydrogen, 10, Oxygen, 8)
+        }
 
         // 8215 Adipic Acid
-        AdipicAcid = Material.Builder(8215, GTLiteMod.id("adipic_acid"))
-            .dust()
-            .color(0xDA9288).iconSet(ROUGH)
-            .components(Carbon, 6, Hydrogen, 10, Oxygen, 4)
-            .build()
+        AdipicAcid = addMaterial(8215, "adipic_acid")
+        {
+            dust()
+            color(0xDA9288).iconSet(ROUGH)
+            components(Carbon, 6, Hydrogen, 10, Oxygen, 4)
+        }
 
         // 8216 Hexanediol
-        Hexanediol = Material.Builder(8216, GTLiteMod.id("hexanediol"))
-            .liquid()
-            .color(0x98D1EF)
-            .components(Carbon, 6, Hydrogen, 14, Oxygen, 2)
-            .build()
+        Hexanediol = addMaterial(8216, "hexanediol")
+        {
+            liquid()
+            color(0x98D1EF)
+            components(Carbon, 6, Hydrogen, 14, Oxygen, 2)
+        }
 
         // 8217 Hexamethylenediamine
-        Hexamethylenediamine = Material.Builder(8217, GTLiteMod.id("hexamethylenediamine"))
-            .liquid()
-            .color(0x45B387)
-            .components(Carbon, 6, Hydrogen, 16, Nitrogen, 2)
-            .build()
+        Hexamethylenediamine = addMaterial(8217, "hexamethylenediamine")
+        {
+            liquid()
+            color(0x45B387)
+            components(Carbon, 6, Hydrogen, 16, Nitrogen, 2)
+        }
 
         // 8218 Tertbutanol
-        Tertbutanol = Material.Builder(8218, GTLiteMod.id("tertbutanol"))
-            .liquid()
-            .color(0xCCCC2C)
-            .components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
-            .build()
+        Tertbutanol = addMaterial(8218, "tertbutanol")
+        {
+            liquid()
+            color(0xCCCC2C)
+            components(Carbon, 4, Hydrogen, 10, Oxygen, 1)
+        }
 
         // 8219 Ditertbutyl Dicarbonate
-        DitertbutylDicarbonate = Material.Builder(8219, GTLiteMod.id("ditertbutyl_dicarbonate"))
-            .dust()
-            .color(0xCCCCF6).iconSet(ROUGH)
-            .components(Carbon, 10, Hydrogen, 18, Oxygen, 5)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        DitertbutylDicarbonate = addMaterial(8219, "ditertbutyl_dicarbonate")
+        {
+            dust()
+            color(0xCCCCF6).iconSet(ROUGH)
+            components(Carbon, 10, Hydrogen, 18, Oxygen, 5)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8220 Tris(2-aminoethyl)amine
-        Trisaminoethylamine = Material.Builder(8220, GTLiteMod.id("trisaminoethylamine"))
-            .liquid()
-            .color(0x6F7D87)
-            .components(Nitrogen, 4, Hydrogen, 18, Carbon, 6)
-            .build()
-            .setFormula("(NH2CH2CH2)3N", true)
+        Trisaminoethylamine = addMaterial(8220, "trisaminoethylamine")
+        {
+            liquid()
+            color(0x6F7D87)
+            components(Nitrogen, 4, Hydrogen, 18, Carbon, 6)
+        }
 
         // 8221 Tertbutyl Azidoformate
-        TertbutylAzidoformate = Material.Builder(8221, GTLiteMod.id("tertbutyl_azidoformate"))
-            .liquid()
-            .color(0x888818)
-            .components(Carbon, 5, Hydrogen, 9, Nitrogen, 3, Oxygen, 2)
-            .build()
+        TertbutylAzidoformate = addMaterial(8221, "tertbutyl_azidoformate")
+        {
+            liquid()
+            color(0x888818)
+            components(Carbon, 5, Hydrogen, 9, Nitrogen, 3, Oxygen, 2)
+        }
 
         // 8222 Aminated Fullerene
-        AminatedFullerene = Material.Builder(8222, GTLiteMod.id("aminated_fullerene"))
-            .liquid()
-            .color(0x2C2CAA)
-            .components(Carbon, 60, Nitrogen, 12, Hydrogen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        AminatedFullerene = addMaterial(8222, "aminated_fullerene")
+        {
+            liquid()
+            color(0x2C2CAA)
+            components(Carbon, 60, Nitrogen, 12, Hydrogen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8223 Azafullerene
-        Azafullerene = Material.Builder(8223, GTLiteMod.id("azafullerene"))
-            .liquid()
-            .color(0x8A7A1A)
-            .components(Carbon, 60, Nitrogen, 12, Hydrogen, 12)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Azafullerene = addMaterial(8223, "azafullerene")
+        {
+            liquid()
+            color(0x8A7A1A)
+            components(Carbon, 60, Nitrogen, 12, Hydrogen, 12)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8224 Fulvic Acid
-        FulvicAcid = Material.Builder(8224, GTLiteMod.id("fulvic_acid"))
-            .liquid(FluidBuilder().temperature(312))
-            .color(0x59492F)
-            .components(Carbon, 14, Hydrogen, 12, Oxygen, 8)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        FulvicAcid = addMaterial(8224, "fulvic_acid")
+        {
+            liquid()
+            {
+                temperature(312)
+            }
+            color(0x59492F)
+            components(Carbon, 14, Hydrogen, 12, Oxygen, 8)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8225 Mauveine
-        Mauveine = Material.Builder(8225, GTLiteMod.id("mauveine"))
-            .dust()
-            .color(0x660066).iconSet(DULL)
-            .components(Carbon, 26, Hydrogen, 23, Nitrogen, 4)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Mauveine = addMaterial(8225, "mauveine")
+        {
+            dust()
+            color(0x660066).iconSet(DULL)
+            components(Carbon, 26, Hydrogen, 23, Nitrogen, 4)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8226 Diketopyrrolopyrrole
-        Diketopyrrolopyrrole = Material.Builder(8226, GTLiteMod.id("diketopyrrolopyrrole"))
-            .dust()
-            .color(0xFF6600).iconSet(DULL)
-            .components(Carbon, 18, Hydrogen, 12, Nitrogen, 2, Oxygen, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Diketopyrrolopyrrole = addMaterial(8226, "diketopyrrolopyrrole")
+        {
+            dust()
+            color(0xFF6600).iconSet(DULL)
+            components(Carbon, 18, Hydrogen, 12, Nitrogen, 2, Oxygen, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8227 Isopropyl Succinate
-        IsopropylSuccinate = Material.Builder(8227, GTLiteMod.id("isopropyl_succinate"))
-            .liquid()
-            .color(0xB26680)
-            .components(Carbon, 7, Hydrogen, 12, Oxygen, 4)
-            .build()
+        IsopropylSuccinate = addMaterial(8227, "isopropyl_succinate")
+        {
+            liquid()
+            color(0xB26680)
+            components(Carbon, 7, Hydrogen, 12, Oxygen, 4)
+        }
 
         // 8228 Eosin Y
-        EosinY = Material.Builder(8228, GTLiteMod.id("eosin_y"))
-            .dust()
-            .color(0xEAB4EB).iconSet(SHINY)
-            .components(Carbon, 20, Hydrogen, 6, Bromine, 4, Sodium, 2, Oxygen, 5)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        EosinY = addMaterial(8228, "eosin_y")
+        {
+            dust()
+            color(0xEAB4EB).iconSet(SHINY)
+            components(Carbon, 20, Hydrogen, 6, Bromine, 4, Sodium, 2, Oxygen, 5)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8229 Phenylenedioxydiacetic Acid
-        PhenylenedioxydiaceticAcid = Material.Builder(8229, GTLiteMod.id("phenylenedioxydiacetic_acid"))
-            .liquid()
-            .color(0xFFBBBA)
-            .components(Carbon, 10, Hydrogen, 10, Oxygen, 6)
-            .build()
+        PhenylenedioxydiaceticAcid = addMaterial(8229, "phenylenedioxydiacetic_acid")
+        {
+            liquid()
+            color(0xFFBBBA)
+            components(Carbon, 10, Hydrogen, 10, Oxygen, 6)
+        }
 
         // 8230 Ethylamine
-        Ethylamine = Material.Builder(8230, GTLiteMod.id("ethylamine"))
-            .liquid()
-            .color(0x9E9E9E)
-            .components(Carbon, 2, Hydrogen, 7, Nitrogen, 1)
-            .build()
-            .setFormula("C2H5NH2", true)
+        Ethylamine = addMaterial(8230, "ethylamine")
+        {
+            liquid()
+            color(0x9E9E9E)
+            components(Carbon, 2, Hydrogen, 7, Nitrogen, 1)
+        }
 
         // 8231 Diethylthiourea
-        Diethylthiourea = Material.Builder(8231, GTLiteMod.id("diethylthiourea"))
-            .liquid()
-            .color(0x8D8EC2)
-            .components(Carbon, 5, Hydrogen, 12, Nitrogen, 2, Sulfur, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("(C2H5NH)2CS", true);
+        Diethylthiourea = addMaterial(8231, "diethylthiourea")
+        {
+            liquid()
+            color(0x8D8EC2)
+            components(Carbon, 5, Hydrogen, 12, Nitrogen, 2, Sulfur, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 8232 Isophthaloylbisdiethylthiourea
-        Isophthaloylbisdiethylthiourea = Material.Builder(8232, GTLiteMod.id("isophthaloylbisdiethylthiourea"))
-            .liquid()
-            .color(0xA2D4E1)
-            .components(Carbon, 18, Hydrogen, 26, Nitrogen, 4, Oxygen, 2, Sulfur, 2)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        Isophthaloylbisdiethylthiourea = addMaterial(8232, "isophthaloylbisdiethylthiourea")
+        {
+            liquid()
+            color(0xA2D4E1)
+            components(Carbon, 18, Hydrogen, 26, Nitrogen, 4, Oxygen, 2, Sulfur, 2)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteSecondDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteSecondDegreeMaterials.kt
@@ -16,7 +16,6 @@ import gregtech.api.GTValues.V
 import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.ZPM
 import gregtech.api.fluids.FluidBuilder
-import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.Materials.Actinium
 import gregtech.api.unification.material.Materials.Aluminium
 import gregtech.api.unification.material.Materials.Americium
@@ -183,8 +182,6 @@ import gregtech.api.unification.material.info.MaterialIconSet.METALLIC
 import gregtech.api.unification.material.info.MaterialIconSet.SAND
 import gregtech.api.unification.material.info.MaterialIconSet.SHINY
 import gregtech.api.unification.material.properties.BlastProperty.GasTier
-import gregtech.api.unification.material.properties.MaterialToolProperty
-import gregtechlite.gtlitecore.GTLiteMod
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Abyssalloy
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumGroupAlloyA
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumGroupAlloyB
@@ -275,6 +272,12 @@ import gregtechlite.gtlitecore.api.unification.material.info.GTLiteMaterialIconS
 import gregtechlite.gtlitecore.api.MINUTE
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
+import gregtechlite.gtlitecore.api.extension.blastProp
+import gregtechlite.gtlitecore.api.extension.cableProp
+import gregtechlite.gtlitecore.api.extension.fluidPipeProp
+import gregtechlite.gtlitecore.api.extension.itemPipeProp
+import gregtechlite.gtlitecore.api.extension.rotorProp
+import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BoronFranciumCarbideSuperconductor
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CaesiumCeriumCobaltIndium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyConductiveMixture
@@ -292,1057 +295,992 @@ object GTLiteSecondDegreeMaterials
     fun init()
     {
         // 4001 Kovar
-        Kovar = Material.Builder(4001, GTLiteMod.id("kovar"))
-            .ingot()
-            .colorAverage().iconSet(SHINY)
-            .components(Iron, 2, Nickel, 1, Cobalt, 1)
-            .flags(EXT_METAL, GENERATE_RING, GENERATE_FRAME)
-            .build()
-            .setFormula("Fe10Ni5Co3", true)
+        Kovar = addMaterial(4001, "kovar")
+        {
+            ingot()
+            colorAverage().iconSet(SHINY)
+            components(Iron, 2, Nickel, 1, Cobalt, 1)
+            flags(EXT_METAL, GENERATE_RING, GENERATE_FRAME)
+        }
 
         // 4002 Maraging Steel 250
-        MaragingSteel250 = Material.Builder(4002, GTLiteMod.id("maraging_steel_250"))
-            .ingot()
-            .fluid()
-            .color(0x92918D).iconSet(METALLIC)
-            .components(Iron, 16, Molybdenum, 1, Titanium, 1, Nickel, 4, Cobalt, 2)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_DOUBLE_PLATE)
-            .blast { b ->
-                b.temp(2413, GasTier.LOW) // Kanthal
-                    .blastStats(VA[HV], 20 * SECOND)
-                    .vacuumStats(VA[MV], 2 * SECOND + 2 * TICK)
-            }
-            .itemPipeProperties(576, 16F)
-            .build()
+        MaragingSteel250 = addMaterial(4002, "maraging_steel_250")
+        {
+            ingot()
+            fluid()
+            color(0x92918D).iconSet(METALLIC)
+            components(Iron, 16, Molybdenum, 1, Titanium, 1, Nickel, 4, Cobalt, 2)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_DOUBLE_PLATE)
+            blastProp(2413, GasTier.LOW, // Kanthal
+                      VA[HV], 20 * SECOND,
+                      VA[MV], 2 * SECOND + 2 * TICK)
+            itemPipeProp(576, 16F)
+        }
 
         // 4003 Inconel-625
-        Inconel625 = Material.Builder(4003, GTLiteMod.id("inconel_625"))
-            .ingot()
-            .fluid()
-            .color(0x80C880).iconSet(METALLIC)
-            .components(Nickel, 3, Chrome, 7, Molybdenum, 10, Invar, 10, Nichrome, 13)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(2425, GasTier.LOW) // Kanthal
-                    .blastStats(VA[HV], 25 * SECOND)
-                    .vacuumStats(VA[MV], 4 * SECOND + 4 * TICK)
-            }
-            .build()
+        Inconel625 = addMaterial(4003, "inconel_625")
+        {
+            ingot()
+            fluid()
+            color(0x80C880).iconSet(METALLIC)
+            components(Nickel, 3, Chrome, 7, Molybdenum, 10, Invar, 10, Nichrome, 13)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
+            blastProp(2425, GasTier.LOW, // Kanthal
+                      VA[HV], 25 * SECOND,
+                      VA[MV], 4 * SECOND + 4 * TICK)
+        }
 
         // 4004 Staballoy
-        Staballoy = Material.Builder(4004, GTLiteMod.id("staballoy"))
-            .ingot()
-            .fluid()
-            .color(0x444B42).iconSet(METALLIC)
-            .components(Uranium, 9, Titanium, 1)
-            .flags(
-                EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_DOUBLE_PLATE, GENERATE_DENSE
-            )
-            .blast { b ->
-                b.temp(3450, GasTier.MID) // Nichrome
-                    .blastStats(VA[HV], 37 * SECOND + 10 * TICK)
-                    .vacuumStats(VA[MV], 21 * SECOND + 9 * TICK)
-            }
-            .build()
+        Staballoy = addMaterial(4004, "staballoy")
+        {
+            ingot()
+            fluid()
+            color(0x444B42).iconSet(METALLIC)
+            components(Uranium, 9, Titanium, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_DOUBLE_PLATE,
+                  GENERATE_DENSE)
+            blastProp(3450, GasTier.MID, // Nichrome
+                      VA[HV], 37 * SECOND + 10 * TICK,
+                      VA[MV], 21 * SECOND + 9 * TICK)
+        }
 
         // 4005 Talonite
-        Talonite = Material.Builder(4005, GTLiteMod.id("talonite"))
-            .ingot()
-            .fluid()
-            .color(0x9991A5).iconSet(SHINY)
-            .components(Cobalt, 4, Chrome, 3, Phosphorus, 2, Molybdenum, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_ROTOR, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(3454, GasTier.MID) // Nichrome
-                    .blastStats(VA[HV], 28 * SECOND + 10 * TICK)
-                    .vacuumStats(VA[MV], 3 * SECOND + 18 * TICK)
-            }
-            .build()
+        Talonite = addMaterial(4005, "talonite")
+        {
+            ingot()
+            fluid()
+            color(0x9991A5).iconSet(SHINY)
+            components(Cobalt, 4, Chrome, 3, Phosphorus, 2, Molybdenum, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_ROTOR, GENERATE_SPRING,
+                  GENERATE_SPRING_SMALL)
+            blastProp(3454, GasTier.MID, // Nichrome
+                      VA[HV], 28 * SECOND + 10 * TICK,
+                      VA[MV], 3 * SECOND + 18 * TICK)
+        }
 
         // 4006 Zeron-100
-        Zeron100 = Material.Builder(4006, GTLiteMod.id("zeron_100"))
-            .ingot()
-            .fluid()
-            .color(0xB4B414).iconSet(SHINY)
-            .components(Chrome, 13, Nickel, 3, Molybdenum, 2, Copper, 10, Tungsten, 2, Steel, 20)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(5400, GasTier.HIGH) // HSS-G
-                    .blastStats(VA[IV], 48 * SECOND)
-                    .vacuumStats(VA[EV], 5 * SECOND + 8 * TICK)
-            }
-            .build()
+        Zeron100 = addMaterial(4006, "zeron_100")
+        {
+            ingot()
+            fluid()
+            color(0xB4B414).iconSet(SHINY)
+            components(Chrome, 13, Nickel, 3, Molybdenum, 2, Copper, 10, Tungsten, 2, Steel, 20)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
+            blastProp(5400, GasTier.HIGH, // HSS-G
+                      VA[IV], 48 * SECOND,
+                      VA[EV], 5 * SECOND + 8 * TICK)
+        }
 
         // 4007 Watertight Steel
-        WatertightSteel = Material.Builder(4007, GTLiteMod.id("watertight_steel"))
-            .ingot()
-            .fluid()
-            .color(0x7878B4).iconSet(METALLIC)
-            .components(Iron, 7, Aluminium, 4, Nickel, 2, Chrome, 1, Sulfur, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(3850, GasTier.MID) // RTM Alloy (Nichrome via 2x EV Energy Hatch)
-                    .blastStats(VA[HV], 24 * SECOND)
-                    .vacuumStats(VA[MV], 2 * SECOND)
-            }
-            .build()
+        WatertightSteel = addMaterial(4007, "watertight_steel")
+        {
+            ingot()
+            fluid()
+            color(0x7878B4).iconSet(METALLIC)
+            components(Iron, 7, Aluminium, 4, Nickel, 2, Chrome, 1, Sulfur, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(3850, GasTier.MID, // RTM Alloy
+                      VA[HV], 24 * SECOND,
+                      VA[MV], 2 * SECOND)
+        }
 
         // 4008 Stellite
-        Stellite = Material.Builder(4008, GTLiteMod.id("stellite"))
-            .ingot()
-            .fluid()
-            .color(0x9991A5).iconSet(SHINY)
-            .components(Cobalt, 9, Chrome, 9, Manganese, 5, Titanium, 2)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(3310, GasTier.MID) // Nichrome
-                    .blastStats(VA[EV], 30 * SECOND)
-                    .vacuumStats(VA[MV], 6 * SECOND)
-            }
-            .build()
+        Stellite = addMaterial(4008, "stellite")
+        {
+            ingot()
+            fluid()
+            color(0x9991A5).iconSet(SHINY)
+            components(Cobalt, 9, Chrome, 9, Manganese, 5, Titanium, 2)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(3310, GasTier.MID, // Nichrome
+                      VA[EV], 30 * SECOND,
+                      VA[MV], 6 * SECOND)
+        }
 
         // 4009 Tumbaga
-        Tumbaga = Material.Builder(4009, GTLiteMod.id("tumbaga"))
-            .ingot()
-            .fluid()
-            .color(0xFFB20F).iconSet(SHINY)
-            .components(Gold, 7, Bronze, 3)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE,
-                GENERATE_DENSE)
-            .blast { b ->
-                b.temp(1200, GasTier.LOW)
-                    .blastStats(VA[MV], 24 * SECOND)
-            }
-            .build()
+        Tumbaga = addMaterial(4009, "tumbaga")
+        {
+            ingot()
+            fluid()
+            color(0xFFB20F).iconSet(SHINY)
+            components(Gold, 7, Bronze, 3)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
+            blastProp(1200, GasTier.LOW, // Cupronickel
+                      VA[MV], 24 * SECOND)
+        }
 
         // 4010 Eglin Steel Base
-        EglinSteelBase = Material.Builder(4010, GTLiteMod.id("eglin_steel_base"))
-            .dust()
-            .color(0x8B4513).iconSet(SAND)
-            .components(Iron, 4, Kanthal, 1, Invar, 5)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        EglinSteelBase = addMaterial(4010, "eglin_steel_base")
+        {
+            dust()
+            color(0x8B4513).iconSet(SAND)
+            components(Iron, 4, Kanthal, 1, Invar, 5)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 4011 Eglin Steel
-        EglinSteel = Material.Builder(4011, GTLiteMod.id("eglin_steel"))
-            .ingot()
-            .fluid()
-            .color(0x8B4513).iconSet(METALLIC)
-            .components(EglinSteelBase, 10, Sulfur, 1, Silicon, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(1048, GasTier.LOW) // Cupronickel
-                    .blastStats(VA[MV], 1 * SECOND + 4 * TICK)
-            }
-            .build()
+        EglinSteel = addMaterial(4011, "eglin_steel")
+        {
+            ingot()
+            fluid()
+            color(0x8B4513).iconSet(METALLIC)
+            components(EglinSteelBase, 10, Sulfur, 1, Silicon, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_DOUBLE_PLATE,
+                  GENERATE_DENSE)
+            blastProp(1048, GasTier.LOW, // Cupronickel
+                      VA[MV], 1 * SECOND + 4 * TICK)
+        }
 
         // 4012 Grisium
-        Grisium = Material.Builder(4012, GTLiteMod.id("grisium"))
-            .ingot()
-            .fluid()
-            .color(0x355D6A).iconSet(METALLIC)
-            .components(Titanium, 9, Carbon, 9, Potassium, 9, Lithium, 9, Sulfur, 9, Hydrogen, 5)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(3550, GasTier.MID) // Nichrome
-                    .blastStats(VA[EV], 26 * SECOND)
-                    .vacuumStats(VA[HV], 13 * SECOND)
-            }
-            .build()
+        Grisium = addMaterial(4012, "grisium")
+        {
+            ingot()
+            fluid()
+            color(0x355D6A).iconSet(METALLIC)
+            components(Titanium, 9, Carbon, 9, Potassium, 9, Lithium, 9, Sulfur, 9, Hydrogen, 5)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(3550, GasTier.MID, // Nichrome
+                      VA[EV], 26 * SECOND,
+                      VA[HV], 13 * SECOND)
+        }
 
         // 4013 Babbit Alloy
-        BabbitAlloy = Material.Builder(4013, GTLiteMod.id("babbit_alloy"))
-            .ingot()
-            .fluid()
-            .color(0xA19CA4).iconSet(METALLIC)
-            .components(Tin, 5, Lead, 36, Antimony, 8, Arsenic, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(737, GasTier.LOW) // Cupronickel
-                    .blastStats(VA[MV], 8 * SECOND)
-            }
-            .build()
+        BabbitAlloy = addMaterial(4013, "babbit_alloy")
+        {
+            ingot()
+            fluid()
+            color(0xA19CA4).iconSet(METALLIC)
+            components(Tin, 5, Lead, 36, Antimony, 8, Arsenic, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(737, GasTier.LOW, // Cupronickel
+                      VA[MV], 8 * SECOND)
+        }
 
         // 4014 Silicon Carbide
-        SiliconCarbide = Material.Builder(4014, GTLiteMod.id("silicon_carbide"))
-            .ingot()
-            .fluid()
-            .color(0x404040).iconSet(METALLIC)
-            .components(Silicon, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_FOIL,
-                GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(3850, GasTier.HIGH) // RTM Alloy (Nichrome via 2x EV Energy Hatch)
-                    .blastStats(VA[IV], 7 * SECOND + 10 * TICK)
-                    .vacuumStats(VA[EV], 3 * SECOND + 5 * TICK)
-            }
-            .build()
+        SiliconCarbide = addMaterial(4014, "silicon_carbide")
+        {
+            ingot()
+            fluid()
+            color(0x404040).iconSet(METALLIC)
+            components(Silicon, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(3850, GasTier.HIGH, // RTM Alloy
+                      VA[IV], 7 * SECOND + 10 * TICK,
+                      VA[EV], 3 * SECOND + 5 * TICK)
+        }
 
         // 4015 HSLA Steel
-        HSLASteel = Material.Builder(4015, GTLiteMod.id("hsla_steel"))
-            .ingot()
-            .fluid()
-            .color(0x808080).iconSet(METALLIC)
-            .components(Invar, 2, Vanadium, 1, Titanium, 1, Molybdenum, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_RING)
-            .blast { b ->
-                b.temp(1711, GasTier.LOW) // Kanthal
-                    .blastStats(VA[HV], 25 * SECOND)
-            }
-            .build()
+        HSLASteel = addMaterial(4015, "hsla_steel")
+        {
+            ingot()
+            fluid()
+            color(0x808080).iconSet(METALLIC)
+            components(Invar, 2, Vanadium, 1, Titanium, 1, Molybdenum, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_RING)
+            blastProp(1711, GasTier.LOW, // Kanthal
+                      VA[HV], 25 * SECOND)
+        }
 
         // 4016 Incoloy-MA813
-        IncoloyMA813 = Material.Builder(4016, GTLiteMod.id("incoloy_ma_813"))
-            .ingot()
-            .fluid()
-            .color(0x37BF7E).iconSet(SHINY)
-            .components(VanadiumSteel, 4, Niobium, 2, Chrome, 3, Nickel, 4)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(4800, GasTier.HIGH) // HSS-G (RTM Alloy via 2x HV Energy Hatch)
-                    .blastStats(VA[IV], 34 * SECOND)
-                    .vacuumStats(VA[EV], 17 * SECOND)
-            }
-            .build()
+        IncoloyMA813 = addMaterial(4016, "incoloy_ma_813")
+        {
+            ingot()
+            fluid()
+            color(0x37BF7E).iconSet(SHINY)
+            components(VanadiumSteel, 4, Niobium, 2, Chrome, 3, Nickel, 4)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_BOLT_SCREW)
+            blastProp(4800, GasTier.HIGH, // HSS-G
+                      VA[IV], 34 * SECOND,
+                      VA[EV], 17 * SECOND)
+        }
 
         // 4017 Monel 500
-        Monel500 = Material.Builder(4017, GTLiteMod.id("monel_500"))
-            .ingot()
-            .fluid()
-            .color(0x7777F1).iconSet(BRIGHT)
-            .components(Nickel, 23, Manganese, 2, Copper, 10, Aluminium, 4, Titanium, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(4500, GasTier.MID) // RTM Alloy
-                    .blastStats(VA[IV], 27 * SECOND)
-                    .vacuumStats(VA[HV], 20 * SECOND)
-            }
-            .build()
+        Monel500 = addMaterial(4017, "monel_500")
+        {
+            ingot()
+            fluid()
+            color(0x7777F1).iconSet(BRIGHT)
+            components(Nickel, 23, Manganese, 2, Copper, 10, Aluminium, 4, Titanium, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(4500, GasTier.MID, // RTM Alloy
+                      VA[IV], 27 * SECOND,
+                      VA[HV], 20 * SECOND)
+        }
 
         // 4018 Incoloy-MA956
-        IncoloyMA956 = Material.Builder(4018, GTLiteMod.id("incoloy_ma_956"))
-            .ingot()
-            .fluid()
-            .color(0xAABEBB).iconSet(METALLIC)
-            .components(Iron, 16, Aluminium, 3, Chrome, 5, Yttrium, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(5325, GasTier.HIGH) // HSS-G
-                    .blastStats(VA[IV], 40 * SECOND)
-                    .vacuumStats(VA[HV], 25 * SECOND)
-            }
-            .build()
+        IncoloyMA956 = addMaterial(4018, "incoloy_ma_956")
+        {
+            ingot()
+            fluid()
+            color(0xAABEBB).iconSet(METALLIC)
+            components(Iron, 16, Aluminium, 3, Chrome, 5, Yttrium, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(5325, GasTier.HIGH, // HSS-G
+                      VA[IV], 40 * SECOND,
+                      VA[HV], 25 * SECOND)
+        }
 
         // 4019 Zirconium Carbide
-        ZirconiumCarbide = Material.Builder(4019, GTLiteMod.id("zirconium_carbide"))
-            .ingot()
-            .fluid()
-            .color(0xDECAB4).iconSet(METALLIC)
-            .components(Zirconium, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(3250, GasTier.MID) // Nichrome
-                    .blastStats(VA[HV], 48 * SECOND)
-                    .vacuumStats(VA[LV], 24 * SECOND)
-            }
-            .build()
+        ZirconiumCarbide = addMaterial(4019, "zirconium_carbide")
+        {
+            ingot()
+            fluid()
+            color(0xDECAB4).iconSet(METALLIC)
+            components(Zirconium, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(3250, GasTier.MID, // Nichrome
+                      VA[HV], 48 * SECOND,
+                      VA[LV], 24 * SECOND)
+        }
 
         // 4020 Tantalum Carbide
-        TantalumCarbide = Material.Builder(4020, GTLiteMod.id("tantalum_carbide"))
-            .ingot()
-            .fluid()
-            .color(0x56566A).iconSet(METALLIC)
-            .components(Tantalum, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR)
-            .blast { b ->
-                b.temp(4120, GasTier.MID) // RTM Alloy
-                    .blastStats(VA[EV], 60 * SECOND)
-                    .vacuumStats(VA[HV], 20 * SECOND)
-            }
-            .build()
+        TantalumCarbide = addMaterial(4020, "tantalum_carbide")
+        {
+            ingot()
+            fluid()
+            color(0x56566A).iconSet(METALLIC)
+            components(Tantalum, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR)
+            blastProp(4120, GasTier.MID, // RTM Alloy
+                      VA[EV], 1 * MINUTE,
+                      VA[HV], 20 * SECOND)
+        }
 
         // 4021 Molybdenum Disilicide
-        MolybdenumDisilicide = Material.Builder(4021, GTLiteMod.id("molybdenum_disilicide"))
-            .ingot()
-            .fluid()
-            .color(0x6A5BA3).iconSet(METALLIC)
-            .components(Molybdenum, 1, Silicon, 2)
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(2300, GasTier.MID) // Kanthal
-                    .blastStats(VA[EV], 40 * SECOND)
-                    .vacuumStats(12 * SECOND)
-            }
-            .build()
+        MolybdenumDisilicide = addMaterial(4021, "molybdenum_disilicide")
+        {
+            ingot()
+            fluid()
+            color(0x6A5BA3).iconSet(METALLIC)
+            components(Molybdenum, 1, Silicon, 2)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(2300, GasTier.MID, // Kanthal
+                      VA[EV], 40 * SECOND,
+                      VA[MV], 12 * SECOND)
+        }
 
         // 4022 Hastelloy-C276
-        HastelloyC276 = Material.Builder(4022, GTLiteMod.id("hastelloy_c_276"))
-            .ingot()
-            .fluid()
-            .color(0xA47657).iconSet(METALLIC)
-            .components(Nickel, 12, Molybdenum, 8, Chrome, 7, Tungsten, 1, Cobalt, 1, Copper, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(4625, GasTier.MID) // RTM Alloy
-                    .blastStats(VA[IV], 38 * SECOND)
-                    .vacuumStats(VA[HV], 14 * SECOND)
-            }
-            .build()
+        HastelloyC276 = addMaterial(4022, "hastelloy_c_276")
+        {
+            ingot()
+            fluid()
+            color(0xA47657).iconSet(METALLIC)
+            components(Nickel, 12, Molybdenum, 8, Chrome, 7, Tungsten, 1, Cobalt, 1, Copper, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(4625, GasTier.MID, // RTM Alloy
+                      VA[IV], 38 * SECOND,
+                      VA[HV], 14 * SECOND)
+        }
 
         // 4023 Hastelloy-X
-        HastelloyX = Material.Builder(4023, GTLiteMod.id("hastelloy_x"))
-            .ingot()
-            .fluid()
-            .color(0x5785A4).iconSet(METALLIC)
-            .components(Nickel, 8, Iron, 3, Tungsten, 4, Molybdenum, 2, Chrome, 1, Niobium, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(4200, GasTier.MID) // RTM Alloy
-                    .blastStats(VA[IV], 30 * SECOND)
-                    .vacuumStats(VA[HV], 16 * SECOND)
-            }
-            .build()
+        HastelloyX = addMaterial(4023, "hastelloy_x")
+        {
+            ingot()
+            fluid()
+            color(0x5785A4).iconSet(METALLIC)
+            components(Nickel, 8, Iron, 3, Tungsten, 4, Molybdenum, 2, Chrome, 1, Niobium, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(4200, GasTier.MID, // RTM Alloy
+                      VA[IV], 30 * SECOND,
+                      VA[HV], 16 * SECOND)
+        }
 
         // 4024 Hastelloy-N
-        HastelloyN = Material.Builder(4024, GTLiteMod.id("hastelloy_n"))
-            .ingot()
-            .fluid()
-            .color(0xDDDDDD).iconSet(METALLIC)
-            .components(Yttrium, 2, Molybdenum, 4, Chrome, 2, Titanium, 2, Nickel, 15)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_SPRING_SMALL,  GENERATE_SMALL_GEAR)
-            .blast { b ->
-                b.temp(4625, GasTier.HIGH) // HSS-G
-                    .blastStats(VA[IV], 50 * SECOND)
-                    .vacuumStats(VA[EV], 15 * SECOND)
-            }
-            .build()
+        HastelloyN = addMaterial(4024, "hastelloy_n")
+        {
+            ingot()
+            fluid()
+            color(0xDDDDDD).iconSet(METALLIC)
+            components(Yttrium, 2, Molybdenum, 4, Chrome, 2, Titanium, 2, Nickel, 15)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING,
+                  GENERATE_SPRING_SMALL)
+            blastProp(4625, GasTier.HIGH, // HSS-G
+                      VA[IV], 50 * SECOND,
+                      VA[EV], 15 * SECOND)
+        }
 
         // 4025 Aluminium Bronze
-        AluminiumBronze = Material.Builder(4025, GTLiteMod.id("aluminium_bronze"))
-            .ingot()
-            .fluid()
-            .color(0x6CB451).iconSet(METALLIC)
-            .components(Aluminium, 2, Manganese, 1, Bronze, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME,
-                GENERATE_DOUBLE_PLATE)
-            .blast { b ->
-                b.temp(1073, GasTier.LOW) // Cupronickel
-                    .blastStats(VA[MV], 16 * SECOND)
-            }
-            .build()
+        AluminiumBronze = addMaterial(4025, "aluminium_bronze")
+        {
+            ingot()
+            fluid()
+            color(0x6CB451).iconSet(METALLIC)
+            components(Aluminium, 2, Manganese, 1, Bronze, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE)
+            blastProp(1073, GasTier.LOW, // Cupronickel
+                      VA[MV], 16 * SECOND)
+        }
 
         // 4026 René N5
-        ReneN5 = Material.Builder(4026, GTLiteMod.id("rene_n_5"))
-            .ingot()
-            .fluid()
-            .color(0xD599BD).iconSet(SHINY)
-            .components(Nickel, 22, Cobalt, 4, Chrome, 3, Aluminium, 3, Tungsten, 2, Hafnium, 1, Rhenium, 2, Tantalum, 3)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(6800, GasTier.HIGH) // Naquadah
-                    .blastStats(VA[LuV], 30 * SECOND)
-                    .vacuumStats(VA[EV], 25 * SECOND)
-            }
-            .build()
+        ReneN5 = addMaterial(4026, "rene_n_5")
+        {
+            ingot()
+            fluid()
+            color(0xD599BD).iconSet(SHINY)
+            components(Nickel, 22, Cobalt, 4, Chrome, 3, Aluminium, 3, Tungsten, 2, Hafnium, 1, Rhenium, 2, Tantalum, 3)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(6800, GasTier.HIGH, // Naquadah
+                      VA[LuV], 30 * SECOND,
+                      VA[EV], 25 * SECOND)
+        }
 
         // 4027 Titanium Carbide
-        TitaniumCarbide = Material.Builder(4027, GTLiteMod.id("titanium_carbide"))
-            .ingot()
-            .fluid()
-            .color(0xB20B3A).iconSet(METALLIC)
-            .components(Titanium, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(3430, GasTier.MID) // Nichrome
-                    .blastStats(VA[HV], 50 * SECOND)
-                    .vacuumStats(VA[MV], 10 * SECOND)
-            }
-            .build()
+        TitaniumCarbide = addMaterial(4027, "titanium_carbide")
+        {
+            ingot()
+            fluid()
+            color(0xB20B3A).iconSet(METALLIC)
+            components(Titanium, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME)
+            blastProp(3430, GasTier.MID, // Nichrome
+                      VA[HV], 50 * SECOND,
+                      VA[MV], 10 * SECOND)
+        }
 
         // 4028 Titanium Tungsten Carbide
-        TitaniumTungstenCarbide = Material.Builder(4028, GTLiteMod.id("titanium_tungsten_carbide"))
-            .ingot()
-            .fluid()
-            .color(0x800D0D).iconSet(METALLIC)
-            .components(TungstenCarbide, 1, TitaniumCarbide, 2)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_FRAME)
-            .blast { b ->
-                b.temp(3800, GasTier.HIGH) // Nichrome
-                    .blastStats(VA[EV], 50 * SECOND)
-                    .vacuumStats(VA[HV], 15 * SECOND)
-            }
-            .build()
+        TitaniumTungstenCarbide = addMaterial(4028, "titanium_tungsten_carbide")
+        {
+            ingot()
+            fluid()
+            color(0x800D0D).iconSet(METALLIC)
+            components(TungstenCarbide, 1, TitaniumCarbide, 2)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_FRAME)
+            blastProp(3800, GasTier.HIGH, // Nichrome
+                      VA[EV], 50 * SECOND,
+                      VA[HV], 15 * SECOND)
+        }
 
         // 4029 Trinaquadalloy
-        Trinaquadalloy = Material.Builder(4029, GTLiteMod.id("trinaquadalloy"))
-            .ingot()
-            .fluid()
-            .color(0x281832).iconSet(BRIGHT)
-            .components(Trinium, 6, Naquadah, 2, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE,
-                GENERATE_SPRING_SMALL, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(8747, GasTier.HIGHER) // Trinium
-                    .blastStats(VA[ZPM], 1 * MINUTE)
-                    .vacuumStats(VA[IV], 45 * SECOND)
-            }
-            .fluidPipeProperties(7552, 400, true, true, true, true)
-            .build()
+        Trinaquadalloy = addMaterial(4029, "trinaquadalloy")
+        {
+            ingot()
+            fluid()
+            color(0x281832).iconSet(BRIGHT)
+            components(Trinium, 6, Naquadah, 2, Carbon, 1)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE, GENERATE_DENSE,
+                  GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(8747, GasTier.HIGHER, // Trinium
+                      VA[ZPM], 1 * MINUTE,
+                      VA[IV], 45 * SECOND)
+            fluidPipeProp(7552, 400, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 4030 Enriched Naquadah Alloy
-        EnrichedNaquadahAlloy = Material.Builder(4030, GTLiteMod.id("enriched_naquadah_alloy"))
-            .ingot(6)
-            .fluid()
-            .color(0x160740).iconSet(SHINY)
-            .components(NaquadahEnriched, 4, Ruridit, 2, Rutherfordium, 1)
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE,
-                GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR,
-                GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_RING, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(9001, GasTier.HIGHER) // Trinium
-                    .blastStats(VA[ZPM], 1 * MINUTE + 40 * SECOND)
-                    .vacuumStats(VA[LuV], 30 * SECOND)
+        EnrichedNaquadahAlloy = addMaterial(4030, "enriched_naquadah_alloy")
+        {
+            ingot(6)
+            fluid()
+            color(0x160740).iconSet(SHINY)
+            components(NaquadahEnriched, 4, Ruridit, 2, Rutherfordium, 1)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL,
+                  GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_RING, GENERATE_SPRING,
+                  GENERATE_SPRING_SMALL)
+            blastProp(9001, GasTier.HIGHER, // Trinium
+                      VA[ZPM], 1 * MINUTE + 40 * SECOND,
+                      VA[LuV], 30 * SECOND)
+            toolProp(45.0F, 24.0F, 4096, 6)
+            {
+                attackSpeed(0.6F)
+                enchantability(36)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(45.0F, 24.0F, 4096, 6)
-                .attackSpeed(0.6F).enchantability(36).magnetic().build())
-            .rotorStats(18.0f, 6.0f, 7680)
-            .cableProperties(V[UHV], 4, 8)
-            .build()
+            rotorProp(18.0f, 6.0f, 7680)
+            cableProp(V[UHV], 4, 8)
+        }
 
         // 4031 Quantum Alloy
-        QuantumAlloy = Material.Builder(4031, GTLiteMod.id("quantum_alloy"))
-            .ingot(7)
-            .fluid()
-            .color(0x0F0F0F).iconSet(BRIGHT)
-            .components(Stellite, 15, Jasper, 5, Gallium, 5, Americium, 5, Palladium, 5, Bismuth, 5, Germanium, 5, SiliconCarbide, 5)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE,
-                GENERATE_FOIL)
-            .blast { b ->
-                b.temp(11400, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UHV], 58 * SECOND)
-                    .vacuumStats(VA[UV], 29 * SECOND)
-            }
-            .itemPipeProperties(64, 96F)
-            .build()
+        QuantumAlloy = addMaterial(4031, "quantum_alloy")
+        {
+            ingot(7)
+            fluid()
+            color(0x0F0F0F).iconSet(BRIGHT)
+            components(Stellite, 15, Jasper, 5, Gallium, 5, Americium, 5, Palladium, 5, Bismuth, 5, Germanium, 5,
+                       SiliconCarbide, 5)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_DOUBLE_PLATE, GENERATE_FOIL)
+            blastProp(11400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 58 * SECOND,
+                      VA[UV], 29 * SECOND)
+            itemPipeProp(64, 96F)
+        }
 
         // 4032 HDCS (High Durability Compound Steel)
-        HDCS = Material.Builder(4032, GTLiteMod.id("hdcs"))
-            .ingot(7)
-            .fluid()
-            .color(0x334433).iconSet(SHINY)
-            .components(TungstenSteel, 12, HSSS, 9, HSSG, 6, Ruridit, 3, MagnetoResonatic, 2, Plutonium241, 1)
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE, GENERATE_RING, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(10900, GasTier.HIGHEST) // Adamantium (Tritanium)
-                    .blastStats(VA[UHV], 1 * MINUTE + 30 * SECOND)
-                    .vacuumStats(VA[ZPM], 45 * SECOND)
+        HDCS = addMaterial(4032, "hdcs")
+        {
+            ingot(7)
+            fluid()
+            color(0x334433).iconSet(SHINY)
+            components(TungstenSteel, 12, HSSS, 9, HSSG, 6, Ruridit, 3, MagnetoResonatic, 2, Plutonium241, 1)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR,
+                  GENERATE_DOUBLE_PLATE, GENERATE_RING, GENERATE_SPRING, GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(10900, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 1 * MINUTE + 30 * SECOND,
+                      VA[ZPM], 45 * SECOND)
+            rotorProp(16.5f, 3.5f, 6000)
+            toolProp(52.5F, 28.0F, 6144, 7)
+            {
+                attackSpeed(0.5F)
+                enchantability(34)
+                enchantment(Enchantments.SHARPNESS, 5)
+                magnetic()
             }
-            .rotorStats(16.5f, 3.5f, 6000)
-            .toolStats(MaterialToolProperty.Builder.of(52.5F, 28.0F, 6144, 7)
-                .attackSpeed(0.5F).enchantability(34)
-                .enchantment(Enchantments.SHARPNESS, 5)
-                .magnetic().build())
-            .build()
+        }
 
         // 4033 Titan Steel
-        TitanSteel = Material.Builder(4033, GTLiteMod.id("titan_steel"))
-            .ingot(7)
-            .fluid()
-            .color(0xAA0D0D).iconSet(SHINY)
-            .components(TitaniumTungstenCarbide, 3, Jasper, 3, Tritanium, 2)
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE,
-                GENERATE_GEAR, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(10600, GasTier.HIGHEST) // Tritanium
-                    .blastStats(VA[UHV], 1 * MINUTE)
-                    .vacuumStats(VA[UV], 28 * SECOND) }
-            .toolStats(MaterialToolProperty.Builder.of(48.0F, 24.0F, 5120, 7)
-                .attackSpeed(0.4F).enchantability(32)
-                .enchantment(Enchantments.FIRE_ASPECT, 3)
-                .magnetic().build())
-            .itemPipeProperties(576, 72F)
-            .build()
+        TitanSteel = addMaterial(4033, "titan_steel")
+        {
+            ingot(7)
+            fluid()
+            color(0xAA0D0D).iconSet(SHINY)
+            components(TitaniumTungstenCarbide, 3, Jasper, 3, Tritanium, 2)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_GEAR, GENERATE_FRAME,
+                  GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(10600, GasTier.HIGHEST, // Tritanium
+                      VA[UHV], 1 * MINUTE,
+                      VA[UV], 28 * SECOND)
+            toolProp(48.0F, 24.0F, 5120, 7)
+            {
+                attackSpeed(0.4F)
+                enchantability(32)
+                enchantment(Enchantments.FIRE_ASPECT, 3)
+                magnetic()
+            }
+            itemPipeProp(576, 72F)
+        }
 
         // 4034 Tairitsium
-        Tairitsium = Material.Builder(4034, GTLiteMod.id("tairitsium"))
-            .ingot()
-            .fluid()
-            .color(0x003F5F).iconSet(METALLIC)
-            .components(TungstenSteel, 8, Naquadria, 7, Bedrockium, 4, Carbon, 4, VanadiumSteel, 3, Francium, 1)
-            .blast { b ->
-                b.temp(10400, GasTier.HIGHEST) // Tritanium
-                    .blastStats(VA[UHV], 20 * SECOND)
-                    .vacuumStats(VA[UV], 6 * SECOND + 10 * TICK) }
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE,
-                GENERATE_GEAR, GENERATE_FOIL, GENERATE_FRAME, GENERATE_RING,
-                GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR)
-            .toolStats(MaterialToolProperty.Builder.of(36.5F, 44.2F, 4980, 7)
-                .attackSpeed(0.6F).enchantability(30)
-                .enchantment(Enchantments.LOOTING, 3)
-                .build())
-            .build()
+        Tairitsium = addMaterial(4034, "tairitsium")
+        {
+            ingot()
+            fluid()
+            color(0x003F5F).iconSet(METALLIC)
+            components(TungstenSteel, 8, Naquadria, 7, Bedrockium, 4, Carbon, 4, VanadiumSteel, 3, Francium, 1)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_GEAR, GENERATE_FOIL,
+                  GENERATE_FRAME, GENERATE_RING, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR)
+            blastProp(10400, GasTier.HIGHEST, // Tritanium
+                      VA[UHV], 20 * SECOND,
+                      VA[UV], 6 * SECOND + 10 * TICK)
+            toolProp(36.5F, 44.2F, 4980, 7)
+            {
+                attackSpeed(0.6F)
+                enchantability(30)
+                enchantment(Enchantments.LOOTING, 3)
+            }
+        }
 
         // 4035 Halkonite Steel
-        HalkoniteSteel = Material.Builder(4035, GTLiteMod.id("halkonite_steel"))
-            .ingot()
-            .liquid(FluidBuilder().customStill()
-                .translation("gtlitecore.fluid.molten"))
-            .iconSet(HALKONITE)
-            .components(CosmicNeutronium, 2, Tairitsium, 2, RedPhosphorus, 2, TitanSteel, 1, Infinity, 1)
-            .blast { b -> b
-                .temp(13801, GasTier.HIGHEST) // Infinity
-                .blastStats(VA[UEV], 40 * SECOND)
-                .vacuumStats(VA[UHV], 20 * SECOND)
-            }
-            .flags(EXT2_METAL, NO_UNIFICATION, GENERATE_FOIL, GENERATE_FRAME,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .cableProperties(V[UIV], 48, 64, false)
-            .build()
-            .setFormula("SpNt2((FeW)8*Nq*7?4C4(VCrFe7)3Fr)2P8(((WC)(TiC)2)3(CaMg5(OH)2(Si4O11)2)3Tr2)If", true) // Fix a little formula problem from P4.
+        HalkoniteSteel = addMaterial(4035, "halkonite_steel")
+        {
+            ingot()
+            liquid(FluidBuilder().customStill().translation("gtlitecore.fluid.molten"))
+            iconSet(HALKONITE)
+            components(CosmicNeutronium, 2, Tairitsium, 2, RedPhosphorus, 2, TitanSteel, 1, Infinity, 1)
+            flags(EXT2_METAL, NO_UNIFICATION, GENERATE_FOIL, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
+            blastProp(13801, GasTier.HIGHEST, // Infinity
+                      VA[UEV], 40 * SECOND,
+                      VA[UHV], 20 * SECOND)
+            cableProp(V[UIV], 48, 64)
+        }
 
         // 4036 Hastelloy-X78
-        HastelloyX78 = Material.Builder(4036, GTLiteMod.id("hastelloy_x_78"))
-            .ingot()
-            .fluid()
-            .color(0xD1CB0B).iconSet(SHINY)
-            .components(NaquadahAlloy, 10, Rhenium, 5, Naquadria, 4, Gadolinium, 3,
-                Strontium, 2, Polonium, 3, Rutherfordium, 2, Fermium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_GEAR,
-                GENERATE_RING, GENERATE_FOIL, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL,
-                GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(12300, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UHV], 44 * SECOND)
-                    .vacuumStats(VA[UV], 22 * SECOND)
+        HastelloyX78 = addMaterial(4036, "hastelloy_x_78")
+        {
+            ingot()
+            fluid()
+            color(0xD1CB0B).iconSet(SHINY)
+            components(NaquadahAlloy, 10, Rhenium, 5, Naquadria, 4, Gadolinium, 3, Strontium, 2, Polonium, 3,
+                       Rutherfordium, 2, Fermium, 1)
+            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_GEAR, GENERATE_RING, GENERATE_FOIL,
+                   GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
+            blastProp(12300, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 44 * SECOND,
+                      VA[UV], 22 * SECOND)
+            fluidPipeProp(9300, 640, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+            toolProp(44.8F, 64.4F, 7470, 7)
+            {
+                attackSpeed(0.5F)
+                enchantability(32)
+                magnetic()
             }
-            .fluidPipeProperties(9300, 640, true, true, true, true)
-            .toolStats(MaterialToolProperty.Builder.of(44.8F, 64.4F, 7470, 7)
-                .attackSpeed(0.5F).enchantability(32)
-                .magnetic()
-                .build())
-            .build()
+        }
 
         // 4037 Hastelloy-K243
-        HastelloyK243 = Material.Builder(4037, GTLiteMod.id("hastelloy_k_243"))
-            .ingot()
-            .fluid()
-            .color(0x92D959).iconSet(BRIGHT)
-            .components(HastelloyX78, 5, NiobiumNitride, 2, Tritanium, 4, TungstenCarbide, 4, Promethium, 4, Mendelevium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_GEAR, GENERATE_RING,
-                GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
-            .blast { b ->
-                b.temp(14000, GasTier.HIGHEST) // Infinity
-                    .blastStats(VA[UEV], 1 * MINUTE + 25 * SECOND)
-                    .vacuumStats(VA[UHV], 48 * SECOND)
+        HastelloyK243 = addMaterial(4037, "hastelloy_k_243")
+        {
+            ingot()
+            fluid()
+            color(0x92D959).iconSet(BRIGHT)
+            components(HastelloyX78, 5, NiobiumNitride, 2, Tritanium, 4, TungstenCarbide, 4, Promethium, 4, Mendelevium, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_GEAR, GENERATE_RING, GENERATE_SMALL_GEAR,
+                  GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            blastProp(14000, GasTier.HIGHEST, // Infinity
+                      VA[UEV], 1 * MINUTE + 25 * SECOND,
+                      VA[UHV], 48 * SECOND)
+            toolProp(58.0F, 80.0F, 11205, 8)
+            {
+                attackSpeed(0.8F)
+                enchantability(36)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(58.0F, 80.0F, 11205, 8)
-                .attackSpeed(0.8F).enchantability(36)
-                .magnetic()
-                .build())
-            .build()
+        }
 
         // 4038 Pikyonium 64B
-        Pikyonium64B = Material.Builder(4038, GTLiteMod.id("pikyonium_64_b"))
-            .ingot()
-            .fluid()
-            .color(0x3467BA).iconSet(SHINY)
-            .components(Inconel718, 8, EglinSteel, 5, NaquadahEnriched, 4, TungstenSteel, 4, Cerium, 3,
-                Antimony, 2, Platinum, 2, Ytterbium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(10400, GasTier.HIGHER) // Tritanium
-                    .blastStats(VA[UV], 30 * SECOND)
-                    .vacuumStats(VA[LuV], 15 * SECOND)
-            }
-            .rotorStats(18.2F, 5.5F, 7200)
-            .build()
+        Pikyonium64B = addMaterial(4038, "pikyonium_64_b")
+        {
+            ingot()
+            fluid()
+            color(0x3467BA).iconSet(SHINY)
+            components(Inconel718, 8, EglinSteel, 5, NaquadahEnriched, 4, TungstenSteel, 4, Cerium, 3, Antimony, 2,
+                       Platinum, 2, Ytterbium, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
+            blastProp(10400, GasTier.HIGHER, // Tritanium
+                      VA[UV], 30 * SECOND,
+                      VA[LuV], 15 * SECOND)
+            rotorProp(18.2F, 5.5F, 7200)
+        }
 
         // 4039 Arceus Alloy 2B
-        ArceusAlloy2B = Material.Builder(4039, GTLiteMod.id("arceus_alloy_2_b"))
-            .ingot()
-            .fluid()
-            .color(0xC4A415).iconSet(SHINY)
-            .components(Pikyonium64B, 6, Vibranium, 4, Osmiridium, 2, Lawrencium, 3, Thallium, 2, Astatine, 2, Trinium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(13900, GasTier.HIGHEST) // Infinity
-                    .blastStats(VA[UEV], 1 * MINUTE + 15 * SECOND)
-                    .vacuumStats(VA[UV], 48 * SECOND)
-            }
-            .rotorStats(19.0F, 4.8F, 8400)
-            .build()
+        ArceusAlloy2B = addMaterial(4039, "arceus_alloy_2_b")
+        {
+            ingot()
+            fluid()
+            color(0xC4A415).iconSet(SHINY)
+            components(Pikyonium64B, 6, Vibranium, 4, Osmiridium, 2, Lawrencium, 3, Thallium, 2, Astatine, 2, Trinium, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(13900, GasTier.HIGHEST, // Infinity
+                      VA[UEV], 1 * MINUTE + 15 * SECOND,
+                      VA[UV], 48 * SECOND)
+            rotorProp(19.0F, 4.8F, 8400)
+        }
 
         // 4040 Vibranium Tritanium Actinium Iron Superhydride
-        VibraniumTritaniumActiniumIronSuperhydride = Material.Builder(4040, GTLiteMod.id("vibranium_tritanium_actinium_iron_superhydride"))
-            .ingot()
-            .fluid()
-            .color(0x828AAD).iconSet(SHINY)
-            .components(Vibranium, 5, Tritanium, 5, ActiniumSuperhydride, 1, BETSPerrhenate, 1, Iron, 1)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast {b ->
-                b.temp(14400, GasTier.HIGHEST)
-                    .blastStats(VA[UEV], 30 * SECOND)
-                    .vacuumStats(VA[UHV], 15 * SECOND) }
-            .cableProperties(V[UEV], 32, 0, true)
-            .build()
+        VibraniumTritaniumActiniumIronSuperhydride = addMaterial(4040, "vibranium_tritanium_actinium_iron_superhydride")
+        {
+            ingot()
+            fluid()
+            color(0x828AAD).iconSet(SHINY)
+            components(Vibranium, 5, Tritanium, 5, ActiniumSuperhydride, 1, BETSPerrhenate, 1, Iron, 1)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(14400, GasTier.HIGHEST, // Infinity
+                      VA[UEV], 30 * SECOND,
+                      VA[UHV], 15 * SECOND)
+            cableProp(V[UEV], 32, 0, true)
+        }
 
         // 4041 Hafnium Carbide
-        HafniumCarbide = Material.Builder(4041, GTLiteMod.id("hafnium_carbide"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Hafnium, 1, Carbon, 1)
-            .flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_BOLT_SCREW)
-            .blast { b ->
-                b.temp(4090, GasTier.MID) // RTM Alloy
-                    .blastStats(VA[EV], 1 * MINUTE + 5 * SECOND)
-                    .vacuumStats(VA[HV], 30 * SECOND)
-            }
-            .build()
+        HafniumCarbide = addMaterial(4041, "hafnium_carbide")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Hafnium, 1, Carbon, 1)
+            flags(EXT_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_BOLT_SCREW)
+            blastProp(4090, GasTier.MID, // RTM Alloy
+                      VA[EV], 1 * MINUTE + 5 * SECOND,
+                      VA[HV], 30 * SECOND)
+        }
 
         // 4042 Seaborgium Carbide
-        SeaborgiumCarbide = Material.Builder(4042, GTLiteMod.id("seaborgium_carbide"))
-            .ingot()
-            .fluid()
-            .color(0x4059EA).iconSet(METALLIC)
-            .components(Seaborgium, 1, Carbon, 1)
-            .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FOIL, GENERATE_DOUBLE_PLATE)
-            .blast { b ->
-                b.temp(8500, GasTier.HIGH) // Trinium
-                    .blastStats(VA[ZPM], 45 * SECOND)
-                    .vacuumStats(VA[IV], 22 * SECOND + 10 * TICK)
-            }
-            .itemPipeProperties(288, 48F)
-            .build()
+        SeaborgiumCarbide = addMaterial(4042, "seaborgium_carbide")
+        {
+            ingot()
+            fluid()
+            color(0x4059EA).iconSet(METALLIC)
+            components(Seaborgium, 1, Carbon, 1)
+            flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FOIL, GENERATE_DOUBLE_PLATE)
+            blastProp(8500, GasTier.HIGH, // Trinium
+                      VA[ZPM], 45 * SECOND,
+                      VA[IV], 22 * SECOND + 10 * TICK)
+            itemPipeProp(288, 48F)
+        }
 
         // 4043 Tantalum Hafnium Seaborgium Carbide
-        TantalumHafniumSeaborgiumCarbide = Material.Builder(4043, GTLiteMod.id("tantalum_hafnium_seaborgium_carbide"))
-            .ingot()
-            .fluid()
-            .color(0x2C2C2C).iconSet(SHINY)
-            .components(TantalumCarbide, 12, HafniumCarbide, 3, SeaborgiumCarbide, 1)
-            .flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FRAME, GENERATE_SPRING, GENERATE_DOUBLE_PLATE)
-            .blast { b ->
-                b.temp(12900, GasTier.HIGHEST) // Infinity (Adamantium)
-                    .blastStats(VA[UHV], 36 * SECOND)
-                    .vacuumStats(VA[UV], 18 * SECOND)
-            }
-            .build()
-            .setFormula("Ta12Hf3SgC16", true)
+        TantalumHafniumSeaborgiumCarbide = addMaterial(4043, "tantalum_hafnium_seaborgium_carbide")
+        {
+            ingot()
+            fluid()
+            color(0x2C2C2C).iconSet(SHINY)
+            components(TantalumCarbide, 12, HafniumCarbide, 3, SeaborgiumCarbide, 1)
+            flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FRAME, GENERATE_SPRING,
+                  GENERATE_DOUBLE_PLATE)
+            blastProp(12900, GasTier.HIGHEST, // Infinity
+                      VA[UHV], 36 * SECOND,
+                      VA[UV], 18 * SECOND)
+        }
 
         // 4044 Superheavy Alloy (Light)
-        SuperheavyAlloyA = Material.Builder(4044, GTLiteMod.id("light_superheavy_alloy"))
-            .ingot()
-            .fluid()
-            .color(0x4D8BE9).iconSet(SHINY)
-            .components(Rutherfordium, 1, Dubnium, 1, Seaborgium, 1, Bohrium, 1, MetastableHassium, 1,
-                Meitnerium, 1, Darmstadtium, 1, Roentgenium, 1)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(13800, GasTier.HIGHEST) // Infinity
-                    .blastStats(VA[UIV], 48 * SECOND)
-                    .vacuumStats(VA[UHV], 24 * SECOND)
-            }
-            .cableProperties(V[UIV], 48, 5)
-            .build()
+        SuperheavyAlloyA = addMaterial(4044, "light_superheavy_alloy")
+        {
+            ingot()
+            fluid()
+            color(0x4D8BE9).iconSet(SHINY)
+            components(Rutherfordium, 1, Dubnium, 1, Seaborgium, 1, Bohrium, 1, MetastableHassium, 1, Meitnerium, 1,
+                       Darmstadtium, 1, Roentgenium, 1)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_SPRING,
+                  GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
+            blastProp(13800, GasTier.HIGHEST, // Infinity
+                      VA[UIV], 48 * SECOND,
+                      VA[UHV], 24 * SECOND)
+            cableProp(V[UIV], 48, 5)
+        }
 
         // 4045 Superheavy Alloy (Heavy)
-        SuperheavyAlloyB = Material.Builder(4045, GTLiteMod.id("heavy_superheavy_alloy"))
-            .ingot()
-            .fluid()
-            .color(0xE84B36).iconSet(SHINY)
-            .components(Copernicium, 1, Nihonium, 1, MetastableFlerovium, 1, Moscovium, 1,
-                Livermorium, 1, Tennessine, 1, MetastableOganesson, 1)
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(15400, GasTier.HIGHEST) // Halkonite Steel
-                    .blastStats(VA[UXV], 1 * MINUTE + 36 * SECOND)
-                    .vacuumStats(VA[UEV], 48 * SECOND)
-            }
-            .cableProperties(V[UXV], 64, 10)
-            .build()
+        SuperheavyAlloyB = addMaterial(4045, "heavy_superheavy_alloy")
+        {
+            ingot()
+            fluid()
+            color(0xE84B36).iconSet(SHINY)
+            components(Copernicium, 1, Nihonium, 1, MetastableFlerovium, 1, Moscovium, 1, Livermorium, 1, Tennessine, 1,
+                       MetastableOganesson, 1)
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
+            blastProp(15400, GasTier.HIGHEST, // Halkonite Steel
+                      VA[UXV], 1 * MINUTE + 36 * SECOND,
+                      VA[UEV], 48 * SECOND)
+            cableProp(V[UXV], 64, 10)
+        }
 
         // 4046 Precious Metal Alloy
-        PreciousMetalAlloy = Material.Builder(4046, GTLiteMod.id("precious_metal_alloy"))
-            .ingot()
-            .fluid()
-            .color(Gold.materialRGB + Silver.materialRGB + Platinum.materialRGB + Palladium.materialRGB
-                    + Ruthenium.materialRGB + Rhodium.materialRGB + Iridium.materialRGB
-                    + Osmium.materialRGB).iconSet(BRIGHT)
-            .components(Ruthenium, 1, Rhodium, 1, Palladium, 1, Silver, 1,
-                Osmium, 1, Iridium, 1, Platinum, 1, Gold, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(9900, GasTier.HIGHER) // Tritanium
-                    .blastStats(VA[UV], 1 * MINUTE)
-                    .vacuumStats(VA[ZPM], 30 * SECOND)
-            }
-            .build()
+        PreciousMetalAlloy = addMaterial(4046, "precious_metal_alloy")
+        {
+            ingot()
+            fluid()
+            color(Gold.materialRGB + Silver.materialRGB + Platinum.materialRGB + Palladium.materialRGB + Ruthenium.materialRGB
+                  + Rhodium.materialRGB + Iridium.materialRGB + Osmium.materialRGB).iconSet(BRIGHT)
+            components(Ruthenium, 1, Rhodium, 1, Palladium, 1, Silver, 1, Osmium, 1, Iridium, 1, Platinum, 1, Gold, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FINE_WIRE)
+            blastProp(9900, GasTier.HIGHER, // Tritanium
+                      VA[UV], 1 * MINUTE,
+                      VA[ZPM], 30 * SECOND)
+        }
 
         // 4047 Nitinol-60
-        Nitinol60 = Material.Builder(4047, GTLiteMod.id("nitinol_60"))
-            .ingot()
-            .fluid()
-            .color(0xCCB0EC).iconSet(SHINY)
-            .components(Nickel, 2, Titanium, 3)
-            .blast { b ->
-                b.temp(1941, GasTier.HIGH) // Kanthal
-                    .blastStats(VA[EV], 32 * SECOND + 10 * TICK)
-                    .vacuumStats(VA[MV], 7 * SECOND + 4 * TICK) }
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_FRAME,
-                GENERATE_SPRING, GENERATE_RING, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
-            .toolStats(MaterialToolProperty.Builder.of(12.0F, 7.0F, 2304, 3)
-                .enchantability(16).build())
-            .itemPipeProperties(288, 3F)
-            .build()
+        Nitinol60 = addMaterial(4047, "nitinol_60")
+        {
+            ingot()
+            fluid()
+            color(0xCCB0EC).iconSet(SHINY)
+            components(Nickel, 2, Titanium, 3)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_DOUBLE_PLATE, GENERATE_FRAME, GENERATE_SPRING,
+                  GENERATE_RING, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_SPRING_SMALL)
+            blastProp(1941, GasTier.HIGH, // Kanthal
+                      VA[EV], 32 * SECOND + 10 * TICK,
+                      VA[MV], 7 * SECOND + 4 * TICK)
+            toolProp(12.0F, 7.0F, 2304, 3)
+            {
+                enchantability(16)
+            }
+            itemPipeProp(288, 3F)
+        }
 
         // 4048 Abyssalloy
-        Abyssalloy = Material.Builder(4048, GTLiteMod.id("abyssalloy"))
-            .ingot()
-            .fluid()
-            .color(0x9E706A).iconSet(METALLIC)
-            .components(StainlessSteel, 5, TungstenCarbide, 5, Nichrome, 5, Bronze, 5,
-                IncoloyMA956, 5, Iodine, 1, Germanium, 1, Radon, 1)
-            .flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FOIL, GENERATE_FINE_WIRE,
-                   GENERATE_DOUBLE_PLATE, GENERATE_DENSE)
-            .blast { b ->
-                b.temp(12625, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UIV], 4 * MINUTE)
-                    .vacuumStats(VA[UEV], 2 * MINUTE + 30 * SECOND)
-            }
-            .itemPipeProperties(4096, 576F)
-            .build()
+        Abyssalloy = addMaterial(4048, "abyssalloy")
+        {
+            ingot()
+            fluid()
+            color(0x9E706A).iconSet(METALLIC)
+            components(StainlessSteel, 5, TungstenCarbide, 5, Nichrome, 5, Bronze, 5, IncoloyMA956, 5, Iodine, 1,
+                       Germanium, 1, Radon, 1)
+            flags(EXT2_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE,
+                  GENERATE_DENSE)
+            blastProp(12625, GasTier.HIGHEST, // Adamantium
+                      VA[UIV], 4 * MINUTE,
+                      VA[UEV], 2 * MINUTE + 30 * SECOND)
+            itemPipeProp(4096, 576F)
+        }
 
         // 4049 Fullerene Superconductor
-        FullereneSuperconductor = Material.Builder(4049, GTLiteMod.id("fullerene_superconductor"))
-            .ingot()
-            .fluid()
-            .color(0x8BF743).iconSet(BRIGHT)
-            .components(TitanSteel, 16, LanthanumFullereneNanotube, 4, SeaborgiumDopedCarbonNanotube, 4,
-                MetastableOganesson, 3, Xenon, 1)
-            .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL,
-                GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(15900, GasTier.HIGHEST) // Halkonite Steel
-                    .blastStats(VA[UIV], 3 * MINUTE + 25 * SECOND)
-                    .vacuumStats(VA[UEV], 2 * MINUTE)
-            }
-            .cableProperties(V[UIV], 64, 0, true)
-            .build()
+        FullereneSuperconductor = addMaterial(4049, "fullerene_superconductor")
+        {
+            ingot()
+            fluid()
+            color(0x8BF743).iconSet(BRIGHT)
+            components(TitanSteel, 16, LanthanumFullereneNanotube, 4, SeaborgiumDopedCarbonNanotube, 4,
+                       MetastableOganesson, 3, Xenon, 1)
+            flags(STD_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(15900, GasTier.HIGHEST, // Halkonite Steel
+                      VA[UIV], 3 * MINUTE + 25 * SECOND,
+                      VA[UEV], 2 * MINUTE)
+            cableProp(V[UIV], 64, 0, true)
+        }
 
         // 4050 Lanthanum Group Alloy A
-        LanthanumGroupAlloyA = Material.Builder(4050, GTLiteMod.id("light_lanthanum_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Lanthanum, 1, Cerium, 1, Praseodymium, 1, Neodymium, 1, Promethium, 1, Samarium, 1,
-                Europium, 1, Gadolinium, 1)
-            .flags(STD_METAL, GENERATE_FOIL)
-            .blast { b -> b
-                .temp(11400, GasTier.HIGHEST) // Adamantium
-                .blastStats(VA[UHV], 45 * SECOND)
-                .vacuumStats(VA[ZPM], 35 * SECOND)
-            }
-            .build()
+        LanthanumGroupAlloyA = addMaterial(4050, "light_lanthanum_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Lanthanum, 1, Cerium, 1, Praseodymium, 1, Neodymium, 1, Promethium, 1, Samarium, 1, Europium, 1,
+                       Gadolinium, 1)
+            flags(STD_METAL, GENERATE_FOIL)
+            blastProp(11400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 45 * SECOND,
+                      VA[ZPM], 35 * SECOND)
+        }
 
         // 4051 Lanthanum Group Alloy B
-        LanthanumGroupAlloyB = Material.Builder(4051, GTLiteMod.id("heavy_lanthanum_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Terbium, 1, Dysprosium, 1, Holmium, 1, Erbium, 1, Thulium, 1, Ytterbium, 1,
-                Lutetium, 1, Scandium, 1)
-            .flags(EXT2_METAL, GENERATE_FOIL)
-            .blast { b -> b
-                .temp(11400, GasTier.HIGHEST) // Adamantium
-                .blastStats(VA[UHV], 45 * SECOND)
-                .vacuumStats(VA[ZPM], 35 * SECOND)
-            }
-            .build()
+        LanthanumGroupAlloyB = addMaterial(4051, "heavy_lanthanum_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Terbium, 1, Dysprosium, 1, Holmium, 1, Erbium, 1, Thulium, 1, Ytterbium, 1, Lutetium, 1, Scandium, 1)
+            flags(EXT2_METAL, GENERATE_FOIL)
+            blastProp(11400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 45 * SECOND,
+                      VA[ZPM], 35 * SECOND)
+        }
 
         // 4052 Actinium Group Alloy A
-        ActiniumGroupAlloyA = Material.Builder(4052, GTLiteMod.id("light_actinium_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Actinium, 1, Thorium, 1, Protactinium, 1, Uranium, 1, Neptunium, 1,
-                Plutonium239, 1, Americium, 1, Curium, 1)
-            .flags(STD_METAL, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(11400, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UHV], 45 * SECOND)
-                    .vacuumStats(VA[ZPM], 35 * SECOND)
-            }
-            .build()
-            .setFormula("AcThPaUNpPuAmCm", false)
+        ActiniumGroupAlloyA = addMaterial(4052, "light_actinium_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Actinium, 1, Thorium, 1, Protactinium, 1, Uranium, 1, Neptunium, 1, Plutonium239, 1, Americium, 1,
+                       Curium, 1)
+            flags(STD_METAL, GENERATE_FOIL)
+            blastProp(11400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 45 * SECOND,
+                      VA[ZPM], 35 * SECOND)
+        }
 
         // 4053 Actinium Group Alloy B
-        ActiniumGroupAlloyB = Material.Builder(4053, GTLiteMod.id("heavy_actinium_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Berkelium, 1, Californium, 1, Einsteinium, 1, Fermium, 1, Mendelevium, 1,
-                Nobelium, 1, Lawrencium, 1, Yttrium, 1)
-            .flags(STD_METAL, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(11400, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UHV], 45 * SECOND)
-                    .vacuumStats(VA[ZPM], 35 * SECOND)
-            }
-            .build()
+        ActiniumGroupAlloyB = addMaterial(4053, "heavy_actinium_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Berkelium, 1, Californium, 1, Einsteinium, 1, Fermium, 1, Mendelevium, 1, Nobelium, 1,
+                       Lawrencium, 1, Yttrium, 1)
+            flags(STD_METAL, GENERATE_FOIL)
+            blastProp(11400, GasTier.HIGHEST, // Adamantium
+                      VA[UHV], 45 * SECOND,
+                      VA[ZPM], 35 * SECOND)
+        }
 
         // 4054 Cinobite A243
-        CinobiteA243 = Material.Builder(4054, GTLiteMod.id("cinobite_a_243"))
-            .ingot()
-            .fluid()
-            .color(0xA9A9B5).iconSet(METALLIC)
-            .components(Zeron100, 8, Naquadria, 4, Gadolinium, 3, Aluminium, 2, Mercury, 1,
-                Tin, 1, Titanium, 6, Osmiridium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_RING,
-                GENERATE_SPRING_SMALL, GENERATE_DENSE)
-            .blast { r ->
-                r.temp(11465, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UEV], 1 * MINUTE + 25 * SECOND)
-                    .vacuumStats(VA[UHV], 55 * SECOND)
+        CinobiteA243 = addMaterial(4054, "cinobite_a_243")
+        {
+            ingot()
+            fluid()
+            color(0xA9A9B5).iconSet(METALLIC)
+            components(Zeron100, 8, Naquadria, 4, Gadolinium, 3, Aluminium, 2, Mercury, 1, Tin, 1, Titanium, 6, Osmiridium, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_RING, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_DENSE)
+            blastProp(11465, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 1 * MINUTE + 25 * SECOND,
+                      VA[UHV], 55 * SECOND)
+            toolProp(30.0F, 144.0F, 9760, 9)
+            {
+                attackSpeed(0.5F)
+                enchantability(38)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(30.0F, 144.0F, 9760, 9)
-                .attackSpeed(0.5F).enchantability(38)
-                .magnetic()
-                .build())
-            .rotorStats(22.0F, 15F, 6400)
-            .build()
+            rotorProp(22.0F, 15F, 6400)
+        }
 
         // 4055 Lafium
-        Lafium = Material.Builder(4055, GTLiteMod.id("lafium"))
-            .ingot()
-            .fluid()
-            .color(0x0D0D60).iconSet(SHINY)
-            .components(HastelloyN, 8, NaquadahAlloy, 4, Samarium, 2, Tungsten, 4, Argon, 2,
-                Aluminium, 6, Nickel, 8, Carbon, 2)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL)
-            .blast { r ->
-                r.temp(12865, GasTier.HIGHEST) // Adamantium
-                    .blastStats(VA[UEV], 45 * SECOND)
-                    .vacuumStats(VA[UHV], 22 * SECOND + 10 * TICK)
-            }
-            .fluidPipeProperties(10640, 960, true, true, true, true)
-            .build()
+        Lafium = addMaterial(4055, "lafium")
+        {
+            ingot()
+            fluid()
+            color(0x0D0D60).iconSet(SHINY)
+            components(HastelloyN, 8, NaquadahAlloy, 4, Samarium, 2, Tungsten, 4, Argon, 2, Aluminium, 6, Nickel, 8, Carbon, 2)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL)
+            blastProp(12865, GasTier.HIGHEST, // Adamantium
+                      VA[UEV], 45 * SECOND,
+                      VA[UHV], 22 * SECOND + 10 * TICK)
+            fluidPipeProp(10640, 960, gasProof = true, acidProof = true, cryoProof = true, plasmaProof = true)
+        }
 
         // 4056 Alkali Group Alloy
-        AlkaliGroupAlloy = Material.Builder(4056, GTLiteMod.id("alkali_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(SHINY)
-            .components(Lithium, 1, Sodium, 1, Potassium, 1, Rubidium, 1, Caesium, 1, Francium, 1)
-            .blast { b ->
-                b.temp(6600, GasTier.HIGH) // Naquadah
-                    .blastStats(VA[IV], 20 * SECOND)
-                    .vacuumStats(VA[HV], 10 * SECOND)
-            }
-            .build()
+        AlkaliGroupAlloy = addMaterial(4056, "alkali_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(SHINY)
+            components(Lithium, 1, Sodium, 1, Potassium, 1, Rubidium, 1, Caesium, 1, Francium, 1)
+            blastProp(6600, GasTier.HIGH, // Naquadah
+                      VA[IV], 20 * SECOND,
+                      VA[HV], 10 * SECOND)
+        }
 
         // 4057 Alkali Earth Group Alloy
-        AlkaliEarthGroupAlloy = Material.Builder(4057, GTLiteMod.id("alkali_earth_group_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(SHINY)
-            .components(Beryllium, 1, Magnesium, 1, Calcium, 1, Strontium, 1, Barium, 1, Radium, 1)
-            .blast { b ->
-                b.temp(7400, GasTier.HIGH) // Trinium (Naquadah)
-                    .blastStats(VA[LuV], 25 * SECOND)
-                    .vacuumStats(VA[EV], 15 * SECOND)
-            }
-            .build()
+        AlkaliEarthGroupAlloy = addMaterial(4057, "alkali_earth_group_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(SHINY)
+            components(Beryllium, 1, Magnesium, 1, Calcium, 1, Strontium, 1, Barium, 1, Radium, 1)
+            blastProp(7400, GasTier.HIGH, // Trinium
+                      VA[LuV], 25 * SECOND,
+                      VA[EV], 15 * SECOND)
+        }
 
         // 4058 Light Transition Alloy
-        TransitionAlloyA = Material.Builder(4058, GTLiteMod.id("light_transition_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Titanium, 1, Vanadium, 1, Chrome, 1, Manganese, 1, Iron, 1, Cobalt, 1,
-                Nickel, 1, Copper, 1)
-            .flags(GENERATE_ROD, GENERATE_LONG_ROD)
-            .blast { b ->
-                b.temp(8800, GasTier.HIGH) // Trinium
-                    .blastStats(VA[ZPM], 30 * SECOND)
-                    .vacuumStats(VA[IV], 20 * SECOND)
-            }
-            .build()
+        TransitionAlloyA = addMaterial(4058, "light_transition_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Titanium, 1, Vanadium, 1, Chrome, 1, Manganese, 1, Iron, 1, Cobalt, 1, Nickel, 1, Copper, 1)
+            flags(GENERATE_ROD, GENERATE_LONG_ROD)
+            blastProp(8800, GasTier.HIGH, // Trinium
+                      VA[ZPM], 30 * SECOND,
+                      VA[IV], 20 * SECOND)
+        }
 
         // 4059 Heavy Transition Alloy
-        TransitionAlloyB = Material.Builder(4059, GTLiteMod.id("heavy_transition_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Aluminium, 1, Zinc, 1, Gallium, 1, Germanium, 1, Cadmium, 1, Indium, 1,
-                Tin, 1, Antimony, 1)
-            .blast { b ->
-                b.temp(8800, GasTier.HIGH) // Trinium
-                    .blastStats(VA[ZPM], 30 * SECOND)
-                    .vacuumStats(VA[IV], 20 * SECOND)
-            }
-            .build()
+        TransitionAlloyB = addMaterial(4059, "heavy_transition_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Aluminium, 1, Zinc, 1, Gallium, 1, Germanium, 1, Cadmium, 1, Indium, 1, Tin, 1, Antimony, 1)
+            blastProp(8800, GasTier.HIGH, // Trinium
+                      VA[ZPM], 30 * SECOND,
+                      VA[IV], 20 * SECOND)
+        }
 
         // 4060 Transition Alloy
-        TransitionAlloy = Material.Builder(4060, GTLiteMod.id("transition_alloy"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(TransitionAlloyA, 1, TransitionAlloyB, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("TiVCrMnFeCoNiCuAlZnGaGeCdInSnSb", true)
+        TransitionAlloy = addMaterial(4060, "transition_alloy")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(TransitionAlloyA, 1, TransitionAlloyB, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 4061 Refractory Alloy
-        RefractoryAlloy = Material.Builder(4061, GTLiteMod.id("refractory_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(DULL)
-            .components(Zirconium, 1, Niobium, 1, Molybdenum, 1, Technetium, 1, Hafnium, 1, Tantalum, 1,
-                Tungsten, 1, Rhenium, 1)
-            .blast { b ->
-                b.temp(9900, GasTier.HIGHER) // Tritanium
-                    .blastStats(VA[UV], 35 * SECOND)
-                    .vacuumStats(VA[LuV], 25 * SECOND)
-            }
-            .build()
+        RefractoryAlloy = addMaterial(4061, "refractory_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(DULL)
+            components(Zirconium, 1, Niobium, 1, Molybdenum, 1, Technetium, 1, Hafnium, 1, Tantalum, 1, Tungsten, 1,
+                       Rhenium, 1)
+            blastProp(9900, GasTier.HIGHER, // Tritanium
+                      VA[UV], 35 * SECOND,
+                      VA[LuV], 25 * SECOND)
+        }
 
         // 4062 Toxic Alloy
-        ToxicAlloy = Material.Builder(4062, GTLiteMod.id("toxic_alloy"))
-            .ingot()
-            .fluid()
-            .colorAverage().iconSet(METALLIC)
-            .components(Arsenic, 1, Tellurium, 1, Mercury, 1, Thallium, 1, Lead, 1, Bismuth, 1, Polonium, 1,
-                Astatine, 1)
-            .blast { b ->
-                b.temp(10800, GasTier.HIGHEST) // Tritanium
-                .blastStats(VA[UHV], 40 * SECOND)
-                .vacuumStats(VA[ZPM], 30 * SECOND)
-            }
-            .build()
+        ToxicAlloy = addMaterial(4062, "toxic_alloy")
+        {
+            ingot()
+            fluid()
+            colorAverage().iconSet(METALLIC)
+            components(Arsenic, 1, Tellurium, 1, Mercury, 1, Thallium, 1, Lead, 1, Bismuth, 1, Polonium, 1, Astatine, 1)
+            blastProp(10800, GasTier.HIGHEST, // Tritanium
+                      VA[UHV], 40 * SECOND,
+                      VA[ZPM], 30 * SECOND)
+        }
 
         // 4063 Rare Earth Alloy
-        RareEarthAlloy = Material.Builder(4063, GTLiteMod.id("rare_earth_alloy"))
-            .dust()
-            .colorAverage().iconSet(METALLIC)
-            .components(LanthanumGroupAlloyA, 1, LanthanumGroupAlloyB, 1, ActiniumGroupAlloyA, 1,
-                ActiniumGroupAlloyB, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
-            .setFormula("LaCePrNdPmSmEuGdTbDyHoErTmYbLuScYAcThPaUNpPuAmCmBkCfEsFmMdNoLr", true)
+        RareEarthAlloy = addMaterial(4063, "rare_earth_alloy")
+        {
+            dust()
+            colorAverage().iconSet(METALLIC)
+            components(LanthanumGroupAlloyA, 1, LanthanumGroupAlloyB, 1, ActiniumGroupAlloyA, 1, ActiniumGroupAlloyB, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 4064 Light Non-Metallic Mixture
-        NonMetallicMixtureA = Material.Builder(4064, GTLiteMod.id("light_non_metallic_mixture"))
-            .gas(FluidBuilder()
-                .name("gregtech.fluid.generic"))
-            .colorAverage()
-            .components(Hydrogen, 1, Nitrogen, 1, Oxygen, 1, Fluorine, 1, Chlorine, 1, Bromine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NonMetallicMixtureA = addMaterial(4064, "light_non_metallic_mixture")
+        {
+            gas(FluidBuilder().name("gregtech.fluid.generic"))
+            colorAverage()
+            components(Hydrogen, 1, Nitrogen, 1, Oxygen, 1, Fluorine, 1, Chlorine, 1, Bromine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 4065 Heavy Non-Metallic Mixture
-        NonMetallicMixtureB = Material.Builder(4065, GTLiteMod.id("heavy_non_metallic_mixture"))
-            .liquid()
-            .colorAverage()
-            .components(Boron, 1, Carbon, 1, Silicon, 1, Phosphorus, 1, Sulfur, 1, Selenium, 1,
-                Iodine, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NonMetallicMixtureB = addMaterial(4065, "heavy_non_metallic_mixture")
+        {
+            liquid()
+            colorAverage()
+            components(Boron, 1, Carbon, 1, Silicon, 1, Phosphorus, 1, Sulfur, 1, Selenium, 1, Iodine, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 4066 Noble Gas Mixture
-        NobleGasMixture = Material.Builder(4066, GTLiteMod.id("noble_gas_mixture"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .colorAverage()
-            .components(Helium, 1, Neon, 1, Argon, 1, Krypton, 1, Xenon, 1, Radon, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        NobleGasMixture = addMaterial(4066, "noble_gas_mixture")
+        {
+            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            colorAverage()
+            components(Helium, 1, Neon, 1, Argon, 1, Krypton, 1, Xenon, 1, Radon, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 4067 Periodicium
-        Periodicium = Material.Builder(4067, GTLiteMod.id("periodicium"))
-            .ingot()
-            .fluid()
-            .color(0x3D4BF6).iconSet(BRIGHT)
-            .components(AlkaliGroupAlloy, 1, AlkaliEarthGroupAlloy, 1, TransitionAlloy, 1,
-                RefractoryAlloy, 1, PreciousMetalAlloy, 1, ToxicAlloy, 1, RareEarthAlloy, 1,
-                SuperheavyAlloyA, 1, SuperheavyAlloyB, 1, NonMetallicMixtureA, 1,
-                NonMetallicMixtureB, 1, NobleGasMixture, 1)
-            .flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_SPRING,
-                GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
-            .cableProperties(V[OpV], 118, 2)
-            .blast { b ->
-                b.temp(18000, GasTier.HIGHEST) // Space Time
-                    .blastStats(VA[UXV], 10 * SECOND)
-                    .vacuumStats(VA[UEV], 2 * SECOND + 10 * TICK)
-            }
-            .build()
-            .setFormula("HHeLiBeBCNOFNeNaMgAlSiPSClArKCaScTiVCrMnFeCoNiCuZnGaGe"
-                + "AsSeBrKrRbSrYZrNbMoTcRuRhPdAgCdInSnSbTeIXeCsBaLaCePrNdPm"
-                + "SmEuGdTbDyHoErTmYbLuHfTaWReOsIrPtAuHgTlPbBiPoAtRnFrRaAcTh"
-                + "PaUNpPuAmCmBkCfEsFmMdNoLrRfDbSgBhHsMtDsRgCnNhFlMcLvTsOg")
+        Periodicium = addMaterial(4067, "periodicium")
+        {
+            ingot()
+            fluid()
+            color(0x3D4BF6).iconSet(BRIGHT)
+            components(AlkaliGroupAlloy, 1, AlkaliEarthGroupAlloy, 1, TransitionAlloy, 1, RefractoryAlloy, 1,
+                       PreciousMetalAlloy, 1, ToxicAlloy, 1, RareEarthAlloy, 1, SuperheavyAlloyA, 1, SuperheavyAlloyB, 1,
+                       NonMetallicMixtureA, 1, NonMetallicMixtureB, 1, NobleGasMixture, 1)
+            flags(EXT2_METAL, DISABLE_DECOMPOSITION, NO_ALLOY_BLAST_RECIPES, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_FINE_WIRE)
+            cableProp(V[OpV], 118, 2)
+            blastProp(18000, GasTier.HIGHEST, // Space Time
+                      VA[UXV], 10 * SECOND,
+                      VA[UEV], 2 * SECOND + 10 * TICK)
+        }
 
         // 4068 Legendarium
-        Legendarium = Material.Builder(4068, GTLiteMod.id("legendarium"))
-            .ingot()
-            .fluid()
-            .color(0xF58FDA).iconSet(ENRICHED)
-            .components(Naquadria, 1, Trinium, 1, Duranium, 1, Tritanium, 1, Neutronium, 1,
-                Adamantium, 1, Vibranium, 1, Taranium, 1)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR,
-                GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL)
-            .blast { b ->
-                b.temp(17800, GasTier.HIGHEST) // Space Time
-                    .blastStats(VA[UXV], 1 * MINUTE + 20 * SECOND)
-                    .vacuumStats(VA[UEV], 40 * SECOND)
+        Legendarium = addMaterial(4068, "legendarium")
+        {
+            ingot()
+            fluid()
+            color(0xF58FDA).iconSet(ENRICHED)
+            components(Naquadria, 1, Trinium, 1, Duranium, 1, Tritanium, 1, Neutronium, 1, Adamantium, 1, Vibranium, 1,
+                       Taranium, 1)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_RING,
+                  GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL)
+            blastProp(17800, GasTier.HIGHEST, // Space Time
+                      VA[UXV], 1 * MINUTE + 20 * SECOND,
+                      VA[UEV], 40 * SECOND)
+            toolProp(180.0F, 90.0F, 97600, 20)
+            {
+                attackSpeed(0.4F)
+                enchantability(42)
+                magnetic()
             }
-            .toolStats(MaterialToolProperty.Builder.of(180.0F, 90.0F, 97600, 20)
-                .attackSpeed(0.4F).enchantability(42)
-                .magnetic()
-                .build())
-            .build()
+        }
 
         // 4069 Boron Francium Carbide Superconductor
-        BoronFranciumCarbideSuperconductor = Material.Builder(4069, GTLiteMod.id("boron_francium_carbide_superconductor"))
-            .ingot()
-            .fluid()
-            .color(0x359FFC).iconSet(BRIGHT)
-            .components(HeavyConductiveMixture, 17, CaesiumCeriumCobaltIndium, 14, MagnetoResonatic, 4, Taranium, 2, PlutoniumPhosphide, 2,
-                        MetastableHassium, 1, MetastableOganesson, 1)
-            .flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .blast { b ->
-                b.temp(17901, GasTier.HIGHEST) // Space Time
-                    .blastStats(VA[UXV], 4 * MINUTE + 25 * SECOND)
-                    .vacuumStats(VA[UIV], 3 * MINUTE + 12 * SECOND)
-            }
-            .cableProperties(V[UXV], 128, 0, true)
-            .build()
+        BoronFranciumCarbideSuperconductor = addMaterial(4069, "boron_francium_carbide_superconductor")
+        {
+            ingot()
+            fluid()
+            color(0x359FFC).iconSet(BRIGHT)
+            components(HeavyConductiveMixture, 17, CaesiumCeriumCobaltIndium, 14, MagnetoResonatic, 4, Taranium, 2,
+                       PlutoniumPhosphide, 2, MetastableHassium, 1, MetastableOganesson, 1)
+            flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(17901, GasTier.HIGHEST, // Space Time
+                      VA[UXV], 4 * MINUTE + 25 * SECOND,
+                      VA[UIV], 3 * MINUTE + 12 * SECOND)
+            cableProp(V[UXV], 128, 0, true)
+        }
 
         // 4070 Neutronium Superconductor
-        NeutroniumSuperconductor = Material.Builder(4070, GTLiteMod.id("neutronium_superconductor"))
-            .ingot()
-            .fluid()
-            .color(0xF8BCD5).iconSet(BRIGHT)
-            .components(CosmicNeutronium, 4, Neutronium, 5, Legendarium, 5, Bohrium, 5, NeutroniumDopedCarbonNanotube, 4,
-                        TantalumHafniumSeaborgiumCarbide, 3, IndiumGalliumPhosphide, 3,
-                        RheniumHassiumThalliumIsophtaloylbisdiethylthioureaHexafluorophosphate, 12)
-            .blast { b ->
-                b.temp(18501, GasTier.HIGHEST) // Eternity
-                    .blastStats(VA[OpV], 6 * MINUTE + 15 * SECOND)
-                    .vacuumStats(VA[UIV], 4 * MINUTE)
-            }
-            .cableProperties(V[OpV], 256, 0, true)
-            .flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .build()
+        NeutroniumSuperconductor = addMaterial(4070, "neutronium_superconductor")
+        {
+            ingot()
+            fluid()
+            color(0xF8BCD5).iconSet(BRIGHT)
+            components(CosmicNeutronium, 4, Neutronium, 5, Legendarium, 5, Bohrium, 5, NeutroniumDopedCarbonNanotube, 4,
+                       TantalumHafniumSeaborgiumCarbide, 3, IndiumGalliumPhosphide, 3,
+                       RheniumHassiumThalliumIsophtaloylbisdiethylthioureaHexafluorophosphate, 12)
+            flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            blastProp(18501, GasTier.HIGHEST, // Eternity
+                      VA[OpV], 6 * MINUTE + 15 * SECOND,
+                      VA[UIV], 4 * MINUTE)
+            cableProp(V[OpV], 256, 0, true)
+        }
 
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteSecondDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteSecondDegreeMaterials.kt
@@ -15,7 +15,6 @@ import gregtech.api.GTValues.UXV
 import gregtech.api.GTValues.V
 import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.ZPM
-import gregtech.api.fluids.FluidBuilder
 import gregtech.api.unification.material.Materials.Actinium
 import gregtech.api.unification.material.Materials.Aluminium
 import gregtech.api.unification.material.Materials.Americium
@@ -275,7 +274,9 @@ import gregtechlite.gtlitecore.api.TICK
 import gregtechlite.gtlitecore.api.extension.blastProp
 import gregtechlite.gtlitecore.api.extension.cableProp
 import gregtechlite.gtlitecore.api.extension.fluidPipeProp
+import gregtechlite.gtlitecore.api.extension.gas
 import gregtechlite.gtlitecore.api.extension.itemPipeProp
+import gregtechlite.gtlitecore.api.extension.liquid
 import gregtechlite.gtlitecore.api.extension.rotorProp
 import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BoronFranciumCarbideSuperconductor
@@ -771,7 +772,11 @@ object GTLiteSecondDegreeMaterials
         HalkoniteSteel = addMaterial(4035, "halkonite_steel")
         {
             ingot()
-            liquid(FluidBuilder().customStill().translation("gtlitecore.fluid.molten"))
+            liquid()
+            {
+                translation("gtlitecore.fluid.molten")
+                customStill()
+            }
             iconSet(HALKONITE)
             components(CosmicNeutronium, 2, Tairitsium, 2, RedPhosphorus, 2, TitanSteel, 1, Infinity, 1)
             flags(EXT2_METAL, NO_UNIFICATION, GENERATE_FOIL, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL,
@@ -1189,7 +1194,10 @@ object GTLiteSecondDegreeMaterials
         // 4064 Light Non-Metallic Mixture
         NonMetallicMixtureA = addMaterial(4064, "light_non_metallic_mixture")
         {
-            gas(FluidBuilder().name("gregtech.fluid.generic"))
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
             colorAverage()
             components(Hydrogen, 1, Nitrogen, 1, Oxygen, 1, Fluorine, 1, Chlorine, 1, Bromine, 1)
             flags(DISABLE_DECOMPOSITION)
@@ -1207,7 +1215,10 @@ object GTLiteSecondDegreeMaterials
         // 4066 Noble Gas Mixture
         NobleGasMixture = addMaterial(4066, "noble_gas_mixture")
         {
-            gas(FluidBuilder().translation("gregtech.fluid.generic"))
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
             colorAverage()
             components(Helium, 1, Neon, 1, Argon, 1, Krypton, 1, Xenon, 1, Radon, 1)
             flags(DISABLE_DECOMPOSITION)

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteThirdDegreeMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteThirdDegreeMaterials.kt
@@ -1,7 +1,6 @@
 package gregtechlite.gtlitecore.api.unification.material
 
 import gregtech.api.fluids.FluidBuilder
-import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.Materials.Air
 import gregtech.api.unification.material.Materials.Andradite
 import gregtech.api.unification.material.Materials.BandedIron
@@ -35,7 +34,8 @@ import gregtech.api.unification.material.info.MaterialFlags.DISABLE_DECOMPOSITIO
 import gregtech.api.unification.material.info.MaterialFlags.NO_SMASHING
 import gregtech.api.unification.material.info.MaterialIconSet.DULL
 import gregtech.api.unification.material.info.MaterialIconSet.ROUGH
-import gregtechlite.gtlitecore.GTLiteMod
+import gregtechlite.gtlitecore.api.extension.gas
+import gregtechlite.gtlitecore.api.extension.liquid
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Albite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Augite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Azurite
@@ -92,236 +92,300 @@ object GTLiteThirdDegreeMaterials
     {
 
         // 6001 Limestone
-        Limestone = Material.Builder(6001, GTLiteMod.id("limestone"))
-            .dust()
-            .color(0xA9A9A9).iconSet(ROUGH)
-            .components(Calcite, 4, Dolomite, 1, Quicklime, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(CaCO3)4(CaMg(CO3)2)?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        Limestone = addMaterial(6001, "limestone")
+        {
+            dust()
+            color(0xA9A9A9).iconSet(ROUGH)
+            components(Calcite, 4, Dolomite, 1, Quicklime, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6002 Komatiite
-        Komatiite = Material.Builder(6002, GTLiteMod.id("komatiite"))
-            .dust()
-            .color(0xBCB073).iconSet(ROUGH)
-            .components(Olivine, 2, Magnesite, 1, Flint, 1, DarkAsh, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(Mg2Fe(SiO2)2)2(MgCO3)(SiO2)?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        Komatiite = addMaterial(6002, "komatiite")
+        {
+            dust()
+            color(0xBCB073).iconSet(ROUGH)
+            components(Olivine, 2, Magnesite, 1, Flint, 1, DarkAsh, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6003 Green Schist
-        GreenSchist = Material.Builder(6003, GTLiteMod.id("green_schist"))
-            .dust()
-            .color(0x56AE65).iconSet(ROUGH)
-            .components(Tanzanite, 2, Quartzite, 2, Talc, 1, Calcite, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(Ca2Al3Si3HO13)2(SiO2)2(Mg3Si4H2O12)?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        GreenSchist = addMaterial(6003, "green_schist")
+        {
+            dust()
+            color(0x56AE65).iconSet(ROUGH)
+            components(Tanzanite, 2, Quartzite, 2, Talc, 1, Calcite, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6004 Blue Schist
-        BlueSchist = Material.Builder(6004, GTLiteMod.id("blue_schist"))
-            .dust()
-            .color(0x537FAC).iconSet(ROUGH)
-            .components(Azurite, 3, Sodalite, 2, Iron, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(Cu3(CO3)2(OH)2)3(Al3Si3Na4Cl)2?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        BlueSchist = addMaterial(6004, "blue_schist")
+        {
+            dust()
+            color(0x537FAC).iconSet(ROUGH)
+            components(Azurite, 3, Sodalite, 2, Iron, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6005 Kimberlite
-        Kimberlite = Material.Builder(6005, GTLiteMod.id("kimberlite"))
-            .dust()
-            .color(0x201313).iconSet(ROUGH)
-            .components(Forsterite, 3, Augite, 3, Andradite, 2, Lizardite, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(Mg2(SiO4))3((Ca2MgFe)(MgFe)2(Si2O6)4)3(Ca3Fe2Si3O12)2?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        Kimberlite = addMaterial(6005, "kimberlite")
+        {
+            dust()
+            color(0x201313).iconSet(ROUGH)
+            components(Forsterite, 3, Augite, 3, Andradite, 2, Lizardite, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6006 Slate
-        Slate = Material.Builder(6006, GTLiteMod.id("slate"))
-            .dust()
-            .color(0x756869).iconSet(ROUGH)
-            .components(SiliconDioxide, 5, Muscovite, 2, Clinochlore, 2, Albite, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(SiO2)5(KAl2(AlSi3O10)(OH)2)2(Mg5Al2Si3O10(OH)8)2?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        Slate = addMaterial(6006, "slate")
+        {
+            dust()
+            color(0x756869).iconSet(ROUGH)
+            components(SiliconDioxide, 5, Muscovite, 2, Clinochlore, 2, Albite, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6007 Shale
-        Shale = Material.Builder(6007, GTLiteMod.id("shale"))
-            .dust()
-            .color(0x3F2E2F).iconSet(ROUGH)
-            .components(Calcite, 6, Clay, 2, SiliconDioxide, 1, Fluorite, 1)
-            .flags(NO_SMASHING, DISABLE_DECOMPOSITION) // Add Centrifuging recipe at CentrifugeRecipes#init().
-            .build()
-            .setFormula("(CaCO3)6(Na2LiAl2Si2(H2O)6)2(SiO2)(CaF2)?", true)
+        // Add Centrifuging recipe at CentrifugeRecipes.
+        Shale = addMaterial(6007, "shale")
+        {
+            dust()
+            color(0x3F2E2F).iconSet(ROUGH)
+            components(Calcite, 6, Clay, 2, SiliconDioxide, 1, Fluorite, 1)
+            flags(NO_SMASHING, DISABLE_DECOMPOSITION)
+        }
 
         // 6008-6010 is for stone types addition in the future.
         // ...
 
         // 6011 Blazing Pyrotheum
-        BlazingPyrotheum = Material.Builder(6011, GTLiteMod.id("blazing_pyrotheum"))
-            .dust()
-            .liquid(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(4000)
-                .customFlow().customStill())
-            .iconSet(PYROTHEUM)
-            .components(Blaze, 2, Redstone, 1, Sulfur, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        BlazingPyrotheum = addMaterial(6011, "blazing_pyrotheum")
+        {
+            dust()
+            liquid()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(4000)
+                customFlow()
+                customStill()
+            }
+            iconSet(PYROTHEUM)
+            components(Blaze, 2, Redstone, 1, Sulfur, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 6012 Gelid Cryotheum
-        GelidCryotheum = Material.Builder(6012, GTLiteMod.id("gelid_cryotheum"))
-            .dust()
-            .liquid(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(2)
-                .customFlow().customStill())
-            .iconSet(CRYOTHEUM)
-            .components(Ice, 2, Electrotine, 1, Water, 1)
-            .flags(DECOMPOSITION_BY_ELECTROLYZING)
-            .build()
-            .setFormula("((Si(FeS2)5(CrAl2O3)Hg3)(AgAu))(H2O)3", true)
+        GelidCryotheum = addMaterial(6012, "gelid_cryotheum")
+        {
+            dust()
+            liquid()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(2)
+                customFlow()
+                customStill()
+            }
+            iconSet(CRYOTHEUM)
+            components(Ice, 2, Electrotine, 1, Water, 1)
+            flags(DECOMPOSITION_BY_ELECTROLYZING)
+        }
 
         // 6013 Tectonic Petrotheum
-        TectonicPetrotheum = Material.Builder(6013, GTLiteMod.id("tectonic_petrotheum"))
-            .dust()
-            .liquid(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(350)
-                .customFlow().customFlow())
-            .iconSet(PETROTHEUM)
-            .components(Clay, 2, Obsidian, 1, Stone, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        TectonicPetrotheum = addMaterial(6013, "tectonic_petrotheum")
+        {
+            dust()
+            liquid()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(350)
+                customFlow()
+                customFlow()
+            }
+            iconSet(PETROTHEUM)
+            components(Clay, 2, Obsidian, 1, Stone, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 6014 Zephyrean Aerotheum
-        ZephyreanAerotheum = Material.Builder(6014, GTLiteMod.id("zephyrean_aerotheum"))
-            .dust()
-            .liquid(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(600)
-                .customFlow().customStill())
-            .iconSet(AEROTHEUM)
-            .components(SiliconDioxide, 2, Saltpeter, 1, Air, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        ZephyreanAerotheum = addMaterial(6014, "zephyrean_aerotheum")
+        {
+            dust()
+            liquid()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(600)
+                customFlow()
+                customStill()
+            }
+            iconSet(AEROTHEUM)
+            components(SiliconDioxide, 2, Saltpeter, 1, Air, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6015 Sienna
-        Sienna = Material.Builder(6015, GTLiteMod.id("sienna"))
-            .dust()
-            .color(0x4A3724)
-            .components(ManganeseMonoxide, 1, BandedIron, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        Sienna = addMaterial(6015, "sienna")
+        {
+            dust()
+            color(0x4A3724)
+            components(ManganeseMonoxide, 1, BandedIron, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 6016 Burnt Sienna
-        BurntSienna = Material.Builder(6016, GTLiteMod.id("burnt_sienna"))
-            .dust()
-            .color(0x662E2E)
-            .components(ManganeseMonoxide, 1, BandedIron, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        BurntSienna = addMaterial(6016, "burnt_sienna")
+        {
+            dust()
+            color(0x662E2E)
+            components(ManganeseMonoxide, 1, BandedIron, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 6017 Manganese Blue
-        ManganeseBlue = Material.Builder(6017, GTLiteMod.id("manganese_blue"))
-            .dust()
-            .color(0x80ABC5).iconSet(ROUGH)
-            .components(Barite, 1, BariumManganate, 1)
-            .flags(DECOMPOSITION_BY_CENTRIFUGING)
-            .build()
+        ManganeseBlue = addMaterial(6017, "manganese_blue")
+        {
+            dust()
+            color(0x80ABC5).iconSet(ROUGH)
+            components(Barite, 1, BariumManganate, 1)
+            flags(DECOMPOSITION_BY_CENTRIFUGING)
+        }
 
         // 6018-6025 for some misc materials in the future.
         // ...
 
         // 6026 Superheated Steam
-        SuperheatedSteam = Material.Builder(6026, GTLiteMod.id("superheated_steam"))
-            .gas(FluidBuilder().temperature(573))
-            .color(0xC4C4C4).iconSet(DULL)
-            .components(Water, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuperheatedSteam = addMaterial(6026, "superheated_steam")
+        {
+            gas()
+            {
+                temperature(573)
+            }
+            color(0xC4C4C4).iconSet(DULL)
+            components(Water, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6027 Superheated Eutatic Sodium Potassium
-        SuperheatedSodiumPotassiumEutatic = Material.Builder(6027, GTLiteMod.id("superheated_sodium_potassium_eutatic"))
-            .liquid(FluidBuilder().temperature(758))
-            .color(SodiumPotassiumEutatic.materialRGB).iconSet(DULL)
-            .components(SodiumPotassiumEutatic, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuperheatedSodiumPotassiumEutatic = addMaterial(6027, "superheated_sodium_potassium_eutatic")
+        {
+            liquid()
+            {
+                temperature(758)
+            }
+            color(SodiumPotassiumEutatic.materialRGB).iconSet(DULL)
+            components(SodiumPotassiumEutatic, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6028 Superheated Eutatic Lead Bismuth
-        SuperheatedLeadBismuthEutatic = Material.Builder(6028, GTLiteMod.id("superheated_lead_bismuth_eutatic"))
-            .liquid(FluidBuilder().temperature(1643))
-            .color(LeadBismuthEutatic.materialRGB).iconSet(DULL)
-            .components(LeadBismuthEutatic, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuperheatedLeadBismuthEutatic = addMaterial(6028, "superheated_lead_bismuth_eutatic")
+        {
+            liquid(FluidBuilder().temperature(1643))
+            color(LeadBismuthEutatic.materialRGB).iconSet(DULL)
+            components(LeadBismuthEutatic, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6029 Superheated Lithium Sodium Potassium Fluorides
-        SuperheatedLithiumSodiumPotassiumFluorides = Material.Builder(6029, GTLiteMod.id("superheated_lithium_sodium_potassium_fluorides"))
-            .liquid(FluidBuilder().temperature(1543))
-            .color(LithiumSodiumPotassiumFluorides.materialRGB).iconSet(DULL)
-            .components(LithiumSodiumPotassiumFluorides, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuperheatedLithiumSodiumPotassiumFluorides = addMaterial(6029, "superheated_lithium_sodium_potassium_fluorides")
+        {
+            liquid()
+            {
+                temperature(1543)
+            }
+            color(LithiumSodiumPotassiumFluorides.materialRGB).iconSet(DULL)
+            components(LithiumSodiumPotassiumFluorides, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6030 Superheated Lithium Beryllium Fluorides
-        SuperheatedLithiumBerylliumFluorides = Material.Builder(6030, GTLiteMod.id("superheated_lithium_beryllium_fluorides"))
-            .liquid(FluidBuilder().temperature(1403))
-            .color(LithiumBerylliumFluorides.materialRGB).iconSet(DULL)
-            .components(LithiumBerylliumFluorides, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SuperheatedLithiumBerylliumFluorides = addMaterial(6030, "superheated_lithium_beryllium_fluorides")
+        {
+            liquid()
+            {
+                temperature(1403)
+            }
+            color(LithiumBerylliumFluorides.materialRGB).iconSet(DULL)
+            components(LithiumBerylliumFluorides, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6031 Supercritical Steam
-        SupercriticalSteam = Material.Builder(6031, GTLiteMod.id("supercritical_steam"))
-            .gas(FluidBuilder().temperature(873))
-            .color(0xC4C4C4).iconSet(SUPERCRITICAL)
-            .components(Water, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SupercriticalSteam = addMaterial(6031, "supercritical_steam")
+        {
+            gas()
+            {
+                temperature(873)
+            }
+            color(0xC4C4C4).iconSet(SUPERCRITICAL)
+            components(Water, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6032 Supercritical Eutatic Sodium Potassium
-        SupercriticalSodiumPotassiumEutatic = Material.Builder(6032, GTLiteMod.id("supercritical_sodium_potassium_eutatic"))
-            .liquid(FluidBuilder().temperature(1058))
-            .color(SodiumPotassiumEutatic.materialRGB).iconSet(SUPERCRITICAL)
-            .components(SodiumPotassiumEutatic, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SupercriticalSodiumPotassiumEutatic = addMaterial(6032, "supercritical_sodium_potassium_eutatic")
+        {
+            liquid()
+            {
+                temperature(1058)
+            }
+            color(SodiumPotassiumEutatic.materialRGB).iconSet(SUPERCRITICAL)
+            components(SodiumPotassiumEutatic, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6033 Supercritical Eutatic Lead Bismuth
-        SupercriticalLeadBismuthEutatic = Material.Builder(6033, GTLiteMod.id("supercritical_lead_bismuth_eutatic"))
-            .liquid(FluidBuilder().temperature(1943))
-            .color(LeadBismuthEutatic.materialRGB).iconSet(SUPERCRITICAL)
-            .components(LeadBismuthEutatic, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SupercriticalLeadBismuthEutatic = addMaterial(6033, "supercritical_lead_bismuth_eutatic")
+        {
+            liquid()
+            {
+                temperature(1943)
+            }
+            color(LeadBismuthEutatic.materialRGB).iconSet(SUPERCRITICAL)
+            components(LeadBismuthEutatic, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6034 Supercritical Lithium Sodium Potassium Fluorides
-        SupercriticalLithiumSodiumPotassiumFluorides = Material.Builder(6034, GTLiteMod.id("supercritical_lithium_sodium_potassium_fluorides"))
-            .liquid(FluidBuilder().temperature(1843))
-            .color(LithiumSodiumPotassiumFluorides.materialRGB).iconSet(SUPERCRITICAL)
-            .components(LithiumSodiumPotassiumFluorides, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SupercriticalLithiumSodiumPotassiumFluorides = addMaterial(6034, "supercritical_lithium_sodium_potassium_fluorides")
+        {
+            liquid()
+            {
+                temperature(1843)
+            }
+            color(LithiumSodiumPotassiumFluorides.materialRGB).iconSet(SUPERCRITICAL)
+            components(LithiumSodiumPotassiumFluorides, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 6035 Supercritical Lithium Beryllium Fluorides
-        SupercriticalLithiumBerylliumFluorides = Material.Builder(6035, GTLiteMod.id("supercritical_lithium_beryllium_fluorides"))
-            .liquid(FluidBuilder().temperature(1703))
-            .color(LithiumBerylliumFluorides.materialRGB).iconSet(SUPERCRITICAL)
-            .components(LithiumBerylliumFluorides, 1)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SupercriticalLithiumBerylliumFluorides = addMaterial(6035, "supercritical_lithium_beryllium_fluorides")
+        {
+            liquid()
+            {
+                temperature(1703)
+            }
+            color(LithiumBerylliumFluorides.materialRGB).iconSet(SUPERCRITICAL)
+            components(LithiumBerylliumFluorides, 1)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // ...
 
         // 6051 Ferrosilite
-        Ferrosilite = Material.Builder(6051, GTLiteMod.id("ferrosilite"))
-            .dust(1)
-            .ore()
-            .color(0x97632A)
-            .components(Iron, 1, Silicon, 1, Oxygen, 3)
-            .build()
+        // Because GTCEu remove this material in 2.9.x version, nop...
+        Ferrosilite = addMaterial(6051, "ferrosilite")
+        {
+            dust(1)
+            ore()
+            color(0x97632A)
+            components(Iron, 1, Silicon, 1, Oxygen, 3)
+        }
 
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteUnknownCompositionMaterials.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/GTLiteUnknownCompositionMaterials.kt
@@ -2,8 +2,6 @@ package gregtechlite.gtlitecore.api.unification.material
 
 import gregtech.api.GTValues.MAX
 import gregtech.api.GTValues.V
-import gregtech.api.fluids.FluidBuilder
-import gregtech.api.unification.material.Material
 import gregtech.api.unification.material.Materials.EXT2_METAL
 import gregtech.api.unification.material.Materials.GreenSapphire
 import gregtech.api.unification.material.Materials.Ruby
@@ -30,11 +28,14 @@ import gregtech.api.unification.material.info.MaterialIconSet.DULL
 import gregtech.api.unification.material.info.MaterialIconSet.FINE
 import gregtech.api.unification.material.info.MaterialIconSet.METALLIC
 import gregtech.api.unification.material.info.MaterialIconSet.ROUGH
-import gregtech.api.unification.material.properties.MaterialToolProperty
-import gregtechlite.gtlitecore.GTLiteMod
 import gregtechlite.gtlitecore.api.SECOND
+import gregtechlite.gtlitecore.api.extension.cableProp
 import gregtechlite.gtlitecore.api.extension.colorAverage
-import gregtechlite.gtlitecore.api.translation.CommonI18n
+import gregtechlite.gtlitecore.api.extension.gas
+import gregtechlite.gtlitecore.api.extension.liquid
+import gregtechlite.gtlitecore.api.extension.plasma
+import gregtechlite.gtlitecore.api.extension.rotorProp
+import gregtechlite.gtlitecore.api.extension.toolProp
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AcidicSaltWater
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AlgaeMixture
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Antimatter
@@ -185,730 +186,893 @@ object GTLiteUnknownCompositionMaterials
     fun init()
     {
         // 12001 Latex
-        Latex = Material.Builder(12001, GTLiteMod.id("latex"))
-            .dust()
-            .liquid()
-            .color(0xFFFADA)
-            .build()
+        Latex = addMaterial(12001, "latex")
+        {
+            dust()
+            liquid()
+            color(0xFFFADA)
+        }
 
         // 12002 Resin
-        Resin = Material.Builder(12002, GTLiteMod.id("resin"))
-            .dust()
-            .liquid()
-            .color(0xB5803A)
-            .flags(FLAMMABLE)
-            .build()
+        Resin = addMaterial(12002, "resin")
+        {
+            dust()
+            liquid()
+            color(0xB5803A)
+            flags(FLAMMABLE)
+        }
 
         // 12003 Rainbow Sap
-        RainbowSap = Material.Builder(12003, GTLiteMod.id("rainbow_sap"))
-            .liquid(FluidBuilder().customStill())
-            .build()
+        RainbowSap = addMaterial(12003, "rainbow_sap")
+        {
+            liquid()
+            {
+                customStill()
+            }
+        }
 
         // 12004-12020 for other sap liquids.
         // ...
 
         // 12021 Blood
-        Blood = Material.Builder(12021, GTLiteMod.id("blood"))
-            .liquid()
-            .color(0x5C0606)
-            .build()
+        Blood = addMaterial(12021, "blood")
+        {
+            liquid()
+            color(0x5C0606)
+        }
 
         // 12022 Blood Cells
-        BloodCells = Material.Builder(12022, GTLiteMod.id("blood_cells"))
-            .liquid()
-            .color(0xAD2424).iconSet(DULL)
-            .build()
+        BloodCells = addMaterial(12022, "blood_cells")
+        {
+            liquid()
+            color(0xAD2424).iconSet(DULL)
+        }
 
         // 12023 Blood Plasma
-        BloodPlasma = Material.Builder(12023, GTLiteMod.id("blood_plasma"))
-            .liquid()
-            .color(0xE37171).iconSet(DULL)
-            .build()
+        BloodPlasma = addMaterial(12023, "blood_plasma")
+        {
+            liquid()
+            color(0xE37171).iconSet(DULL)
+        }
 
         // 12024 bFGF
-        BFGF = Material.Builder(12024, GTLiteMod.id("bfgf"))
-            .liquid()
-            .color(0xB365E0)
-            .build()
-            .setFormula("bFGF", false)
+        BFGF = addMaterial(12024, "bfgf")
+        {
+            liquid()
+            color(0xB365E0)
+        }
 
         // 12025 EGF
-        EGF = Material.Builder(12025, GTLiteMod.id("egf"))
-            .liquid()
-            .color(0x815799)
-            .build()
-            .setFormula("EGF", false) // C257H381N73O83S7 in reality world ^^.
+        // Chemical formula is C257H381N73O83S7 in reality world ^^.
+        EGF = addMaterial(12025, "egf")
+        {
+            liquid()
+            color(0x815799)
+        }
 
         // 12026 CAT
-        CAT = Material.Builder(12026, GTLiteMod.id("cat"))
-            .liquid()
-            .color(0xDB6596)
-            .build()
-            .setFormula("CAT", false)
+        CAT = addMaterial(12026, "cat")
+        {
+            liquid()
+            color(0xDB6596)
+        }
 
         // 12027 Kerogen
-        Kerogen = Material.Builder(12027, GTLiteMod.id("kerogen"))
-            .liquid(FluidBuilder().temperature(302))
-            .color(0xA7A7A7).iconSet(DULL)
-            .build()
+        Kerogen = addMaterial(12027, "kerogen")
+        {
+            liquid()
+            {
+                temperature(302)
+            }
+            color(0xA7A7A7).iconSet(DULL)
+        }
 
         // 12028 Paraffin
-        Paraffin = Material.Builder(12028, GTLiteMod.id("paraffin"))
-            .dust(0, 40 * SECOND)
-            .color(0xD2D2FA).iconSet(WAX)
-            .flags(FLAMMABLE)
-            .build()
+        Paraffin = addMaterial(12028, "paraffin")
+        {
+            dust(0, 40 * SECOND)
+            color(0xD2D2FA).iconSet(WAX)
+            flags(FLAMMABLE)
+        }
 
         // 12029 Bitumen
-        Bitumen = Material.Builder(12029, GTLiteMod.id("bitumen"))
-            .dust()
-            .color(0x2D2D05).iconSet(WAX)
-            .build()
+        Bitumen = addMaterial(12029, "bitumen")
+        {
+            dust()
+            color(0x2D2D05).iconSet(WAX)
+        }
 
         // 12030 for other misc biological materials
         // ...
 
         // 12031 Green Sapphire Juice
-        GreenSapphireJuice = Material.Builder(12031, GTLiteMod.id("green_sapphire_juice"))
-            .liquid()
-            .color(GreenSapphire.materialRGB)
-            .components(GreenSapphire.materialComponents)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        GreenSapphireJuice = addMaterial(12031, "green_sapphire_juice")
+        {
+            liquid()
+            color(GreenSapphire.materialRGB)
+            components(GreenSapphire.materialComponents)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 12032 Sapphire Juice
-        SapphireJuice = Material.Builder(12032, GTLiteMod.id("sapphire_juice"))
-            .liquid()
-            .color(Sapphire.materialRGB)
-            .components(Sapphire.materialComponents)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        SapphireJuice = addMaterial(12032, "sapphire_juice")
+        {
+            liquid()
+            color(Sapphire.materialRGB)
+            components(Sapphire.materialComponents)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 12033 Ruby Juice
-        RubyJuice = Material.Builder(12033, GTLiteMod.id("ruby_juice"))
-            .liquid()
-            .color(Ruby.materialRGB)
-            .components(Ruby.materialComponents)
-            .flags(DISABLE_DECOMPOSITION)
-            .build()
+        RubyJuice = addMaterial(12033, "ruby_juice")
+        {
+            liquid()
+            color(Ruby.materialRGB)
+            components(Ruby.materialComponents)
+            flags(DISABLE_DECOMPOSITION)
+        }
 
         // 12034-12039 for other gem slurries and juices.
         // ...
 
         // 12040 Greenhouse Gas
-        GreenhouseGas = Material.Builder(12040, GTLiteMod.id("greenhouse_gas"))
-            .gas(FluidBuilder().temperature(313))
-            .build()
-            .setFormula("N78O21Ar9?", true)
+        GreenhouseGas = addMaterial(12040, "greenhouse_gas")
+        {
+            gas()
+            {
+                temperature(313)
+            }
+        }
 
         // 12041 Grape Juice
-        GrapeJuice = Material.Builder(12041, GTLiteMod.id("grape_juice"))
-            .liquid()
-            .color(0x50C039)
-            .build()
+        GrapeJuice = addMaterial(12041, "grape_juice")
+        {
+            liquid()
+            color(0x50C039)
+        }
 
         // 12042 Red Wine
-        RedWine = Material.Builder(12042, GTLiteMod.id("red_wine"))
-            .liquid()
-            .color(0x7D0B07)
-            .build()
+        RedWine = addMaterial(12042, "red_wine")
+        {
+            liquid()
+            color(0x7D0B07)
+        }
 
         // 12043 Vinegar
-        Vinegar = Material.Builder(12043, GTLiteMod.id("vinegar"))
-            .liquid()
-            .color(0x5E0805)
-            .build()
+        Vinegar = addMaterial(12043, "vinegar")
+        {
+            liquid()
+            color(0x5E0805)
+        }
 
         // 12044 Potato Juice
-        PotatoJuice = Material.Builder(12044, GTLiteMod.id("potato_juice"))
-            .liquid()
-            .color(0xC3A92C)
-            .build()
+        PotatoJuice = addMaterial(12044, "potato_juice")
+        {
+            liquid()
+            color(0xC3A92C)
+        }
 
         // 12045 Vodka
-        Vodka = Material.Builder(12045, GTLiteMod.id("vodka"))
-            .liquid()
-            .colorAverage(PotatoJuice, Water)
-            .build()
+        Vodka = addMaterial(12045, "vodka")
+        {
+            liquid()
+            colorAverage(PotatoJuice, Water)
+        }
 
         // 12046 Polenta
-        Polenta = Material.Builder(12046, GTLiteMod.id("polenta"))
-            .liquid()
-            .color(0xBBA844)
-            .build()
+        Polenta = addMaterial(12046, "polenta")
+        {
+            liquid()
+            color(0xBBA844)
+        }
 
         // 12047 Coffee
-        Coffee = Material.Builder(12047, GTLiteMod.id("coffee"))
-            .liquid()
-            .color(0x36312E)
-            .build()
+        Coffee = addMaterial(12047, "coffee")
+        {
+            liquid()
+            color(0x36312E)
+        }
 
         // 12048 Butter
-        Butter = Material.Builder(12048, GTLiteMod.id("butter"))
-            .liquid()
-            .color(0xFFEF82)
-            .build()
+        Butter = addMaterial(12048, "butter")
+        {
+            liquid()
+            color(0xFFEF82)
+        }
 
         // 12049 Purple Drink
-        PurpleDrink = Material.Builder(12049, GTLiteMod.id("purple_drink"))
-            .liquid()
-            .color(0xB405FF)
-            .build()
+        PurpleDrink = addMaterial(12049, "purple_drink")
+        {
+            liquid()
+            color(0xB405FF)
+        }
 
         // 12050 Carbon 5 Fraction
-        Carbon5Fraction = Material.Builder(12050, GTLiteMod.id("carbon_5_fraction"))
-            .liquid()
-            .color(0x9C8638)
-            .flags(FLAMMABLE)
-            .build()
+        Carbon5Fraction = addMaterial(12050, "carbon_5_fraction")
+        {
+            liquid()
+            color(0x9C8638)
+            flags(FLAMMABLE)
+        }
 
         // 12051 Dimerized Carbon 5 Fraction
-        DimerizedCarbon5Fraction = Material.Builder(12051, GTLiteMod.id("dimerized_carbon_5_fraction"))
-            .liquid()
-            .color(0x9C9538)
-            .flags(FLAMMABLE)
-            .build()
+        DimerizedCarbon5Fraction = addMaterial(12051, "dimerized_carbon_5_fraction")
+        {
+            liquid()
+            color(0x9C9538)
+            flags(FLAMMABLE)
+        }
 
         // 12052 Olive Oil
-        OliveOil = Material.Builder(12052, GTLiteMod.id("olive_oil"))
-            .liquid()
-            .color(0x969D56)
-            .build()
+        OliveOil = addMaterial(12052, "olive_oil")
+        {
+            liquid()
+            color(0x969D56)
+        }
 
         // 12053 Fat
-        Fat = Material.Builder(12053, GTLiteMod.id("fat"))
-            .liquid()
-            .color(0xFFF200)
-            .build()
-            .setFormula("C57H110O6", true)
+        Fat = addMaterial(12053, "fat")
+        {
+            liquid()
+            color(0xFFF200)
+        }
 
         // 12054 Mud
-        Mud = Material.Builder(12054, GTLiteMod.id("mud"))
-            .liquid()
-            .color(0x2C2B01)
-            .build()
+        Mud = addMaterial(12054, "mud")
+        {
+            liquid()
+            color(0x2C2B01)
+        }
 
         // 12055 Lemon Extract
-        LemonExtract = Material.Builder(12055, GTLiteMod.id("lemon_extract"))
-            .liquid()
-            .color(0xFCE80A)
-            .build()
+        LemonExtract = addMaterial(12055, "lemon_extract")
+        {
+            liquid()
+            color(0xFCE80A)
+        }
 
         // 12056 Lime Extract
-        LimeExtract = Material.Builder(12056, GTLiteMod.id("lime_extract"))
-            .liquid()
-            .color(0x85F218)
-            .build()
+        LimeExtract = addMaterial(12056, "lime_extract")
+        {
+            liquid()
+            color(0x85F218)
+        }
 
         // 12057 Orange Extract
-        OrangeExtract = Material.Builder(12057, GTLiteMod.id("orange_extract"))
-            .liquid()
-            .color(0xFF6100)
-            .build()
+        OrangeExtract = addMaterial(12057, "orange_extract")
+        {
+            liquid()
+            color(0xFF6100)
+        }
 
         // 12058 Lemon-Lime Mixture
-        LemonLimeMixture = Material.Builder(12058, GTLiteMod.id("lemon_lime_mixture"))
-            .liquid()
-            .color(0xBDDB5A)
-            .build()
+        LemonLimeMixture = addMaterial(12058, "lemon_lime_mixture")
+        {
+            liquid()
+            color(0xBDDB5A)
+        }
 
         // 12059 Lemon-Lime Soda Syrup
-        LemonLimeSodaSyrup = Material.Builder(12059, GTLiteMod.id("lemon_lime_soda_syrup"))
-            .liquid()
-            .color(0x76FF0D)
-            .build()
+        LemonLimeSodaSyrup = addMaterial(12059, "lemon_lime_soda_syrup")
+        {
+            liquid()
+            color(0x76FF0D)
+        }
 
         // 12060 Etirps™ (Sprite)
-        Etirps = Material.Builder(12060, GTLiteMod.id("etirps"))
-            .liquid()
-            .color(0xB0FF73)
-            .build()
+        Etirps = addMaterial(12060, "etirps")
+        {
+            liquid()
+            color(0xB0FF73)
+        }
 
         // 12061 Cranberry Extract
-        CranberryExtract = Material.Builder(12061, GTLiteMod.id("cranberry_extract"))
-            .liquid()
-            .color(0x8C0D22)
-            .build()
+        CranberryExtract = addMaterial(12061, "cranberry_extract")
+        {
+            liquid()
+            color(0x8C0D22)
+        }
 
         // 12062 Cranberry Soda Syrup
-        CranberrySodaSyrup = Material.Builder(12062, GTLiteMod.id("cranberry_soda_syrup"))
-            .liquid()
-            .color(0x8C0D22)
-            .build()
+        CranberrySodaSyrup = addMaterial(12062, "cranberry_soda_syrup")
+        {
+            liquid()
+            color(0x8C0D22)
+        }
 
         // 12063 Cranberry Etirps™ (Sprite)
-        CranberryEtirps = Material.Builder(12063, GTLiteMod.id("cranberry_etirps"))
-            .liquid()
-            .colorAverage(CranberryExtract.materialRGB, 0xBBDDBB)
-            .build()
+        CranberryEtirps = addMaterial(12063, "cranberry_etirps")
+        {
+            liquid()
+            colorAverage(CranberryExtract.materialRGB, 0xBBDDBB)
+        }
 
         // 12064 Cough Syrup
-        CoughSyrup = Material.Builder(12064, GTLiteMod.id("cough_syrup"))
-            .liquid()
-            .color(0x5C1B5E)
-            .build()
+        CoughSyrup = addMaterial(12064, "cough_syrup")
+        {
+            liquid()
+            color(0x5C1B5E)
+        }
 
         // 12065 Apple Syrup
-        AppleSyrup = Material.Builder(12065, GTLiteMod.id("apple_syrup"))
-            .liquid()
-            .color(0xF2E1AC)
-            .build()
+        AppleSyrup = addMaterial(12065, "apple_syrup")
+        {
+            liquid()
+            color(0xF2E1AC)
+        }
 
         // 12065 Cane Syrup
-        CaneSyrup = Material.Builder(12066, GTLiteMod.id("cane_syrup"))
-            .liquid()
-            .color(0xF2F1DC)
-            .build()
+        CaneSyrup = addMaterial(12066, "cane_syrup")
+        {
+            liquid()
+            color(0xF2F1DC)
+        }
 
         // 12066 Apple-Cane Syrup
-        AppleCaneSyrup = Material.Builder(12067, GTLiteMod.id("apple_cane_syrup"))
-            .liquid()
-            .color(0xE7F5AE)
-            .build()
+        AppleCaneSyrup = addMaterial(12067, "apple_cane_syrup")
+        {
+            liquid()
+            color(0xE7F5AE)
+        }
 
         // 12067 Hard Apple Candy Syrup
-        HardAppleCandySyrup = Material.Builder(12068, GTLiteMod.id("hard_apple_candy_syrup"))
-            .liquid()
-            .color(0x78E32B)
-            .build()
+        HardAppleCandySyrup = addMaterial(12068, "hard_apple_candy_syrup")
+        {
+            liquid()
+            color(0x78E32B)
+        }
 
         // 12068 Fracturing Fluid
-        FracturingFluid = Material.Builder(12069, GTLiteMod.id("fracturing_fluid"))
-            .liquid()
-            .color(0x96D6D5)
-            .build()
+        FracturingFluid = addMaterial(12069, "fracturing_fluid")
+        {
+            liquid()
+            color(0x96D6D5)
+        }
 
         // 12069-12100 for misc unknown composition materials.
         // ...
 
         // 12101 Free Electron Gas
-        FreeElectronGas = Material.Builder(12101, GTLiteMod.id("free_electron_gas"))
-            .gas(FluidBuilder()
-                .temperature(50)
-                .translation("gregtech.fluid.generic"))
+        FreeElectronGas = addMaterial(12101, "free_electron_gas")
+        {
+            gas()
+            {
+                temperature(50)
+                translation("gregtech.fluid.generic")
+            }
             .color(0x507BB3)
-            .build()
+        }
 
         // 12102 Fermionic UU Matter
-        FermionicUUMatter = Material.Builder(12102, GTLiteMod.id("fermionic_uu_matter"))
-            .liquid(FluidBuilder().temperature(125))
-            .color(UUMatter.materialRGB / 3)
-            .build()
+        FermionicUUMatter = addMaterial(12102, "fermionic_uu_matter")
+        {
+            liquid()
+            {
+                temperature(125)
+            }
+            color(UUMatter.materialRGB / 3)
+        }
 
         // 12103 Bosonic UU Matter
-        BosonicUUMatter = Material.Builder(12103, GTLiteMod.id("bosonic_uu_matter"))
-            .liquid(FluidBuilder().temperature(125))
-            .color(UUMatter.materialRGB - FermionicUUMatter.materialRGB)
-            .build()
+        BosonicUUMatter = addMaterial(12103, "bosonic_uu_matter")
+        {
+            liquid()
+            {
+                temperature(125)
+            }
+            color(UUMatter.materialRGB - FermionicUUMatter.materialRGB)
+        }
 
         // 12104 Rich Nitrogen Mixture
-        RichNitrogenMixture = Material.Builder(12104, GTLiteMod.id("rich_nitrogen_mixture"))
-            .gas(FluidBuilder().temperature(400))
-            .color(0x6891D8)
-            .build()
+        RichNitrogenMixture = addMaterial(12104, "rich_nitrogen_mixture")
+        {
+            gas()
+            {
+                temperature(400)
+            }
+            color(0x6891D8)
+        }
 
         // 12105 Rich Ammonia Mixture
-        RichAmmoniaMixture = Material.Builder(12105, GTLiteMod.id("rich_ammonia_mixture"))
-            .gas(FluidBuilder().temperature(400))
-            .color(0x708ACD)
-            .build()
+        RichAmmoniaMixture = addMaterial(12105, "rich_ammonia_mixture")
+        {
+            gas()
+            {
+                temperature(400)
+            }
+            color(0x708ACD)
+        }
 
         // 12106 Sea Water
-        SeaWater = Material.Builder(12106, GTLiteMod.id("sea_water"))
-            .liquid()
-            .color(0x0000FF)
-            .build()
-            .setFormula("H2O?", true)
+        SeaWater = addMaterial(12106, "sea_water")
+        {
+            liquid()
+            color(0x0000FF)
+        }
 
         // 12107 Acidic Salt Water
-        AcidicSaltWater = Material.Builder(12107, GTLiteMod.id("acidic_salt_water"))
-            .liquid()
-            .colorAverage(SaltWater, SulfuricAcid)
-            .build()
-            .setFormula("(H2O)(H2SO4)?", true)
+        AcidicSaltWater = addMaterial(12107, "acidic_salt_water")
+        {
+            liquid()
+            colorAverage(SaltWater, SulfuricAcid)
+        }
 
         // 12108 Chalcogen Anode Mud
-        ChalcogenAnodeMud = Material.Builder(12108, GTLiteMod.id("chalcogen_anode_mud"))
-            .dust()
-            .color(0x8A3324)
-            .iconSet(FINE)
-            .build()
+        ChalcogenAnodeMud = addMaterial(12108, "chalcogen_anode_mud")
+        {
+            dust()
+            color(0x8A3324).iconSet(FINE)
+        }
 
         // 12109 Rare Earth Hydroxides Solution
-        RareEarthHydroxidesSolution = Material.Builder(12109, GTLiteMod.id("rare_earth_hydroxides_solution"))
-            .liquid()
-            .color(0x434327)
-            .build()
+        RareEarthHydroxidesSolution = addMaterial(12109, "rare_earth_hydroxides_solution")
+        {
+            liquid()
+            color(0x434327)
+        }
 
         // 12110 Rare Earth Chlorides Solution
-        RareEarthChloridesSolution = Material.Builder(12110, GTLiteMod.id("rare_earth_chlorides_solution"))
-            .liquid()
-            .color(0x838367)
-            .build()
+        RareEarthChloridesSolution = addMaterial(12110, "rare_earth_chlorides_solution")
+        {
+            liquid()
+            color(0x838367)
+        }
 
         // 12111 Brevibacterium Flavum
-        BrevibacteriumFlavum = Material.Builder(12111, GTLiteMod.id("brevibacterium_flavum"))
-            .dust()
-            .color(0x766718).iconSet(ROUGH)
-            .build()
+        BrevibacteriumFlavum = addMaterial(12111, "brevibacterium_flavum")
+        {
+            dust()
+            color(0x766718).iconSet(ROUGH)
+        }
 
         // 12112 Yeast
-        Yeast = Material.Builder(12112, GTLiteMod.id("yeast"))
-            .dust()
-            .color(0xF0E660).iconSet(ROUGH)
-            .build()
+        Yeast = addMaterial(12112, "yeast")
+        {
+            dust()
+            color(0xF0E660).iconSet(ROUGH)
+        }
 
         // 12113 Cupriavidus Necator
-        CupriavidusNecator = Material.Builder(12113, GTLiteMod.id("cupriavidus_necator"))
-            .dust()
-            .color(0x2C4D24).iconSet(ROUGH)
-            .build()
+        CupriavidusNecator = addMaterial(12113, "cupriavidus_necator")
+        {
+            dust()
+            color(0x2C4D24).iconSet(ROUGH)
+        }
 
         // 12114 Streptococcus Pyogenes
-        StreptococcusPyogenes = Material.Builder(12114, GTLiteMod.id("streptococcus_pyogenes"))
-            .dust()
-            .color(0x999933).iconSet(ROUGH)
-            .build()
+        StreptococcusPyogenes = addMaterial(12114, "streptococcus_pyogenes")
+        {
+            dust()
+            color(0x999933).iconSet(ROUGH)
+        }
 
         // 12115 Escherichia Coli
-        EscherichiaColi = Material.Builder(12115, GTLiteMod.id("escherichia_coli"))
-            .dust()
-            .color(0x398C47).iconSet(DULL)
-            .build()
+        EscherichiaColi = addMaterial(12115, "escherichia_coli")
+        {
+            dust()
+            color(0x398C47).iconSet(DULL)
+        }
 
         // 12116 Green Algae
-        GreenAlgae = Material.Builder(12116, GTLiteMod.id("green_algae"))
-            .dust()
-            .color(0x228B22).iconSet(METALLIC)
-            .build()
+        GreenAlgae = addMaterial(12116, "green_algae")
+        {
+            dust()
+            color(0x228B22).iconSet(METALLIC)
+        }
 
         // 12117 Brown Algae
-        BrownAlgae = Material.Builder(12117, GTLiteMod.id("brown_algae"))
-            .dust()
-            .color(0xA52A2A).iconSet(METALLIC)
-            .build()
+        BrownAlgae = addMaterial(12117, "brown_algae")
+        {
+            dust()
+            color(0xA52A2A).iconSet(METALLIC)
+        }
 
         // 12118 Red Algae
-        RedAlgae = Material.Builder(12118, GTLiteMod.id("red_algae"))
-            .dust()
-            .color(0xF08080).iconSet(METALLIC)
-            .build()
+        RedAlgae = addMaterial(12118, "red_algae")
+        {
+            dust()
+            color(0xF08080).iconSet(METALLIC)
+        }
 
         // 12119 Algae Mixture
-        AlgaeMixture = Material.Builder(12119, GTLiteMod.id("algae_mixture"))
-            .liquid()
-            .colorAverage(GreenAlgae, BrownAlgae, RedAlgae).iconSet(DULL)
-            .build()
+        AlgaeMixture = addMaterial(12119, "algae_mixture")
+        {
+            liquid()
+            colorAverage(GreenAlgae, BrownAlgae, RedAlgae).iconSet(DULL)
+        }
 
         // 12115-12130 for other biological components.
         // ...
 
         // 12131 MethylamineMixture
-        MethylamineMixture = Material.Builder(12131, GTLiteMod.id("methylamine_mixture"))
-            .liquid()
-            .color(0xAA4400)
-            .build()
+        MethylamineMixture = addMaterial(12131, "methylamine_mixture")
+        {
+            liquid()
+            color(0xAA4400)
+        }
 
         // 12132 B-Z Medium
-        BZMedium = Material.Builder(12132, GTLiteMod.id("bz_medium"))
-            .liquid()
-            .color(0xA2FD35)
-            .build()
+        BZMedium = addMaterial(12132, "bz_medium")
+        {
+            liquid()
+            color(0xA2FD35)
+        }
 
         // 12133 Low Purity Enriched Naquadah Emulsion
-        LowPurityEnrichedNaquadahEmulsion = Material.Builder(12133, GTLiteMod.id("low_purity_enriched_naquadah_emulsion"))
-            .liquid()
-            .color(0x4C4C4C).iconSet(DULL)
-            .build()
+        LowPurityEnrichedNaquadahEmulsion = addMaterial(12133, "low_purity_enriched_naquadah_emulsion")
+        {
+            liquid()
+            color(0x4C4C4C).iconSet(DULL)
+        }
 
         // 12134 Low Purity Naquadria Emulsion
-        LowPurityNaquadriaEmulsion = Material.Builder(12134, GTLiteMod.id("low_purity_naquadria_emulsion"))
-            .liquid()
-            .color(0x393939)
-            .iconSet(DULL)
-            .build()
+        LowPurityNaquadriaEmulsion = addMaterial(12134, "low_purity_naquadria_emulsion")
+        {
+            liquid()
+            color(0x393939).iconSet(DULL)
+        }
 
         // 12135 Bedrock Smoke
-        BedrockSmoke = Material.Builder(12135, GTLiteMod.id("bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x525252)
-            .build()
+        BedrockSmoke = addMaterial(12135, "bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x525252)
+        }
 
         // 12136 Bedrock Soot Solution
-        BedrockSootSolution = Material.Builder(12136, GTLiteMod.id("bedrock_soot_solution"))
-            .liquid()
-            .color(0x1E2430)
-            .build()
+        BedrockSootSolution = addMaterial(12136, "bedrock_soot_solution")
+        {
+            liquid()
+            color(0x1E2430)
+        }
 
         // 12137 Clean Bedrock Soot Solution
-        CleanBedrockSootSolution = Material.Builder(12137, GTLiteMod.id("clean_bedrock_soot_solution"))
-            .liquid()
-            .color(0xA89F9E)
-            .build()
+        CleanBedrockSootSolution = addMaterial(12137, "clean_bedrock_soot_solution")
+        {
+            liquid()
+            color(0xA89F9E)
+        }
 
         // 12138 Heavy Bedrock Smoke
-        HeavyBedrockSmoke = Material.Builder(12138, GTLiteMod.id("heavy_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x242222)
-            .build()
+        HeavyBedrockSmoke = addMaterial(12138, "heavy_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x242222)
+        }
 
         // 12139 Medium Bedrock Smoke
-        MediumBedrockSmoke = Material.Builder(12139, GTLiteMod.id("medium_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x2E2C2C)
-            .build()
+        MediumBedrockSmoke = addMaterial(12139, "medium_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x2E2C2C)
+        }
 
         // 12140 Light Bedrock Smoke
-        LightBedrockSmoke = Material.Builder(12140, GTLiteMod.id("light_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x363333)
-            .build()
+        LightBedrockSmoke = addMaterial(12140, "light_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x363333)
+        }
 
         // 12141 Ultralight Bedrock Smoke
-        UltralightBedrockSmoke = Material.Builder(12141, GTLiteMod.id("ultralight_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x403D3D)
-            .build()
+        UltralightBedrockSmoke = addMaterial(12141, "ultralight_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x403D3D)
+        }
 
         // 12142 Heavy Taranium Gas
-        HeavyTaraniumGas = Material.Builder(12142, GTLiteMod.id("heavy_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x262626)
-            .build()
+        HeavyTaraniumGas = addMaterial(12142, "heavy_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x262626)
+        }
 
         // 12143 Medium Taranium Gas
-        MediumTaraniumGas = Material.Builder(12143, GTLiteMod.id("medium_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x313131)
-            .build()
+        MediumTaraniumGas = addMaterial(12143, "medium_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x313131)
+        }
 
         // 12144 Light Taranium Gas
-        LightTaraniumGas = Material.Builder(12144, GTLiteMod.id("light_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x404040)
-            .build()
+        LightTaraniumGas = addMaterial(12144, "light_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x404040)
+        }
 
         // 12145 Bedrock Gas
-        BedrockGas = Material.Builder(12145, GTLiteMod.id("bedrock_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x575757)
-            .build()
+        BedrockGas = addMaterial(12145, "bedrock_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x575757)
+        }
 
         // 12146 Crude Naquadah Fuel
-        CrudeNaquadahFuel = Material.Builder(12146, GTLiteMod.id("crude_naquadah_fuel"))
-            .liquid()
-            .color(0x077F4E)
-            .build()
+        CrudeNaquadahFuel = addMaterial(12146, "crude_naquadah_fuel")
+        {
+            liquid()
+            color(0x077F4E)
+        }
 
         // 12147 Heavy Naquadah Fuel
-        HeavyNaquadahFuel = Material.Builder(12147, GTLiteMod.id("heavy_naquadah_fuel"))
-            .liquid()
-            .color(0x088C56)
-            .build()
+        HeavyNaquadahFuel = addMaterial(12147, "heavy_naquadah_fuel")
+        {
+            liquid()
+            color(0x088C56)
+        }
 
         // 12148 Medium Naquadah Fuel
-        MediumNaquadahFuel = Material.Builder(12148, GTLiteMod.id("medium_naquadah_fuel"))
-            .liquid()
-            .color(0x09A566)
-            .build()
+        MediumNaquadahFuel = addMaterial(12148, "medium_naquadah_fuel")
+        {
+            liquid()
+            color(0x09A566)
+        }
 
         // 12149 Light Naquadah Fuel
-        LightNaquadahFuel = Material.Builder(12149, GTLiteMod.id("light_naquadah_fuel"))
-            .liquid()
-            .color(0x0BBF75)
-            .build()
+        LightNaquadahFuel = addMaterial(12149, "light_naquadah_fuel")
+        {
+            liquid()
+            color(0x0BBF75)
+        }
 
         // 12150 Naquadah Gas
-        NaquadahGas = Material.Builder(12150, GTLiteMod.id("naquadah_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x0CD985)
-            .build()
+        NaquadahGas = addMaterial(12150, "naquadah_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x0CD985)
+        }
 
         // 12151 Cracked Heavy Taranium Gas
-        CrackedHeavyTaraniumGas = Material.Builder(12151, GTLiteMod.id("cracked_heavy_taranium_gas"))
-            .liquid()
-            .color(0x1F2B2E)
-            .build()
+        CrackedHeavyTaraniumGas = addMaterial(12151, "cracked_heavy_taranium_gas")
+        {
+            liquid()
+            color(0x1F2B2E)
+        }
 
         // 12152 Cracked Medium Taranium Gas
-        CrackedMediumTaraniumGas = Material.Builder(12152, GTLiteMod.id("cracked_medium_taranium_gas"))
-            .liquid()
-            .color(0x29393D)
-            .build()
+        CrackedMediumTaraniumGas = addMaterial(12152, "cracked_medium_taranium_gas")
+        {
+            liquid()
+            color(0x29393D)
+        }
 
         // 12153 Cracked Light Taranium Gas
-        CrackedLightTaraniumGas = Material.Builder(12153, GTLiteMod.id("cracked_light_taranium_gas"))
-            .liquid()
-            .color(0x374C52)
-            .build()
+        CrackedLightTaraniumGas = addMaterial(12153, "cracked_light_taranium_gas")
+        {
+            liquid()
+            color(0x374C52)
+        }
 
         // 12154 Heavy Taranium Fuel
-        HeavyTaraniumFuel = Material.Builder(12154, GTLiteMod.id("heavy_taranium_fuel"))
-            .liquid()
-            .color(0x141414)
-            .build()
+        HeavyTaraniumFuel = addMaterial(12154, "heavy_taranium_fuel")
+        {
+            liquid()
+            color(0x141414)
+        }
 
         // 12155 Medium Taranium Fuel
-        MediumTaraniumFuel = Material.Builder(12155, GTLiteMod.id("medium_taranium_fuel"))
-            .liquid()
-            .color(0x181818)
-            .build()
+        MediumTaraniumFuel = addMaterial(12155, "medium_taranium_fuel")
+        {
+            liquid()
+            color(0x181818)
+        }
 
         // 12156 Light Taranium Fuel
-        LightTaraniumFuel = Material.Builder(12156, GTLiteMod.id("light_taranium_fuel"))
-            .liquid()
-            .color(0x1C1C1C)
-            .build()
+        LightTaraniumFuel = addMaterial(12156, "light_taranium_fuel")
+        {
+            liquid()
+            color(0x1C1C1C)
+        }
 
         // 12157 Enriched Bedrock Soot Solution
-        EnrichedBedrockSootSolution = Material.Builder(12157, GTLiteMod.id("enriched_bedrock_soot_solution"))
-            .liquid()
-            .color(0x280C26)
-            .build()
+        EnrichedBedrockSootSolution = addMaterial(12157, "enriched_bedrock_soot_solution")
+        {
+            liquid()
+            color(0x280C26)
+        }
 
         // 12158 Clean Enriched Bedrock Soot Solution
-        CleanEnrichedBedrockSootSolution = Material.Builder(12158, GTLiteMod.id("clean_enriched_bedrock_soot_solution"))
-            .liquid()
-            .color(0x828C8C)
-            .build()
+        CleanEnrichedBedrockSootSolution = addMaterial(12158, "clean_enriched_bedrock_soot_solution")
+        {
+            liquid()
+            color(0x828C8C)
+        }
 
         // 12159 Heavy Enriched Bedrock Smoke
-        HeavyEnrichedBedrockSmoke = Material.Builder(12159, GTLiteMod.id("heavy_enriched_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x1A2222)
-            .build()
+        HeavyEnrichedBedrockSmoke = addMaterial(12159, "heavy_enriched_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x1A2222)
+        }
 
         // 12160 Medium Enriched Bedrock Smoke
-        MediumEnrichedBedrockSmoke = Material.Builder(12160, GTLiteMod.id("medium_enriched_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x1E2C2C)
-            .build()
+        MediumEnrichedBedrockSmoke = addMaterial(12160, "medium_enriched_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x1E2C2C)
+        }
 
         // 12161 Light Enriched Bedrock Smoke
-        LightEnrichedBedrockSmoke = Material.Builder(12161, GTLiteMod.id("light_enriched_bedrock_smoke"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x163333)
-            .build()
+        LightEnrichedBedrockSmoke = addMaterial(12161, "light_enriched_bedrock_smoke")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x163333)
+        }
 
         // 12162 Heavy Enriched Taranium Gas
-        HeavyEnrichedTaraniumGas = Material.Builder(12162, GTLiteMod.id("heavy_enriched_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x1F2626)
-            .build()
+        HeavyEnrichedTaraniumGas = addMaterial(12162, "heavy_enriched_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x1F2626)
+        }
 
         // 12163 Medium Enriched Taranium Gas
-        MediumEnrichedTaraniumGas = Material.Builder(12163, GTLiteMod.id("medium_enriched_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x1F3131)
-            .build()
+        MediumEnrichedTaraniumGas = addMaterial(12163, "medium_enriched_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x1F3131)
+        }
 
         // 12164 Light Enriched Taranium Gas
-        LightEnrichedTaraniumGas = Material.Builder(12164, GTLiteMod.id("light_enriched_taranium_gas"))
-            .gas(FluidBuilder()
-                .translation("gregtech.fluid.generic"))
-            .color(0x1F4040)
-            .build()
+        LightEnrichedTaraniumGas = addMaterial(12164, "light_enriched_taranium_gas")
+        {
+            gas()
+            {
+                translation("gregtech.fluid.generic")
+            }
+            color(0x1F4040)
+        }
 
         // 12165 Cracked Heavy Enriched Taranium Gas
-        CrackedHeavyEnrichedTaraniumGas = Material.Builder(12165, GTLiteMod.id("cracked_heavy_enriched_taranium_gas"))
-            .liquid()
-            .color(0x2E1F2E)
-            .build()
+        CrackedHeavyEnrichedTaraniumGas = addMaterial(12165, "cracked_heavy_enriched_taranium_gas")
+        {
+            liquid()
+            color(0x2E1F2E)
+        }
 
         // 12166 Cracked Medium Enriched Taranium Gas
-        CrackedMediumEnrichedTaraniumGas = Material.Builder(12166, GTLiteMod.id("cracked_medium_enriched_taranium_gas"))
-            .liquid()
-            .color(0x29393D)
-            .build()
+        CrackedMediumEnrichedTaraniumGas = addMaterial(12166, "cracked_medium_enriched_taranium_gas")
+        {
+            liquid()
+            color(0x29393D)
+        }
 
         // 12167 Cracked Light Enriched Taranium Gas
-        CrackedLightEnrichedTaraniumGas = Material.Builder(12167, GTLiteMod.id("cracked_light_enriched_taranium_gas"))
-            .liquid()
-            .color(0x374C52)
-            .build()
+        CrackedLightEnrichedTaraniumGas = addMaterial(12167, "cracked_light_enriched_taranium_gas")
+        {
+            liquid()
+            color(0x374C52)
+        }
 
         // 12168 Heavy Enriched Taranium Fuel
-        HeavyEnrichedTaraniumFuel = Material.Builder(12168, GTLiteMod.id("heavy_enriched_taranium_fuel"))
-            .liquid()
-            .color(0x0F1414)
-            .build()
+        HeavyEnrichedTaraniumFuel = addMaterial(12168, "heavy_enriched_taranium_fuel")
+        {
+            liquid()
+            color(0x0F1414)
+        }
 
         // 12169 Medium Enriched Taranium Fuel
-        MediumEnrichedTaraniumFuel = Material.Builder(12169, GTLiteMod.id("medium_enriched_taranium_fuel"))
-            .liquid()
-            .color(0x0F1818)
-            .build()
+        MediumEnrichedTaraniumFuel = addMaterial(12169, "medium_enriched_taranium_fuel")
+        {
+            liquid()
+            color(0x0F1818)
+        }
 
         // 12170 Light Enriched Taranium Fuel
-        LightEnrichedTaraniumFuel = Material.Builder(12170, GTLiteMod.id("light_enriched_taranium_fuel"))
-            .liquid()
-            .color(0x0F1C1C)
-            .build()
+        LightEnrichedTaraniumFuel = addMaterial(12170, "light_enriched_taranium_fuel")
+        {
+            liquid()
+            color(0x0F1C1C)
+        }
 
         // 12171 Energetic Naquadria
-        NaquadriaEnergetic = Material.Builder(12171, GTLiteMod.id("energetic_naquadria"))
-            .liquid()
-            .color(0x202020)
-            .build()
+        NaquadriaEnergetic = addMaterial(12171, "energetic_naquadria")
+        {
+            liquid()
+            color(0x202020)
+        }
 
         // 12172 Quasi-fissioning plasma
-        QuasifissioningPlasma = Material.Builder(12172, GTLiteMod.id("quasi_fissioning_plasma"))
-            .plasma()
-            .color(0xB0A2C3).iconSet(DULL)
-            .build()
+        QuasifissioningPlasma = addMaterial(12172, "quasi_fissioning_plasma")
+        {
+            plasma()
+            color(0xB0A2C3).iconSet(DULL)
+        }
 
         // 12173 Oganesson Breeding Base
-        OganessonBreedingBase = Material.Builder(12173, GTLiteMod.id("oganesson_breeding_base"))
-            .liquid()
-            .color(0xA65A7F).iconSet(DULL)
-            .build()
+        OganessonBreedingBase = addMaterial(12173, "oganesson_breeding_base")
+        {
+            liquid()
+            color(0xA65A7F).iconSet(DULL)
+        }
 
         // 12174 Unprocessed Nd:YAG Solution
-        UnprocessedNdYAGSolution = Material.Builder(12174, GTLiteMod.id("unprocessed_nd_yag_solution"))
-            .liquid()
-            .color(0x6F20AF).iconSet(DULL)
-            .build()
-            .setFormula("Nd:YAG?", false)
+        UnprocessedNdYAGSolution = addMaterial(12174, "unprocessed_nd_yag_solution")
+        {
+            liquid()
+            color(0x6F20AF).iconSet(DULL)
+        }
 
         // 12175 Mutated Living Solder
-        MutatedLivingSolder = Material.Builder(12175, GTLiteMod.id("mutated_living_solder"))
-            .liquid(FluidBuilder()
-                .temperature(10525))
-            .color(0x936D9B).iconSet(DULL)
-            .build()
+        MutatedLivingSolder = addMaterial(12175, "mutated_living_solder")
+        {
+            liquid()
+            {
+                temperature(10525)
+            }
+            color(0x936D9B).iconSet(DULL)
+        }
 
         // 12176 Sodio-Indene
-        SodioIndene = Material.Builder(12176, GTLiteMod.id("sodio_indene"))
-            .liquid()
-            .color(0x1D1C24)
-            .build()
+        SodioIndene = addMaterial(12176, "sodio_indene")
+        {
+            liquid()
+            color(0x1D1C24)
+        }
 
         // 12177 Steam-cracked Sodio-Indene
-        SteamCrackedSodioIndene = Material.Builder(12177, GTLiteMod.id("steam_cracked_sodio_indene"))
-            .liquid(FluidBuilder().temperature(1105))
-            .color(0x1C1A29)
-            .build()
+        SteamCrackedSodioIndene = addMaterial(12177, "steam_cracked_sodio_indene")
+        {
+            liquid()
+            {
+                temperature(1105)
+            }
+            color(0x1C1A29)
+        }
 
         // 12178 Phosphorene Solution
-        PhosphoreneSolution = Material.Builder(12178, GTLiteMod.id("phosphorene_solution"))
-            .liquid()
-            .color(0x465966)
-            .build()
+        PhosphoreneSolution = addMaterial(12178, "phosphorene_solution")
+        {
+            liquid()
+            color(0x465966)
+        }
 
         // 12179-12999 for misc materials.
         // ...
@@ -918,204 +1082,263 @@ object GTLiteUnknownCompositionMaterials
         // https://link.springer.com/chapter/10.1007/978-3-642-02286-9_1
 
         // 13001 Neutron-Proton Fermi Superfluid
-        NeutronProtonFermiSuperfluid = Material.Builder(13001, GTLiteMod.id("neutron_proton_fermi_superfluid"))
-            .plasma(FluidBuilder()
-                .temperature(100_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        NeutronProtonFermiSuperfluid = addMaterial(13001, "neutron_proton_fermi_superfluid")
+        {
+            plasma()
+            {
+                temperature(100_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13002 Heavy Lepton Mixture
-        HeavyLeptonMixture = Material.Builder(13002, GTLiteMod.id("heavy_lepton_mixture"))
-            .liquid(FluidBuilder()
-                .temperature(48_000_000)
-                .customStill())
-            .build()
+        HeavyLeptonMixture = addMaterial(13002, "heavy_lepton_mixture")
+        {
+            liquid()
+            {
+                temperature(48_000_000)
+                customStill()
+            }
+        }
 
         // 13003 Quark-Gluon Plasma
-        QuarkGluonPlasma = Material.Builder(13003, GTLiteMod.id("quark_gluon_plasma"))
-            .plasma(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(1_500_000_000) // In reality world, Q-G plasma has 15000000000~20000000000 MeV by theory, so we transform it as K.
-                .customStill())
-            .build()
+        // In reality world, Q-G plasma has 15,000,000,000~20,000,000,000 MeV by theory, so we transform it as K.
+        QuarkGluonPlasma = addMaterial(13003, "quark_gluon_plasma")
+        {
+            plasma()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(1_500_000_000)
+                customStill()
+            }
+        }
 
         // 13004 Heavy Quarks
-        HeavyQuarks = Material.Builder(13004, GTLiteMod.id("heavy_quarks"))
-            .liquid(FluidBuilder()
-                .temperature(1_800_000_000)
-                .customStill())
-            .build()
+        HeavyQuarks = addMaterial(13004, "heavy_quarks")
+        {
+            liquid()
+            {
+                temperature(1_800_000_000)
+                customStill()
+            }
+        }
 
         // 13005 Light Quarks
-        LightQuarks = Material.Builder(13005, GTLiteMod.id("light_quarks"))
-            .liquid(FluidBuilder()
-                .temperature(900_000_000)
-                .customStill())
-            .build()
+        LightQuarks = addMaterial(13005, "light_quarks")
+        {
+            liquid()
+            {
+                temperature(900_000_000)
+                customStill()
+            }
+        }
 
         // 13006 Gluons
-        Gluons = Material.Builder(13006, GTLiteMod.id("gluons"))
-            .gas(FluidBuilder()
-                .temperature(2_000_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        Gluons = addMaterial(13006, "gluons")
+        {
+            gas()
+            {
+                temperature(2_000_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13007 Hadronic Resonant Gas
-        HadronicResonantGas = Material.Builder(13007, GTLiteMod.id("hadronic_resonant_gas"))
-            .gas(FluidBuilder()
-                .temperature(1_500_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        HadronicResonantGas = addMaterial(13007, "hadronic_resonant_gas")
+        {
+            gas()
+            {
+                temperature(1_500_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13008 Stable Baryonic Matter
-        StableBaryonicMatter = Material.Builder(13008, GTLiteMod.id("stable_baryonic_matter"))
-            .plasma(FluidBuilder()
-                .temperature(1_200_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        StableBaryonicMatter = addMaterial(13008, "stable_baryonic_matter")
+        {
+            plasma()
+            {
+                temperature(1_200_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13009 High Energy Quark-Gluon Plasma
-        HighEnergyQuarkGluonPlasma = Material.Builder(13009, GTLiteMod.id("high_energy_quark_gluon_plasma"))
-            .plasma(FluidBuilder()
-                .translation("gregtech.fluid.generic")
-                .temperature(2_000_000_000) // In reality world, Q-G plasma has 15000000000~20000000000 MeV by theory, so we transform it as K.
-                .customStill())
-            .build()
+        HighEnergyQuarkGluonPlasma = addMaterial(13009, "high_energy_quark_gluon_plasma")
+        {
+            plasma()
+            {
+                translation("gregtech.fluid.generic")
+                temperature(2_000_000_000)
+                customStill()
+            }
+        }
 
         // 13010 Resonant Strange Meson
-        ResonantStrangeMeson = Material.Builder(13010, GTLiteMod.id("resonant_strange_meson"))
-            .plasma(FluidBuilder()
-                .temperature(1_600_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        ResonantStrangeMeson = addMaterial(13010, "resonant_strange_meson")
+        {
+            plasma()
+            {
+                temperature(1_600_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13011 Protomatter
-        Protomatter = Material.Builder(13011, GTLiteMod.id("protomatter"))
-            .plasma(FluidBuilder()
-                .temperature(1_000_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        Protomatter = addMaterial(13011, "protomatter")
+        {
+            plasma()
+            {
+                temperature(1_000_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13012 Semistable Antimatter
-        SemistableAntimatter = Material.Builder(13012, GTLiteMod.id("semistable_antimatter"))
-            .plasma(FluidBuilder()
-                .temperature(1_500_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        SemistableAntimatter = addMaterial(13012, "semistable_antimatter")
+        {
+            plasma()
+            {
+                temperature(1_500_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13013 Antimatter
-        Antimatter = Material.Builder(13013, GTLiteMod.id("antimatter"))
-            .plasma(FluidBuilder()
-                .temperature(2_000_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        Antimatter = addMaterial(13013, "antimatter")
+        {
+            plasma()
+            {
+                temperature(2_000_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13014 Spatially Enlarged Fluid
-        SpatiallyEnlargedFluid = Material.Builder(13014, GTLiteMod.id("spatially_enlarged_fluid"))
-            .liquid(FluidBuilder()
-                .temperature(1)
-                .customStill())
-            .build()
+        SpatiallyEnlargedFluid = addMaterial(13014, "spatially_enlarged_fluid")
+        {
+            liquid()
+            {
+                temperature(1)
+                customStill()
+            }
+        }
 
         // 13015 Tachyon Rich Temporal Fluid
-        TachyonRichTemporalFluid = Material.Builder(13015, GTLiteMod.id("tachyon_rich_temporal_fluid"))
-            .liquid(FluidBuilder()
-                .temperature(1)
-                .customStill())
-            .build()
+        TachyonRichTemporalFluid = addMaterial(13015, "tachyon_rich_temporal_fluid")
+        {
+            liquid()
+            {
+                temperature(1)
+                customStill()
+            }
+        }
 
         // 13016 Primordial Matter
-        PrimordialMatter = Material.Builder(13016, GTLiteMod.id("primordial_matter"))
-            .liquid(FluidBuilder()
-                .temperature(2_000_000_000)
-                .customStill())
-            .build()
+        PrimordialMatter = addMaterial(13016, "primordial_matter")
+        {
+            liquid()
+            {
+                temperature(2_000_000_000)
+                customStill()
+            }
+        }
 
         // 13017 Condensed Raw Stellar Plasma Mixture
-        RawStarMatter = Material.Builder(13017, GTLiteMod.id("condensed_raw_stellar_plasma_mixture"))
-            .plasma(FluidBuilder()
-                .temperature(2_000_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        RawStarMatter = addMaterial(13017, "condensed_raw_stellar_plasma_mixture")
+        {
+            plasma()
+            {
+                temperature(2_000_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // 13018 Magnetohydrodynamically Constrained Star Matter (MHDCSM)
-        MagnetohydrodynamicallyConstrainedStarMatter = Material.Builder(13018, GTLiteMod.id("magnetohydrodynamically_constrained_star_matter"))
-            .ingot()
-            .plasma(FluidBuilder()
-                .temperature(2_000_000_000))
-            .iconSet(MHDCSM)
-            .flags(EXT2_METAL, NO_UNIFICATION, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL,
-                GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND,
-                GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
-            .build()
+        MagnetohydrodynamicallyConstrainedStarMatter = addMaterial(13018, "magnetohydrodynamically_constrained_star_matter")
+        {
+            ingot()
+            plasma()
+            {
+                temperature(2_000_000_000)
+            }
+            iconSet(MHDCSM)
+            flags(EXT2_METAL, NO_UNIFICATION, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_FOIL, GENERATE_ROTOR,
+                  GENERATE_FRAME, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                  GENERATE_FINE_WIRE)
+        }
 
         // 13019 Self-Interacting Dark Matter (SIDM)
-        SelfInteractingDarkMatter = Material.Builder(13019, GTLiteMod.id("self_interacting_dark_matter"))
-            .ingot()
-            .liquid()
-            .iconSet(DARKMATTER)
-            .flags(EXT2_METAL, GENERATE_FRAME, GENERATE_FOIL, GENERATE_FINE_WIRE)
-            .cableProperties(V[MAX] - 1, 488, 1)
-            .build()
+        SelfInteractingDarkMatter = addMaterial(13019, "self_interacting_dark_matter")
+        {
+            ingot()
+            liquid()
+            iconSet(DARKMATTER)
+            flags(EXT2_METAL, GENERATE_FRAME, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            cableProp(V[MAX] - 1, 488, 1)
+        }
 
         // 13020 Realized Quantum Foam Shard (RQFS)
-        RealizedQuantumFoamShard = Material.Builder(13020, GTLiteMod.id("realized_quantum_foam_shard"))
-            .ingot()
-            .liquid()
-            .iconSet(QUANTUM) // lightness 80 on base; shadow
-            .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME,
-                   GENERATE_SPRING, GENERATE_SPRING_SMALL)
-            .cableProperties(V[MAX] - 1, 365, 1)
-            .build()
+        RealizedQuantumFoamShard = addMaterial(13020, "realized_quantum_foam_shard")
+        {
+            ingot()
+            liquid()
+            iconSet(QUANTUM) // lightness 80 on base; shadow
+            flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL)
+            cableProp(V[MAX] - 1, 365, 1)
+        }
 
         // 13021 Axino-Fused Red Matter (AFRM)
-        AxinoFusedRedMatter = Material.Builder(13021, GTLiteMod.id("axino_fused_red_matter"))
-            .ingot()
-            .liquid()
-            .color(0x9A0707).iconSet(REDMATTER)
-            .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR, GENERATE_SMALL_GEAR,
-                   GENERATE_ROUND, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL,
-                   GENERATE_FINE_WIRE)
-            .toolStats(MaterialToolProperty.Builder.of(640.0F, 640.0F, Int.MAX_VALUE - 1, 1_048_576)
-                           .attackSpeed(9.0F).enchantability(99)
-                           .enchantment(Enchantments.SHARPNESS, 128)
-                           .enchantment(Enchantments.SWEEPING, 128)
-                           .enchantment(Enchantments.LOOTING, 128)
-                           .enchantment(Enchantments.EFFICIENCY, 128)
-                           .enchantment(Enchantments.FORTUNE, 128)
-                           .enchantment(Enchantments.MENDING, 128)
-                           .enchantment(Enchantments.UNBREAKING, 128)
-                           .magnetic()
-                           .unbreakable()
-                           .build())
-            .rotorStats(8192.0F, 2048.0F, Int.MAX_VALUE - 1)
-            .build()
-            .setFormula(CommonI18n.format("gtlitecore.material.axino_fused_red_matter.formula", "Hot Dark Matter formed by the Aggregation of Dark Matter and Supersymmetric Axions"))
+        AxinoFusedRedMatter = addMaterial(13021, "axino_fused_red_matter")
+        {
+            ingot()
+            liquid()
+            color(0x9A0707).iconSet(REDMATTER)
+            flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_ROUND,
+                  GENERATE_ROTOR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_FINE_WIRE)
+            toolProp(640.0F, 640.0F, Int.MAX_VALUE - 1, 1_048_576)
+            {
+                attackSpeed(9.0F)
+                enchantability(99)
+                enchantment(Enchantments.SHARPNESS, 128)
+                enchantment(Enchantments.SWEEPING, 128)
+                enchantment(Enchantments.LOOTING, 128)
+                enchantment(Enchantments.EFFICIENCY, 128)
+                enchantment(Enchantments.FORTUNE, 128)
+                enchantment(Enchantments.MENDING, 128)
+                enchantment(Enchantments.UNBREAKING, 128)
+                magnetic()
+                unbreakable()
+            }
+            rotorProp(8192.0F, 2048.0F, Int.MAX_VALUE - 1)
+        }
 
         // ...
 
         // 13050 Dimensionally Shifted Superfluid
-        DimensionallyShiftedSuperfluid = Material.Builder(13050, GTLiteMod.id("dimensionally_shifted_superfluid"))
-            .plasma(FluidBuilder()
-                .temperature(2_000_000_000)
-                .translation("gregtech.fluid.generic")
-                .customStill())
-            .build()
+        DimensionallyShiftedSuperfluid = addMaterial(13050, "dimensionally_shifted_superfluid")
+        {
+            plasma()
+            {
+                temperature(2_000_000_000)
+                translation("gregtech.fluid.generic")
+                customStill()
+            }
+        }
 
         // ...
 
         // 14000 Eternity+ (Token)
-        EternityPlusToken = Material.Builder(14000, GTLiteMod.id("eternity_plus_token"))
-            .build()
+        EternityPlusToken = addMaterial(14000, "eternity_plus_token") {}
     }
 
     // @formatter:on

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/MaterialBuilderDSL.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/MaterialBuilderDSL.kt
@@ -1,0 +1,15 @@
+@file:JvmName("MaterialBuilderDSL")
+package gregtechlite.gtlitecore.api.unification.material
+
+import gregtech.api.unification.material.Material
+import gregtechlite.gtlitecore.api.MOD_ID
+import net.minecraft.util.ResourceLocation
+
+fun matCreator(id: Int, name: String, builder: Material.Builder.() -> Unit): Material
+    = matCreator(id, MOD_ID, name, builder)
+
+fun matCreator(id: Int, modid: String, name: String, builder: Material.Builder.() -> Unit): Material
+    = matCreator(id, ResourceLocation(modid, name), builder)
+
+fun matCreator(id: Int, location: ResourceLocation, builder: Material.Builder.() -> Unit): Material
+    = Material.Builder(id, location).apply(builder).build()

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/MaterialBuilderDSL.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/MaterialBuilderDSL.kt
@@ -5,11 +5,11 @@ import gregtech.api.unification.material.Material
 import gregtechlite.gtlitecore.api.MOD_ID
 import net.minecraft.util.ResourceLocation
 
-fun matCreator(id: Int, name: String, builder: Material.Builder.() -> Unit): Material
-    = matCreator(id, MOD_ID, name, builder)
+fun addMaterial(id: Int, name: String, builder: Material.Builder.() -> Unit): Material
+    = addMaterial(id, MOD_ID, name, builder)
 
-fun matCreator(id: Int, modid: String, name: String, builder: Material.Builder.() -> Unit): Material
-    = matCreator(id, ResourceLocation(modid, name), builder)
+fun addMaterial(id: Int, modid: String, name: String, builder: Material.Builder.() -> Unit): Material
+    = addMaterial(id, ResourceLocation(modid, name), builder)
 
-fun matCreator(id: Int, location: ResourceLocation, builder: Material.Builder.() -> Unit): Material
+fun addMaterial(id: Int, location: ResourceLocation, builder: Material.Builder.() -> Unit): Material
     = Material.Builder(id, location).apply(builder).build()

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
@@ -196,6 +196,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BETSPerrhenate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BismuthStrontiumCalciumCuprate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BlueSchist
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CeriumCarbonate
@@ -213,18 +214,23 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylcadmium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ErbiumDopedZBLANGlass
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Firestone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FleroviumYtterbiumPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GelidCryotheum
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GreenSchist
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HalkoniteSteel
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyAlkaliChloridesSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalBoronNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalSiliconNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HydroxyquinolineAluminium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Iron3Sulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kimberlite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Komatiite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kovar
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumEmbeddedFullerene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneMixture
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneNanotube
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LeadNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Lignite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Limestone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LithiumBerylliumFluorides
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LithiumSodiumPotassiumFluorides
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LuTmDopedYttriumVanadateDeposition
@@ -253,7 +259,9 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrussianBlue
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PurifiedPlatinumGroupConcentrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RareEarthAlloy
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RoastedSphalerite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Shale
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SilicaGelBase
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Slate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAcetate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumFormate
@@ -558,7 +566,8 @@ object GTLiteMaterialProperties
 
     fun setChemicalFormula()
     {
-        // GTCEu Materials
+        // region GTCEu Materials
+
         Biotite.setFormula("KMg3Al2(AlSi3O10)F2", true)
         Mica.setFormula("KAl2(AlSi3O10)F2", true)
         Bauxite.setFormula("(Al2O3)3(TiO2)2(H2O)2?", true)
@@ -567,10 +576,16 @@ object GTLiteMaterialProperties
         RarestMetalMixture.setFormula("IrOs?", true)
         IridiumMetalResidue.setFormula("Ir2O3", true)
 
-        // Element Materials
+        // endregion
+
+        // region Element Materials
+
         DegenerateRhenium.setFormula("§cR§de", true)
 
-        // First Degree Materials
+        // endregion
+
+        // region First Degree Materials
+
         Dolomite.setFormula("CaMg(CO3)2", true)
         Azurite.setFormula("Cu3(CO3)2(OH)2", true)
         Forsterite.setFormula("Mg2(SiO4)", true)
@@ -669,7 +684,10 @@ object GTLiteMaterialProperties
         PlutoniumDioxide.setFormula("PuO2", true)
         MOX.setFormula("(PuO2)(UO2)2", true)
 
-        // Second Degree Materials
+        // endregion
+
+        // region Second Degree Materials
+
         Kovar.setFormula("Fe10Ni5Co3", true)
         HalkoniteSteel.setFormula("SpNt2((FeW)8*Nq*7?4C4(VCrFe7)3Fr)2P8(((WC)(TiC)2)3(CaMg5(OH)2(Si4O11)2)3Tr2)If", true)
         TantalumHafniumSeaborgiumCarbide.setFormula("Ta12Hf3SgC16", true)
@@ -681,6 +699,21 @@ object GTLiteMaterialProperties
                                + "SmEuGdTbDyHoErTmYbLuHfTaWReOsIrPtAuHgTlPbBiPoAtRnFrRaAcTh"
                                + "PaUNpPuAmCmBkCfEsFmMdNoLrRfDbSgBhHsMtDsRgCnNhFlMcLvTsOg")
 
+        // endregion
+
+        // region Third Degree Materials
+
+        Limestone.setFormula("(CaCO3)4(CaMg(CO3)2)?", true)
+        Komatiite.setFormula("(Mg2Fe(SiO2)2)2(MgCO3)(SiO2)?", true)
+        GreenSchist.setFormula("(Ca2Al3Si3HO13)2(SiO2)2(Mg3Si4H2O12)?", true)
+        BlueSchist.setFormula("(Cu3(CO3)2(OH)2)3(Al3Si3Na4Cl)2?", true)
+        Kimberlite.setFormula("(Mg2(SiO4))3((Ca2MgFe)(MgFe)2(Si2O6)4)3(Ca3Fe2Si3O12)2?", true)
+        Slate.setFormula("(SiO2)5(KAl2(AlSi3O10)(OH)2)2(Mg5Al2Si3O10(OH)8)2?", true)
+        Shale.setFormula("(CaCO3)6(Na2LiAl2Si2(H2O)6)2(SiO2)(CaF2)?", true)
+
+        GelidCryotheum.setFormula("((Si(FeS2)5(CrAl2O3)Hg3)(AgAu))(H2O)3", true)
+
+        // endregion
 
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
@@ -177,9 +177,11 @@ import gregtechlite.gtlitecore.api.extension.addIngot
 import gregtechlite.gtlitecore.api.extension.addLiquid
 import gregtechlite.gtlitecore.api.extension.addLiquidAndPlasma
 import gregtechlite.gtlitecore.api.extension.addPlasma
+import gregtechlite.gtlitecore.api.translation.CommonI18n
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetamide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetonitrile
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AcetylChloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AcidicSaltWater
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumGroupAlloyA
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumOxalate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AdamantiumUnstable
@@ -198,7 +200,9 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumPersulfat
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumSulfate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmorphousBoronNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Aniline
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AxinoFusedRedMatter
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BETSPerrhenate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BFGF
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BenzylBromide
@@ -211,6 +215,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Bromobutane
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butanediol
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butanol
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butyllithium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CAT
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CeriumCarbonate
@@ -239,18 +244,21 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylcadmium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylformamide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dinitrodipropanyloxybenzene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Durene
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.EGF
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ErbiumDopedZBLANGlass
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylamine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylanthrahydroquinone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylanthraquinone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.EthyleneGlycol
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylenediamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Fat
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Firestone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FleroviumYtterbiumPlasma
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FormicAcid
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FullerenePolymerMatrix
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GelidCryotheum
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GreenSchist
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GreenhouseGas
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HalkoniteSteel
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyAlkaliChloridesSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalBoronNitride
@@ -323,6 +331,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RareEarthAlloy
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RawPolyphosphonitrileFluoroRubber
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RawPolytetramethyleneGlycolRubber
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RoastedSphalerite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SeaWater
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Shale
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SilicaGelBase
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Slate
@@ -353,6 +362,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trimethylgallium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TrimethyltinChloride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Triphenylphosphine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trisaminoethylamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UnprocessedNdYAGSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrateSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.VibraniumUnstable
@@ -870,7 +880,16 @@ object GTLiteMaterialProperties
         // endregion
 
         // region Unknown Composition Materials
-
+        BFGF.setFormula("bFGF", false)
+        EGF.setFormula("EGF", false)
+        CAT.setFormula("CAT", false)
+        GreenhouseGas.setFormula("N78O21Ar9?", true)
+        Fat.setFormula("C57H110O6", true)
+        SeaWater.setFormula("H2O?", true)
+        AcidicSaltWater.setFormula("(H2O)(H2SO4)?", true)
+        UnprocessedNdYAGSolution.setFormula("Nd:YAG?", false)
+        AxinoFusedRedMatter.setFormula(CommonI18n.format("gtlitecore.material.axino_fused_red_matter.formula",
+            "Hot Dark Matter formed by the Aggregation of Dark Matter and Supersymmetric Axions"))
         // endregion
 
     }

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
@@ -177,6 +177,7 @@ import gregtechlite.gtlitecore.api.extension.addIngot
 import gregtechlite.gtlitecore.api.extension.addLiquid
 import gregtechlite.gtlitecore.api.extension.addLiquidAndPlasma
 import gregtechlite.gtlitecore.api.extension.addPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumGroupAlloyA
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumOxalate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AdamantiumUnstable
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminaSolution
@@ -212,11 +213,13 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylcadmium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ErbiumDopedZBLANGlass
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Firestone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FleroviumYtterbiumPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HalkoniteSteel
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyAlkaliChloridesSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalBoronNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalSiliconNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HydroxyquinolineAluminium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Iron3Sulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kovar
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumEmbeddedFullerene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneMixture
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneNanotube
@@ -234,6 +237,7 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.NdYAG
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumAcetate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumFullereneMatrix
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Periodicium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PhotopolymerSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupConcentrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupResidue
@@ -247,15 +251,18 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrHoYNitratesSolu
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PraseodymiumDopedZBLANGlass
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrussianBlue
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PurifiedPlatinumGroupConcentrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RareEarthAlloy
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RoastedSphalerite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SilicaGelBase
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAcetate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumFormate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumPolonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TantalumHafniumSeaborgiumCarbide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThalliumThuliumDopedCaesiumIodide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThoriumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TitaniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TransitionAlloy
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TrichlorocyclopentadienylTitanium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrateSolution
@@ -661,6 +668,20 @@ object GTLiteMaterialProperties
         ChromaticGlass.setFormula("(SiO2)64", true)
         PlutoniumDioxide.setFormula("PuO2", true)
         MOX.setFormula("(PuO2)(UO2)2", true)
+
+        // Second Degree Materials
+        Kovar.setFormula("Fe10Ni5Co3", true)
+        HalkoniteSteel.setFormula("SpNt2((FeW)8*Nq*7?4C4(VCrFe7)3Fr)2P8(((WC)(TiC)2)3(CaMg5(OH)2(Si4O11)2)3Tr2)If", true)
+        TantalumHafniumSeaborgiumCarbide.setFormula("Ta12Hf3SgC16", true)
+        ActiniumGroupAlloyA.setFormula("AcThPaUNpPuAmCm", true)
+        TransitionAlloy.setFormula("TiVCrMnFeCoNiCuAlZnGaGeCdInSnSb", true)
+        RareEarthAlloy.setFormula("LaCePrNdPmSmEuGdTbDyHoErTmYbLuScYAcThPaUNpPuAmCmBkCfEsFmMdNoLr", true)
+        Periodicium.setFormula("HHeLiBeBCNOFNeNaMgAlSiPSClArKCaScTiVCrMnFeCoNiCuZnGaGe"
+                               + "AsSeBrKrRbSrYZrNbMoTcRuRhPdAgCdInSnSbTeIXeCsBaLaCePrNdPm"
+                               + "SmEuGdTbDyHoErTmYbLuHfTaWReOsIrPtAuHgTlPbBiPoAtRnFrRaAcTh"
+                               + "PaUNpPuAmCmBkCfEsFmMdNoLrRfDbSgBhHsMtDsRgCnNhFlMcLvTsOg")
+
+
     }
 
 }

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
@@ -172,32 +172,133 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Tenorite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Wollastonite
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
+import gregtechlite.gtlitecore.api.extension.addDust
+import gregtechlite.gtlitecore.api.extension.addIngot
+import gregtechlite.gtlitecore.api.extension.addLiquid
+import gregtechlite.gtlitecore.api.extension.addLiquidAndPlasma
+import gregtechlite.gtlitecore.api.extension.addPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumOxalate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AdamantiumUnstable
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminaSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumHydroxide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumSulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumAcetate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumCarbonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumHexachloropalladate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumHexachloroplatinate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumPersulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumSulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmorphousBoronNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BETSPerrhenate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumHydroxide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BismuthStrontiumCalciumCuprate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumAlginate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumHydroxide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CeriumCarbonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ChlorinatedSolvents
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ChromaticGlass
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Clinochlore
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CopperArsenite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CopperNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicBoronNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicHeterodiamond
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicSiliconNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicZirconia
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DegenerateRhenium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylcadmium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ErbiumDopedZBLANGlass
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Firestone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FleroviumYtterbiumPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyAlkaliChloridesSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalBoronNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalSiliconNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HydroxyquinolineAluminium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Iron3Sulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumEmbeddedFullerene
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneMixture
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LanthanumFullereneNanotube
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LeadNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Lignite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LithiumBerylliumFluorides
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LithiumSodiumPotassiumFluorides
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LuTmDopedYttriumVanadateDeposition
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LuTmYChloridesSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LuTmYVO
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MOX
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Magnetium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MagnetoResonatic
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.NdYAG
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumAcetate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumFullereneMatrix
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PhotopolymerSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupConcentrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupResidue
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumDioxide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumPhosphide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumTrihydride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PoloniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PotassiumFerrocyanideTrihydrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrHoYLF
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrHoYNitratesSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PraseodymiumDopedZBLANGlass
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrussianBlue
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PurifiedPlatinumGroupConcentrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RoastedSphalerite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SilicaGelBase
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAcetate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAlginate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumFormate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumPolonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThalliumThuliumDopedCaesiumIodide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThoriumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TitaniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TrichlorocyclopentadienylTitanium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrateSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.VibraniumUnstable
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.WaelzOxide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.WaelzSlag
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.YttriumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ZBLANGlass
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ZSM5
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ZincRichSphalerite
 
 /**
  * Consists of all material properties settings.
  *
  * Materials can modify its main properties by the mixins feature, please see these change below.
  *
- * @see magicbook.gtlitecore.mixins.gregtech.MixinMaterialProperties
+ * @see gregtechlite.gtlitecore.mixins.gregtech.MixinMaterialProperties
  */
 object GTLiteMaterialProperties
 {
 
+    fun init()
+    {
+        setMaterialProperties()
+        setOreProperties()
+        setMaterialColors()
+        setChemicalFormula()
+    }
+
     fun setMaterialProperties()
     {
+        // region State Properties
 
-        // Ingot Properties
         arrayOf(Strontium, Rhenium, Uranium, Uranium235, Uranium238, Selenium, Tellurium, Lanthanum, Cerium,
                 Praseodymium, Promethium, Gadolinium, Terbium, Dysprosium, Holmium, Erbium, Thulium, Ytterbium,
                 Scandium, Germanium, Technetium, Cadmium, Dubnium, Rutherfordium, Curium, Seaborgium, Bohrium,
                 Neptunium, Fermium, Rubidium, Calcium, Magnesium, Francium, Thallium, Barium, Lutetium, Californium,
                 Radium, Polonium, Actinium, Protactinium, Berkelium, Einsteinium, Mendelevium, Astatine, Nobelium,
                 Lawrencium, Roentgenium, Moscovium, Meitnerium, Copernicium, Nihonium, Livermorium, Tennessine, Sulfur)
-            .forEach { addIngot(it) }
+            .forEach { it.addIngot() }
 
         // Dust Properties
-        arrayOf(Iodine).forEach { addDust(it) }
+        arrayOf(Iodine).forEach { it.addDust() }
 
         // Liquid Properties
         arrayOf(Bromine, Uranium238, Zircaloy4, Inconel718, SodiumBisulfate, Germanium, Rutherfordium, Dubnium, Curium,
@@ -205,32 +306,122 @@ object GTLiteMaterialProperties
                 Actinium, Protactinium, Berkelium, Einsteinium, Mendelevium, Astatine, Nobelium, Lawrencium, Ytterbium,
                 Rhenium, Roentgenium, Moscovium, Meitnerium, Copernicium, Nihonium, Livermorium, Tennessine, Thulium,
                 Promethium, Barium, Tellurium, Holmium, Erbium, Gadolinium, EnderPearl)
-            .forEach { addLiquid(it) }
+            .forEach { it.addLiquid() }
 
         // Plasma Properties
         arrayOf(Niobium, Zinc, Krypton, Xenon, Radon, Neon, Bismuth, Thorium, Silver, Titanium, Lead)
-            .forEach { addPlasma(it) }
+            .forEach { it.addPlasma() }
 
         // Liquid and Plasma Properties
         arrayOf(Neptunium, Fermium, Boron, Rubidium, Technetium, Calcium, Sulfur)
-            .forEach { addLiquidAndPlasma(it) }
+            .forEach { it.addLiquidAndPlasma() }
 
-        // Ore Properties
+        // endregion
 
-        // World Gen Ores
+        // region Magnetic Properties
+        ChromiumGermaniumTelluride.getProperty(PropertyKey.INGOT)
+            .magneticMaterial = ChromiumGermaniumTellurideMagnetic
+
+        Europium.getProperty(PropertyKey.INGOT)
+            .magneticMaterial = Magnetium
+
+        // endregion
+
+        // region Blast Properties
+
+        Rhenium.setProperty(PropertyKey.BLAST, BlastProperty(3459))
+        Rhenium.getProperty(PropertyKey.BLAST).durationOverride = 13 * SECOND + 8 * TICK
+
+        Uranium.setProperty(PropertyKey.BLAST, BlastProperty(600))
+        Uranium.getProperty(PropertyKey.BLAST).setEutOverride(VA[MV])
+        Uranium.getProperty(PropertyKey.BLAST).durationOverride = 15 * SECOND
+
+        Germanium.setProperty(PropertyKey.BLAST, BlastProperty(1211))
+
+        Americium.setProperty(PropertyKey.BLAST, BlastProperty(7500))
+        Americium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
+        Americium.getProperty(PropertyKey.BLAST).durationOverride = 12 * SECOND
+        Americium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[LuV])
+        Americium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 18 * SECOND
+
+        Seaborgium.setProperty(PropertyKey.BLAST, BlastProperty(8300))
+        Seaborgium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
+        Seaborgium.getProperty(PropertyKey.BLAST).durationOverride = 16 * SECOND
+        Seaborgium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
+        Seaborgium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 22 * SECOND
+
+        Bohrium.setProperty(PropertyKey.BLAST, BlastProperty(8500))
+        Bohrium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
+        Bohrium.getProperty(PropertyKey.BLAST).durationOverride = 18 * SECOND
+        Bohrium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
+        Bohrium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 14 * SECOND
+
+        RutheniumTriniumAmericiumNeutronate.getProperty(PropertyKey.BLAST).blastTemperature = 12100
+        RutheniumTriniumAmericiumNeutronate.getProperty(PropertyKey.BLAST).setEutOverride(VA[UHV])
+
+        Fermium.setProperty(PropertyKey.BLAST, BlastProperty(9500))
+        Fermium.getProperty(PropertyKey.BLAST).setEutOverride(VA[UV])
+        Fermium.getProperty(PropertyKey.BLAST).durationOverride = 22 * SECOND
+        Fermium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
+        Fermium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 12 * SECOND
+
+        Neptunium.setProperty(PropertyKey.BLAST, BlastProperty(3440))
+        Neptunium.getProperty(PropertyKey.BLAST).setEutOverride(VA[EV])
+        Neptunium.getProperty(PropertyKey.BLAST).durationOverride = 14 * SECOND
+        Neptunium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[MV])
+        Neptunium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 6 * SECOND + 5 * TICK
+
+        Technetium.setProperty(PropertyKey.BLAST, BlastProperty(2800))
+        Technetium.getProperty(PropertyKey.BLAST).setEutOverride(VA[IV])
+        Technetium.getProperty(PropertyKey.BLAST).durationOverride = 15 * SECOND
+        Technetium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[HV])
+        Technetium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 4 * SECOND + 10 * TICK
+
+        // endregion
+
+        // region Fluid Pipe Properties
+        Inconel718.setProperty(PropertyKey.FLUID_PIPE,
+                               FluidPipeProperties(2010, 175,
+                                                   true, true, true, false))
+
+        RhodiumPlatedPalladium.setProperty(PropertyKey.FLUID_PIPE,
+                                           FluidPipeProperties(6120, 225,
+                                                               true, true, true, false))
+
+        // endregion
+
+        // region Wire Properties
+
+        Rutherfordium.setProperty(PropertyKey.WIRE, WireProperties(V[ZPM].toInt(), 8, 2))
+        Seaborgium.setProperty(PropertyKey.WIRE, WireProperties(V[UEV].toInt(), 4, 16))
+
+        // endregion
+
+        // region Tool Properties
+
+        Naquadah.setProperty(PropertyKey.TOOL, MaterialToolProperty(20.0F, 8.0F, 2048, 4))
+        Iridium.setProperty(PropertyKey.TOOL, MaterialToolProperty(4.8F, 10.0F, 2560, 4))
+
+        // endregion
+
+    }
+
+    fun setOreProperties()
+    {
+        // Ores which generated in world.
         Andradite.setProperty(PropertyKey.ORE, OreProperty())
         Biotite.setProperty(PropertyKey.ORE, OreProperty())
         Uvarovite.setProperty(PropertyKey.ORE, OreProperty())
         Plutonium239.setProperty(PropertyKey.ORE, OreProperty())
 
-        // Virtual Ores for Mining Drones
+        // Virtual Ores for Mining Drone Airport or higher ore producing machines.
         Uranium.setProperty(PropertyKey.ORE, OreProperty())
         Plutonium241.setProperty(PropertyKey.ORE, OreProperty())
         Chrome.setProperty(PropertyKey.ORE, OreProperty())
         Cadmium.setProperty(PropertyKey.ORE, OreProperty())
 
-        // Ore Byproducts
-        var oreProp: OreProperty = Andradite.getProperty(PropertyKey.ORE)
+        // Set Ore Byproducts.
+        var oreProp = Andradite.getProperty(PropertyKey.ORE)
         oreProp.setOreByProducts(Andradite, Andradite, Calcium)
 
         oreProp = Dolomite.getProperty(PropertyKey.ORE)
@@ -341,91 +532,10 @@ object GTLiteMaterialProperties
 
         oreProp = Molybdenite.getProperty(PropertyKey.ORE)
         oreProp.directSmeltResult = null
+    }
 
-        // Magnetic Materials
-        ChromiumGermaniumTelluride.getProperty(PropertyKey.INGOT)
-            .magneticMaterial = ChromiumGermaniumTellurideMagnetic
-
-        Europium.getProperty(PropertyKey.INGOT)
-            .magneticMaterial = Magnetium
-
-        // Blast Properties
-        Rhenium.setProperty(PropertyKey.BLAST, BlastProperty(3459))
-        Rhenium.getProperty(PropertyKey.BLAST).durationOverride = 13 * SECOND + 8 * TICK
-
-        Uranium.setProperty(PropertyKey.BLAST, BlastProperty(600))
-        Uranium.getProperty(PropertyKey.BLAST).setEutOverride(VA[MV])
-        Uranium.getProperty(PropertyKey.BLAST).durationOverride = 15 * SECOND
-
-        Germanium.setProperty(PropertyKey.BLAST, BlastProperty(1211))
-
-        Americium.setProperty(PropertyKey.BLAST, BlastProperty(7500))
-        Americium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
-        Americium.getProperty(PropertyKey.BLAST).durationOverride = 12 * SECOND
-        Americium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[LuV])
-        Americium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 18 * SECOND
-
-        Seaborgium.setProperty(PropertyKey.BLAST, BlastProperty(8300))
-        Seaborgium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
-        Seaborgium.getProperty(PropertyKey.BLAST).durationOverride = 16 * SECOND
-        Seaborgium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
-        Seaborgium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 22 * SECOND
-
-        Bohrium.setProperty(PropertyKey.BLAST, BlastProperty(8500))
-        Bohrium.getProperty(PropertyKey.BLAST).setEutOverride(VA[ZPM])
-        Bohrium.getProperty(PropertyKey.BLAST).durationOverride = 18 * SECOND
-        Bohrium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
-        Bohrium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 14 * SECOND
-
-        RutheniumTriniumAmericiumNeutronate.getProperty(PropertyKey.BLAST).blastTemperature = 12100
-        RutheniumTriniumAmericiumNeutronate.getProperty(PropertyKey.BLAST).setEutOverride(VA[UHV])
-
-        Fermium.setProperty(PropertyKey.BLAST, BlastProperty(9500))
-        Fermium.getProperty(PropertyKey.BLAST).setEutOverride(VA[UV])
-        Fermium.getProperty(PropertyKey.BLAST).durationOverride = 22 * SECOND
-        Fermium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[IV])
-        Fermium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 12 * SECOND
-
-        Neptunium.setProperty(PropertyKey.BLAST, BlastProperty(3440))
-        Neptunium.getProperty(PropertyKey.BLAST).setEutOverride(VA[EV])
-        Neptunium.getProperty(PropertyKey.BLAST).durationOverride = 14 * SECOND
-        Neptunium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[MV])
-        Neptunium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 6 * SECOND + 5 * TICK
-
-        Technetium.setProperty(PropertyKey.BLAST, BlastProperty(2800))
-        Technetium.getProperty(PropertyKey.BLAST).setEutOverride(VA[IV])
-        Technetium.getProperty(PropertyKey.BLAST).durationOverride = 15 * SECOND
-        Technetium.getProperty(PropertyKey.BLAST).setVacuumEutOverride(VA[HV])
-        Technetium.getProperty(PropertyKey.BLAST).vacuumDurationOverride = 4 * SECOND + 10 * TICK
-
-        // Fluid Pipe Properties
-        Inconel718.setProperty(PropertyKey.FLUID_PIPE,
-                               FluidPipeProperties(2010, 175,
-                                                   true, true, true, false))
-
-        RhodiumPlatedPalladium.setProperty(PropertyKey.FLUID_PIPE,
-                                           FluidPipeProperties(6120, 225,
-                                                               true, true, true, false))
-
-        // Wire Properties
-        Rutherfordium.setProperty(PropertyKey.WIRE, WireProperties(V[ZPM].toInt(), 8, 2))
-
-        Seaborgium.setProperty(PropertyKey.WIRE, WireProperties(V[UEV].toInt(), 4, 16))
-
-        // Tool Properties
-        Naquadah.setProperty(PropertyKey.TOOL, MaterialToolProperty(20.0F, 8.0F, 2048, 4))
-        Iridium.setProperty(PropertyKey.TOOL, MaterialToolProperty(4.8F, 10.0F, 2560, 4))
-
-        // Material Formulas
-        Biotite.setFormula("KMg3Al2(AlSi3O10)F2", true)
-        Mica.setFormula("KAl2(AlSi3O10)F2", true)
-        Bauxite.setFormula("(Al2O3)3(TiO2)2(H2O)2?", true)
-        Graphene.setFormula("C8", true)
-        PalladiumRaw.setFormula("PdCl2", true)
-        RarestMetalMixture.setFormula("IrOs?", true)
-        IridiumMetalResidue.setFormula("Ir2O3", true)
-
-        // Material RGBs
+    fun setMaterialColors()
+    {
         Promethium.materialRGB = 0x24B535
         Dysprosium.materialRGB = 0xDD79DD
         Erbium.materialRGB = 0xCC6633
@@ -439,22 +549,118 @@ object GTLiteMaterialProperties
         Meitnerium.materialRGB = 0x9C1E55
     }
 
-    // region Short-circuit Material Properties Adders
-
-    private fun addIngot(material: Material) = material.setProperty(PropertyKey.INGOT, IngotProperty())
-
-    private fun addDust(material: Material) = material.setProperty(PropertyKey.DUST, DustProperty())
-
-    private fun addLiquid(material: Material) = material.setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.LIQUID, FluidBuilder()))
-
-    private fun addPlasma(material: Material) = material.getProperty(PropertyKey.FLUID).enqueueRegistration(FluidStorageKeys.PLASMA, FluidBuilder())
-
-    private fun addLiquidAndPlasma(material: Material)
+    fun setChemicalFormula()
     {
-        material.setProperty(PropertyKey.FLUID, FluidProperty(FluidStorageKeys.LIQUID, FluidBuilder()))
-        material.getProperty(PropertyKey.FLUID).enqueueRegistration(FluidStorageKeys.PLASMA, FluidBuilder())
-    }
+        // GTCEu Materials
+        Biotite.setFormula("KMg3Al2(AlSi3O10)F2", true)
+        Mica.setFormula("KAl2(AlSi3O10)F2", true)
+        Bauxite.setFormula("(Al2O3)3(TiO2)2(H2O)2?", true)
+        Graphene.setFormula("C8", true)
+        PalladiumRaw.setFormula("PdCl2", true)
+        RarestMetalMixture.setFormula("IrOs?", true)
+        IridiumMetalResidue.setFormula("Ir2O3", true)
 
-    // endregion
+        // Element Materials
+        DegenerateRhenium.setFormula("§cR§de", true)
+
+        // First Degree Materials
+        Dolomite.setFormula("CaMg(CO3)2", true)
+        Azurite.setFormula("Cu3(CO3)2(OH)2", true)
+        Forsterite.setFormula("Mg2(SiO4)", true)
+        Augite.setFormula("(Ca2MgFe)(MgFe)2(Si2O6)4", true)
+        Lizardite.setFormula("Mg3Si2O5(OH)4", true)
+        Muscovite.setFormula("KAl2(AlSi3O10)(OH)2", true)
+        Clinochlore.setFormula("Mg5Al2Si3O10(OH)8", true)
+        Fluorapatite.setFormula("Ca5(PO4)3F", true)
+        Lignite.setFormula("C3(H2O)", true)
+        Firestone.setFormula("(SiO2)3(FeS2)?", true)
+        Iron3Sulfate.setFormula("Fe2(SO4)3", true)
+        Phlogopite.setFormula("KMg3(AlSi3O10)F2", true)
+        Nephelite.setFormula("KNa3(AlSiO4)4", true)
+        HeavyAlkaliChloridesSolution.setFormula("(RbCl)(CsCl)2Cl3(H2O)2", true)
+        AluminiumHydroxide.setFormula("Al(OH)3", true)
+        AluminiumSulfate.setFormula("Al2(SO4)3", true)
+        ZSM5.setFormula("Na(Al2(SO4)3)(SiO2)2(H2O)2", true)
+        Jasper.setFormula("CaMg5(OH)2(Si4O11)2", true)
+        LeadNitrate.setFormula("Pb(NO3)2", true)
+        TitaniumNitrate.setFormula("Ti(NO3)4", true)
+        PalladiumNitrate.setFormula("Pd(NO3)2", true)
+        PalladiumAcetate.setFormula("Pd(CH3COOH)2", true)
+        Dimethylcadmium.setFormula("(CH3)2Cd", true)
+        ZBLANGlass.setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2", true)
+        ErbiumDopedZBLANGlass.setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2Er", true)
+        PraseodymiumDopedZBLANGlass.setFormula("(ZrF4)5(BaF2)2(LaF3)(AlF3)(NaF)2Pr", true)
+        CubicZirconia.setFormula("c-ZrO2", true)
+        MagnetoResonatic.setFormula("(Bi2Te3)4((SiO2)5Fe)3(ZrO2)Fe", true)
+        PlatinumGroupResidue.setFormula("RuRhIr2Os(HNO3)3", true)
+        PlatinumGroupConcentrate.setFormula("AuPtPd(HCl)6", true)
+        PurifiedPlatinumGroupConcentrate.setFormula("H2PtPdCl6", true)
+        AmmoniumHexachloroplatinate.setFormula("(NH4)2PtCl6", true)
+        AmmoniumHexachloropalladate.setFormula("(NH4)2PdCl6", true)
+        YttriumNitrate.setFormula("Y(NO3)3", true)
+        BariumNitrate.setFormula("Ba(NO3)2", true)
+        CopperNitrate.setFormula("Cu(NO3)2", true)
+        RoastedSphalerite.setFormula("(GeO2)?", true)
+        ZincRichSphalerite.setFormula("Zn2(GaGeO2)?", true)
+        WaelzOxide.setFormula("(GeO2)Zn", true)
+        WaelzSlag.setFormula("(ZnSO4)Ga", true)
+        HydroxyquinolineAluminium.setFormula("(C9H7NO)Al", true)
+        BariumHydroxide.setFormula("Ba(OH)2", true)
+        AmmoniumNitrate.setFormula("NH4NO3", true)
+        BismuthStrontiumCalciumCuprate.setFormula("Bi2Sr2CaCu2O8", true)
+        AdamantiumUnstable.setFormula("Ad*", true)
+        VibraniumUnstable.setFormula("Vb*", true)
+        LithiumSodiumPotassiumFluorides.setFormula("F3LiNaK", true)
+        LithiumBerylliumFluorides.setFormula("F3LiBe", true)
+        FleroviumYtterbiumPlasma.setFormula("FlY?", true)
+        SodiumAcetate.setFormula("C2H3NaO2", true)
+        HexagonalBoronNitride.setFormula("h-BN", true)
+        CubicBoronNitride.setFormula("c-BN", true)
+        AmorphousBoronNitride.setFormula("a-BN", true)
+        CubicHeterodiamond.setFormula("c-BC2N", true)
+        CalciumHydroxide.setFormula("Ca(OH)2", true)
+        AluminiumNitrate.setFormula("Al(NO3)3", true)
+        ChlorinatedSolvents.setFormula("(CH4)2Cl5", true)
+        AluminaSolution.setFormula("(Al2O3)(CH2Cl2)(C12H27N)2", true)
+        NdYAG.setFormula("Nd:YAG", true)
+        PoloniumNitrate.setFormula("Po(NO3)4", true)
+        SodiumPolonate.setFormula("Na2PoO4", true)
+        UranylNitrateSolution.setFormula("(UO2)(NO3)2(H2O)?", true)
+        ThoriumNitrate.setFormula("Th(NO3)4", true)
+        UranylNitrate.setFormula("UO2(NO3)2", true)
+        ActiniumOxalate.setFormula("Ac(CO2)4", true)
+        SodiumFormate.setFormula("HCOONa", false)
+        BETSPerrhenate.setFormula("(C10H8S4Se4)ReO4", true)
+        SilicaGelBase.setFormula("(SiNa(OH)O2)(HCl)(H2O)", true)
+        AmmoniumSulfate.setFormula("(NH4)2SO4", true)
+        AmmoniumCarbonate.setFormula("(NH4)2CO3", true)
+        AmmoniumAcetate.setFormula("NH4CH3CO2", true)
+        AmmoniumPersulfate.setFormula("(NH4)2S2O8", true)
+        PalladiumFullereneMatrix.setFormula("(C73H15NFe)Pd", true)
+        LuTmYChloridesSolution.setFormula("(LuCl3)2(TmCl3)2(YCl3)6(H2O)15", true)
+        LuTmDopedYttriumVanadateDeposition.setFormula("Lu/Tm:YVO?", false)
+        LuTmYVO.setFormula("Lu/Tm:YVO", false)
+        HexagonalSiliconNitride.setFormula("h-Si3N4", true)
+        CubicSiliconNitride.setFormula("c-Si3N4", true)
+        CeriumCarbonate.setFormula("Ce2(CO3)3", true)
+        PlutoniumTrihydride.setFormula("PuH3", true)
+        PlutoniumPhosphide.setFormula("PuP", true)
+        LanthanumFullereneMixture.setFormula("(C60H30)2La2", true)
+        LanthanumEmbeddedFullerene.setFormula("(C60)2La2", true)
+        LanthanumFullereneNanotube.setFormula("C48C60La", true)
+        PrHoYNitratesSolution.setFormula("(Pr(NO3)3)2(Ho(NO3)3)2(Y(NO3)3)6(H2O)15", true)
+        PrHoYLF.setFormula("Pr/Ho:YLF", true)
+        TrichlorocyclopentadienylTitanium.setFormula("(C5H5)2Cl3Ti", true)
+        PhotopolymerSolution.setFormula("C149H97N10O2(TiBF20)", true)
+        PotassiumFerrocyanideTrihydrate.setFormula("K4Fe(CN)6(H2O)3", true)
+        PrussianBlue.setFormula("Fe4[Fe(CN)6]3", true)
+        CopperArsenite.setFormula("Cu3(AsO4)2", true)
+        ThalliumThuliumDopedCaesiumIodide.setFormula("Tl/Tm:CsI", false)
+        SodiumAlginate.setFormula("C5H7O4COONa", true)
+        CalciumAlginate.setFormula("(C5H7O4COO)2Ca", true)
+        ChromaticGlass.setFormula("(SiO2)64", true)
+        PlutoniumDioxide.setFormula("PuO2", true)
+        MOX.setFormula("(PuO2)(UO2)2", true)
+    }
 
 }

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/material/properties/GTLiteMaterialProperties.kt
@@ -177,6 +177,9 @@ import gregtechlite.gtlitecore.api.extension.addIngot
 import gregtechlite.gtlitecore.api.extension.addLiquid
 import gregtechlite.gtlitecore.api.extension.addLiquidAndPlasma
 import gregtechlite.gtlitecore.api.extension.addPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetamide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Acetonitrile
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AcetylChloride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumGroupAlloyA
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ActiniumOxalate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AdamantiumUnstable
@@ -185,18 +188,29 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumHydroxid
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AluminiumSulfate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumAcetate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumBifluoride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumCarbonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumCyanate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumHexachloropalladate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumHexachloroplatinate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumPersulfate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmmoniumSulfate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.AmorphousBoronNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Aniline
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BETSPerrhenate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BariumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BenzylBromide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BenzyltrimethylammoniumBromide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BiphenylTetracarboxylicAcidDianhydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BismuthStrontiumCalciumCuprate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Bistrichloromethylbenzene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.BlueSchist
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Bromobutane
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butanediol
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butanol
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Butyllithium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CalciumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CeriumCarbonate
@@ -209,19 +223,49 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicBoronNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicHeterodiamond
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicSiliconNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CubicZirconia
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CyanIndigo
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DegenerateRhenium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Diaminotoluene
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DiethylEther
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DiethylSulfide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DiethylhexylPhosphoricAcid
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Diethylthiourea
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Difluorobenzophenone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DimethylSulfide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylacetamide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DimethylamineHydrochloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylaminopyridine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylcadmium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dimethylformamide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Dinitrodipropanyloxybenzene
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Durene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ErbiumDopedZBLANGlass
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylanthrahydroquinone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylanthraquinone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.EthyleneGlycol
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Ethylenediamine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Firestone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FleroviumYtterbiumPlasma
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FormicAcid
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.FullerenePolymerMatrix
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GelidCryotheum
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.GreenSchist
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HalkoniteSteel
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HeavyAlkaliChloridesSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalBoronNitride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalSiliconNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Hexamethylenetetramine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Hydroquinone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HydroxyquinolineAluminium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Indanone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Indene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Iron3Sulfate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Isochloropropane
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.IsopropylChloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.KaptonE
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.KaptonK
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kevlar
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kimberlite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Komatiite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Kovar
@@ -239,25 +283,45 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.LuTmYVO
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MOX
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Magnetium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MagnetoResonatic
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.MethylFormate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Methylamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Methyltrichlorosilane
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.NHydroxysuccinimide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Naphthylamine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.NdYAG
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Nitroaniline
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Nitrotoluene
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Oxydianiline
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumAcetate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumFullereneMatrix
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PalladiumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ParaPhenylenediamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ParaXylene
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Periodicium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Phenothiazine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Phenylsodium
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PhotopolymerSolution
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PhthalicAnhydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupConcentrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlatinumGroupResidue
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumDioxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumPhosphide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PlutoniumTrihydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PoloniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolyphosphonitrileFluoroRubber
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolystyreneSulfonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Polytetrahydrofuran
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolytetramethyleneGlycolRubber
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PotassiumFerrocyanideTrihydrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrHoYLF
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrHoYNitratesSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PraseodymiumDopedZBLANGlass
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PrussianBlue
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PurifiedPlatinumGroupConcentrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PyromelliticDianhydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RareEarthAlloy
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RawPolyphosphonitrileFluoroRubber
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RawPolytetramethyleneGlycolRubber
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.RoastedSphalerite
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Shale
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SilicaGelBase
@@ -266,12 +330,29 @@ import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAcetate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumAlginate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumFormate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SodiumPolonate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.SuccinicAnhydride
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TantalumHafniumSeaborgiumCarbide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TerephthalicAcid
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TerephthaloylChloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Tetrabromoindigo
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TetraethylammoniumBromide
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Tetrahydrofuran
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TetramethylammoniumChloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TetramethylammoniumHydroxide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThalliumThuliumDopedCaesiumIodide
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ThoriumNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TitaniumNitrate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TolueneDiisocyanate
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TolueneTetramethylDiisocyanate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TransitionAlloy
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Tributylamine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TrichlorocyclopentadienylTitanium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trimethylaluminium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trimethylamine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trimethylgallium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TrimethyltinChloride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Triphenylphosphine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Trisaminoethylamine
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrate
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.UranylNitrateSolution
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.VibraniumUnstable
@@ -567,7 +648,6 @@ object GTLiteMaterialProperties
     fun setChemicalFormula()
     {
         // region GTCEu Materials
-
         Biotite.setFormula("KMg3Al2(AlSi3O10)F2", true)
         Mica.setFormula("KAl2(AlSi3O10)F2", true)
         Bauxite.setFormula("(Al2O3)3(TiO2)2(H2O)2?", true)
@@ -575,17 +655,13 @@ object GTLiteMaterialProperties
         PalladiumRaw.setFormula("PdCl2", true)
         RarestMetalMixture.setFormula("IrOs?", true)
         IridiumMetalResidue.setFormula("Ir2O3", true)
-
         // endregion
 
         // region Element Materials
-
         DegenerateRhenium.setFormula("§cR§de", true)
-
         // endregion
 
         // region First Degree Materials
-
         Dolomite.setFormula("CaMg(CO3)2", true)
         Azurite.setFormula("Cu3(CO3)2(OH)2", true)
         Forsterite.setFormula("Mg2(SiO4)", true)
@@ -683,11 +759,9 @@ object GTLiteMaterialProperties
         ChromaticGlass.setFormula("(SiO2)64", true)
         PlutoniumDioxide.setFormula("PuO2", true)
         MOX.setFormula("(PuO2)(UO2)2", true)
-
         // endregion
 
         // region Second Degree Materials
-
         Kovar.setFormula("Fe10Ni5Co3", true)
         HalkoniteSteel.setFormula("SpNt2((FeW)8*Nq*7?4C4(VCrFe7)3Fr)2P8(((WC)(TiC)2)3(CaMg5(OH)2(Si4O11)2)3Tr2)If", true)
         TantalumHafniumSeaborgiumCarbide.setFormula("Ta12Hf3SgC16", true)
@@ -698,11 +772,9 @@ object GTLiteMaterialProperties
                                + "AsSeBrKrRbSrYZrNbMoTcRuRhPdAgCdInSnSbTeIXeCsBaLaCePrNdPm"
                                + "SmEuGdTbDyHoErTmYbLuHfTaWReOsIrPtAuHgTlPbBiPoAtRnFrRaAcTh"
                                + "PaUNpPuAmCmBkCfEsFmMdNoLrRfDbSgBhHsMtDsRgCnNhFlMcLvTsOg")
-
         // endregion
 
         // region Third Degree Materials
-
         Limestone.setFormula("(CaCO3)4(CaMg(CO3)2)?", true)
         Komatiite.setFormula("(Mg2Fe(SiO2)2)2(MgCO3)(SiO2)?", true)
         GreenSchist.setFormula("(Ca2Al3Si3HO13)2(SiO2)2(Mg3Si4H2O12)?", true)
@@ -710,8 +782,94 @@ object GTLiteMaterialProperties
         Kimberlite.setFormula("(Mg2(SiO4))3((Ca2MgFe)(MgFe)2(Si2O6)4)3(Ca3Fe2Si3O12)2?", true)
         Slate.setFormula("(SiO2)5(KAl2(AlSi3O10)(OH)2)2(Mg5Al2Si3O10(OH)8)2?", true)
         Shale.setFormula("(CaCO3)6(Na2LiAl2Si2(H2O)6)2(SiO2)(CaF2)?", true)
-
         GelidCryotheum.setFormula("((Si(FeS2)5(CrAl2O3)Hg3)(AgAu))(H2O)3", true)
+        // endregion
+
+        // region Organic Chemistry Materials
+        ParaXylene.setFormula("C6H4(CH3)2", true)
+        Nitrotoluene.setFormula("C6H4CH3NO2", true)
+        Butanediol.setFormula("C4H8(OH)2", true)
+        Tetrahydrofuran.setFormula("(CH2)4O", true)
+        DiethylhexylPhosphoricAcid.setFormula("(C8H7O)2PO2H", true)
+        FormicAcid.setFormula("HCOOH", true)
+        MethylFormate.setFormula("HCO2CH3", true)
+        PhthalicAnhydride.setFormula("C6H4(CO)2O", true)
+        Ethylanthraquinone.setFormula("C6H4(CO)2C6H3Et", true)
+        Ethylanthrahydroquinone.setFormula("C6H4(CH2OH)2C6H3Et", true)
+        Durene.setFormula("C6H2(CH3)4", true)
+        PyromelliticDianhydride.setFormula("C6H2(C2O3)2", true)
+        Aniline.setFormula("C6H5NH2", true)
+        Oxydianiline.setFormula("O(C6H4NH2)2", true)
+        KaptonK.setFormula("(C7H2N2O4)(O(C6H4)2)", true)
+        BiphenylTetracarboxylicAcidDianhydride.setFormula("(C8H3O3)2", true)
+        Nitroaniline.setFormula("H2NC6H4NO2", true)
+        ParaPhenylenediamine.setFormula("H2NC6H4NH2", true)
+        KaptonE.setFormula("O(C6H4NH2)2", true)
+        EthyleneGlycol.setFormula("C2H4(OH)2", true)
+        PolystyreneSulfonate.setFormula("C8H7SO3H", true)
+        Methylamine.setFormula("CH3NH2", true)
+        Trimethylamine.setFormula("(CH3)3N", true)
+        TetramethylammoniumChloride.setFormula("N(CH3)4Cl", true)
+        TetramethylammoniumHydroxide.setFormula("N(CH3)4OH", true)
+        Ethylenediamine.setFormula("C2H4(NH2)2", true)
+        RawPolyphosphonitrileFluoroRubber.setFormula("(CH2CF3)6(CH2C3F7)2(C2F4)2(NPO)4O4", true)
+        PolyphosphonitrileFluoroRubber.setFormula("(CH2CF3)6(CH2C3F7)2(C2F4)2(NPO)4O4", true)
+        Polytetrahydrofuran.setFormula("(C4H8O)OH2", true)
+        Diaminotoluene.setFormula("C6H3(NH2)2CH3", true)
+        TolueneDiisocyanate.setFormula("CH3C6H3(NCO)2", true)
+        TolueneTetramethylDiisocyanate.setFormula("(CONH)2(C6H4)2CH2(C4O)", true)
+        RawPolytetramethyleneGlycolRubber.setFormula("(CONH)2(C6H4)2CH2(C4O)HO(CH2)4OH", true)
+        PolytetramethyleneGlycolRubber.setFormula("(CONH)2(C6H4)2CH2(C4O)HO(CH2)4OH", true)
+        Difluorobenzophenone.setFormula("(FC6H4)2CO", true)
+        Hydroquinone.setFormula("C6H4(OH)2", true)
+        Isochloropropane.setFormula("CH3CHClCH3", true)
+        Dinitrodipropanyloxybenzene.setFormula("C12H16O2(NO2)2", true)
+        TerephthalicAcid.setFormula("C6H4(CO2H)2", true)
+        Bistrichloromethylbenzene.setFormula("C6H4(CCl3)2", true)
+        TerephthaloylChloride.setFormula("C6H4(COCl)2", true)
+        Kevlar.setFormula("(C6H4)2(CO)2(NH)2", true)
+        Trimethylaluminium.setFormula("Al2(CH3)6", true)
+        Trimethylgallium.setFormula("Ga(CH3)3", true)
+        AmmoniumCyanate.setFormula("NH4CNO", true)
+        Butanol.setFormula("C4H9OH", true)
+        Tributylamine.setFormula("(C4H9)3N", true)
+        DiethylEther.setFormula("(C2H5)2O", true)
+        BenzylBromide.setFormula("C6H5CH2Br", true)
+        BenzyltrimethylammoniumBromide.setFormula("C6H5CH2N(CH3)3Br", true)
+        Indene.setFormula("C6H4C3H4", true)
+        Indanone.setFormula("C6H4C3H4O", true)
+        Bromobutane.setFormula("C4H9Br", true)
+        Butyllithium.setFormula("C4H9Li", true)
+        AcetylChloride.setFormula("CH3COCl", true)
+        Dimethylacetamide.setFormula("(CH3)2NC(O)CH3", true)
+        SuccinicAnhydride.setFormula("(CH2CO)2O", true)
+        NHydroxysuccinimide.setFormula("(CH2CO)2NOH", true)
+        DimethylamineHydrochloride.setFormula("C2H8NCl", true)
+        Dimethylformamide.setFormula("(CH3)2NC(O)H", true)
+        Acetonitrile.setFormula("CH3CN", true)
+        Acetamide.setFormula("CH3CONH2", true)
+        Hexamethylenetetramine.setFormula("(CH2)6N4", true)
+        TrimethyltinChloride.setFormula("(CH3)3SnCl", true)
+        Dimethylaminopyridine.setFormula("(CH3)2NC5H4N", true)
+        Triphenylphosphine.setFormula("(C6H5)3P", true)
+        DimethylSulfide.setFormula("(CH3)2S", true)
+        FullerenePolymerMatrix.setFormula("(C153H36NO2)PdFe", true)
+        Methyltrichlorosilane.setFormula("Si(CH3)Cl3", true)
+        DiethylSulfide.setFormula("(C2H5)2S", true)
+        Phenothiazine.setFormula("C12H9NS", true)
+        IsopropylChloride.setFormula("(CH3)2CHCl", true)
+        AmmoniumBifluoride.setFormula("NH4HF2", true)
+        TetraethylammoniumBromide.setFormula("N(CH2CH3)4Br", true)
+        Phenylsodium.setFormula("C6H5Na", true)
+        Tetrabromoindigo.setFormula("C16H6Br4N2O2", true)
+        CyanIndigo.setFormula("(C16H10N2O2)2Br4", true)
+        Naphthylamine.setFormula("C10H8NH", true)
+        Trisaminoethylamine.setFormula("(NH2CH2CH2)3N", true)
+        Ethylamine.setFormula("C2H5NH2", true)
+        Diethylthiourea.setFormula("(C2H5NH)2CS", true)
+        // endregion
+
+        // region Unknown Composition Materials
 
         // endregion
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/common/EventHandlers.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/common/EventHandlers.kt
@@ -40,7 +40,7 @@ object EventHandlers
         GTLiteOrePrefix.addToMetaItem()
         GTLiteMaterials.init()
         GTLiteOrePrefix.setOrePrefixInfos()
-        GTLiteMaterialProperties.setMaterialProperties()
+        GTLiteMaterialProperties.init()
         GTLiteToolPropertyAdder.initSoftToolProperties()
         GTLiteMaterialFlags.setMaterialFlags()
         GTLiteMaterialIconSet.setMaterialIconSets()


### PR DESCRIPTION
This PR overhaul `Material.Builder`, `MaterialToolProperty.Builder`, `FluidBuilder` and `BlastProperty.Builder` usage in all Material Registries, replaced all complicated methods with DSL mode.

Now we can create a GTCEu format material with Kotlin DSL syntax:
```kotlin
Adamantium = addMaterial(1, "adamantium")
{
    ingot()
    liquid().plasma()
    color(0xFF0040).iconSet(METALLIC)
    element(Ad)
    flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_GEAR,
          GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
    blastProp(10501, GasTier.HIGH, // Tritanium
              VA[UV], 45 * SECOND,
              VA[ZPM], 22 * SECOND + 10 * TICK)
    rotorProp(22.0f, 10.0f, 491520)
    toolProp(140.0F, 95.0F, 49152, 6)
    {
        attackSpeed(0.5F)
        enchantability(32)
        enchantment(Enchantments.FORTUNE, 5)
        magnetic()
    }
    cableProp(V[UHV], 4, 24)
}
```