### PR TITLE
refactor: Dropped all Java external dependencies and clean up related usages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,13 +149,6 @@ dependencies {
 
     compileOnlyApi(libs.jetbrainsAnnotations)
     annotationProcessor(libs.jetbrainsAnnotations)
-
-    compileOnlyApi(libs.lombok)
-    annotationProcessor(libs.lombok)
-
-    embed(libs.streamex)
-    embed(libs.jheaps)
-    embed(libs.joml)
 }
 
 fun DependencyHandler.deobf(dependencyNotation: Any): Any {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,10 +5,6 @@ asm = "5.2"
 guava = "24.1.1-jre"
 gson = "2.8.6"
 jetbrainsAnnotations = "24.1.0"
-lombok = "1.18.24"
-streamex = "0.8.3"
-jheaps = "0.14"
-joml = "1.10.4"
 
 # Mods
 forgelin = "2.1.0.0"
@@ -36,10 +32,6 @@ asm = { group = "org.ow2.asm", name = "asm-debug-all", version.ref = "asm" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }
-lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
-streamex = { group = "one.util", name = "streamex", version.ref = "streamex" }
-jheaps = { group = "org.jheaps", name = "jheaps", version.ref = "jheaps" }
-joml = { group = "org.joml", name = "joml", version.ref = "joml" }
 
 forgelin = { group = "io.github.chaosunity.forgelin", name = "Forgelin-Continuous", version.ref = "forgelin" }
 mixinBooter = { group = "zone.rong", name = "mixinbooter", version.ref = "mixinBooter" }

--- a/src/main/java/gregtechlite/gtlitecore/common/CommonProxy.java
+++ b/src/main/java/gregtechlite/gtlitecore/common/CommonProxy.java
@@ -26,7 +26,6 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistry;
-import one.util.streamex.StreamEx;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
@@ -134,12 +133,12 @@ public class CommonProxy
         // TODO Crops?...
 
         // Sheeted frames.
-        StreamEx.of(GTLiteBlocks.SHEETED_FRAMES.values())
+        GTLiteBlocks.SHEETED_FRAMES.values().stream()
                 .distinct()
                 .forEach(registry::register);
 
         // Gregtech Walls
-        StreamEx.of(GTLiteBlocks.METAL_WALLS.values())
+        GTLiteBlocks.METAL_WALLS.values().stream()
                 .distinct()
                 .forEach(registry::register);
 
@@ -255,14 +254,14 @@ public class CommonProxy
         registry.register(createItemBlock(GTLiteBlocks.LEPTONIC_CHARGE, ItemBlock::new));
         registry.register(createItemBlock(GTLiteBlocks.QUANTUM_CHROMODYNAMIC_CHARGE, ItemBlock::new));
 
-        StreamEx.of(GTLiteBlocks.SHEETED_FRAMES.values())
+        GTLiteBlocks.SHEETED_FRAMES.values().stream()
                 .distinct()
-                .map(b -> createItemBlock(b, SheetedFrameItemBlock::new))
+                .map(block -> createItemBlock(block, SheetedFrameItemBlock::new))
                 .forEach(registry::register);
 
-        StreamEx.of(GTLiteBlocks.METAL_WALLS.values())
+        GTLiteBlocks.METAL_WALLS.values().stream()
                 .distinct()
-                .map(b -> createItemBlock(b, d -> new MaterialItemBlock(d, GTLiteOrePrefix.wallGt)))
+                .map(block -> createItemBlock(block, blockWall -> new MaterialItemBlock(blockWall, GTLiteOrePrefix.wallGt)))
                 .forEach(registry::register);
 
         registry.register(createItemBlock(GTLiteBlocks.MOTOR_CASING, VariantItemBlock::new));

--- a/src/main/java/gregtechlite/gtlitecore/core/command/Commands.java
+++ b/src/main/java/gregtechlite/gtlitecore/core/command/Commands.java
@@ -1,7 +1,6 @@
 package gregtechlite.gtlitecore.core.command;
 
 import com.morphismmc.morphismlib.collection.ListOps;
-import lombok.NoArgsConstructor;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -15,7 +14,6 @@ import static gregtechlite.gtlitecore.api.GTLiteValues.MOD_ID;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-@NoArgsConstructor
 public class Commands extends CommandTreeBase
 {
 

--- a/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinOreConfigUtils.java
+++ b/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinOreConfigUtils.java
@@ -4,9 +4,10 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.worldgen.config.OreConfigUtils;
-import one.util.streamex.StreamEx;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+
+import java.util.stream.Collectors;
 
 import static gregtechlite.gtlitecore.api.GTLiteValues.MOD_ID;
 
@@ -28,9 +29,9 @@ public abstract class MixinOreConfigUtils
         }
         else if (material == null)
         {
-            return StreamEx.of(GregTechAPI.materialManager.getRegistry(MOD_ID).getAllMaterials())
+            return GregTechAPI.materialManager.getRegistry(MOD_ID).getAllMaterials().stream()
                     .filter(mat -> mat.getName().equals(name))
-                    .toList().get(0);
+                    .collect(Collectors.toList()).get(0);
         }
         else
         {


### PR DESCRIPTION
This PR dropped `lombok`, `joml`, `jheaps` and `streamex` dependencies for the global module dependencies, because these are only useful for Java development, and the mod is refactor by pure Kotlin now.