### PR TITLE
refactor: Clean up recipe handlers and duplicated recipe progressing registries

### DIFF
--- a/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinOreRecipeHandler.java
+++ b/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinOreRecipeHandler.java
@@ -13,6 +13,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinOreRecipeHandler
 {
 
+    /**
+     * Disabled crushedPurified recipes initialization.
+     *
+     * @see gregtechlite.gtlitecore.loader.recipe.handler.OreRecipeHandler
+     */
     @Inject(method = "register",
             at = @At("HEAD"),
             cancellable = true)
@@ -21,6 +26,7 @@ public abstract class MixinOreRecipeHandler
         OrePrefix.ore.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
         OrePrefix.oreEndstone.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
         OrePrefix.oreNetherrack.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
+
         if (ConfigHolder.worldgen.allUniqueStoneTypes)
         {
             OrePrefix.oreGranite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
@@ -35,7 +41,6 @@ public abstract class MixinOreRecipeHandler
         }
 
         OrePrefix.crushed.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedOre);
-        // OrePrefix.crushedPurified.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedPurified);
         OrePrefix.crushedCentrifuged.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedCentrifuged);
         OrePrefix.dustImpure.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processDirtyDust);
         OrePrefix.dustPure.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processPureDust);

--- a/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinPartsRecipeHandler.java
+++ b/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinPartsRecipeHandler.java
@@ -12,12 +12,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinPartsRecipeHandler
 {
 
+    /**
+     * Disabled stick and lens recipes initialization.
+     *
+     * @see gregtechlite.gtlitecore.loader.recipe.handler.PartsRecipeHandler
+     */
     @Inject(method = "register",
             at = @At("HEAD"),
             cancellable = true)
-    private static void callbackRegistrate(CallbackInfo ci)
+    private static void stopInit(CallbackInfo ci)
     {
-        // OrePrefix.stick.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processStick);
         OrePrefix.stickLong.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processLongStick);
         OrePrefix.plate.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processPlate);
         OrePrefix.plateDouble.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processPlateDouble);
@@ -29,7 +33,6 @@ public abstract class MixinPartsRecipeHandler
         OrePrefix.screw.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processScrew);
         OrePrefix.wireFine.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFineWire);
         OrePrefix.foil.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processFoil);
-        // OrePrefix.lens.addProcessingHandler(PropertyKey.GEM, PartsRecipeHandler::processLens);
 
         OrePrefix.gear.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processGear);
         OrePrefix.gearSmall.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processGear);
@@ -40,6 +43,5 @@ public abstract class MixinPartsRecipeHandler
 
         ci.cancel();
     }
-
 
 }

--- a/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinWireCombiningHandler.java
+++ b/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinWireCombiningHandler.java
@@ -10,18 +10,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinWireCombiningHandler
 {
 
+    /**
+     * Disabled all wire combining recipes initialization.
+     *
+     * @see gregtechlite.gtlitecore.loader.recipe.handler.WireCombinationHandler
+     */
     @Inject(method = "register",
             at = @At("HEAD"),
             cancellable = true)
-    private static void callbackRegistrate(CallbackInfo ci)
+    private static void stopInit(CallbackInfo ci)
     {
-        // OrePrefix.wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireCombiningHandler::processWireCompression);
-        // for (OrePrefix wirePrefix : WIRE_DOUBLING_ORDER) {
-        //     wirePrefix.addProcessingHandler(PropertyKey.WIRE, WireCombiningHandler::generateWireCombiningRecipe);
-        // }
-        // for (OrePrefix cablePrefix : cableToWireMap.keySet()) {
-        //     cablePrefix.addProcessingHandler(PropertyKey.WIRE, WireCombiningHandler::processCableStripping);
-        // }
         ci.cancel();
     }
 

--- a/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinWireRecipeHandler.java
+++ b/src/main/java/gregtechlite/gtlitecore/mixins/gregtech/MixinWireRecipeHandler.java
@@ -12,13 +12,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinWireRecipeHandler
 {
 
+    /**
+     * Disabled {@code generateCableCovering()} for all wireGt orePrefixes.
+     * <p>
+     * Only generate wireGtSingle recipes, this method used to generate wiremill recipes.
+     *
+     * @see gregtechlite.gtlitecore.loader.recipe.handler.WireRecipeHandler
+     */
     @Inject(method = "register",
             at = @At("HEAD"),
             cancellable = true)
-    private static void callbackRegistrate(CallbackInfo ci)
+    private static void stopInit(CallbackInfo ci)
     {
         OrePrefix.wireGtSingle.addProcessingHandler(PropertyKey.WIRE, WireRecipeHandler::processWireSingle);
-        // Deleted all generateCableCovering() including.
         ci.cancel();
     }
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/api/mixins/MixinExtension.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/mixins/MixinExtension.kt
@@ -8,4 +8,4 @@ package gregtechlite.gtlitecore.api.mixins
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
-annotation class MixinExtension()
+annotation class MixinExtension

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/CraftingRecipeLoader.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/CraftingRecipeLoader.kt
@@ -45,6 +45,11 @@ import gregtech.common.items.MetaItems.SHAPE_MOLD_GEAR_SMALL
 import gregtech.common.items.MetaItems.SHAPE_MOLD_INGOT
 import gregtech.common.items.MetaItems.SHAPE_MOLD_NAME
 import gregtech.common.items.MetaItems.SHAPE_MOLD_NUGGET
+import gregtech.common.items.MetaItems.SHAPE_MOLD_PIPE_HUGE
+import gregtech.common.items.MetaItems.SHAPE_MOLD_PIPE_LARGE
+import gregtech.common.items.MetaItems.SHAPE_MOLD_PIPE_NORMAL
+import gregtech.common.items.MetaItems.SHAPE_MOLD_PIPE_SMALL
+import gregtech.common.items.MetaItems.SHAPE_MOLD_PIPE_TINY
 import gregtech.common.items.MetaItems.SHAPE_MOLD_PLATE
 import gregtech.common.items.MetaItems.SHAPE_MOLD_RING
 import gregtech.common.items.MetaItems.SHAPE_MOLD_ROD
@@ -115,8 +120,7 @@ internal object CraftingRecipeLoader
     {
         ToolRecipeHandler.registerCustomToolRecipes()
 
-        // Modified all recipes of original shape molds because we need to add
-        // more shape molds (even more and more in future).
+        // Modified all recipes of original shape molds because we need to add more shape molds.
 
         // Shape Mold (Plate)
         ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_plate")
@@ -196,9 +200,6 @@ internal object CraftingRecipeLoader
             "   ", " M ", "f h",
             'M', SHAPE_EMPTY)
 
-        // Add recipes to additional shape molds, should ensure there are not
-        // any conflicts with original extruders.
-
         // Shape Mold (Rod)
         ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_rod")
         ModHandler.addShapedRecipe(true, "shape_mold.rod", SHAPE_MOLD_ROD.stackForm,
@@ -217,11 +218,6 @@ internal object CraftingRecipeLoader
             "f  ", " Mh", "   ",
             'M', SHAPE_EMPTY)
 
-        // Shape Mold (Screw)
-        ModHandler.addShapedRecipe(true, "shape_mold.screw", SHAPE_MOLD_SCREW.stackForm,
-            " f ", " Mh", "   ",
-            'M', SHAPE_EMPTY)
-
         // Shape Mold (Ring)
         ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_ring")
         ModHandler.addShapedRecipe(true, "shape_mold.ring", SHAPE_MOLD_RING.stackForm,
@@ -234,6 +230,43 @@ internal object CraftingRecipeLoader
             "   ", " M ", " fh",
             'M', SHAPE_EMPTY)
 
+        // Shape Mold (Pipe Tiny)
+        ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_pipe_tiny")
+        ModHandler.addShapedRecipe(true, "shape_mold.pipe_tiny", SHAPE_MOLD_PIPE_TINY.stackForm,
+            "h  ", " M ", "  f",
+            'M', SHAPE_EMPTY)
+
+        // Shape Mold (Pipe Small)
+        ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_pipe_small")
+        ModHandler.addShapedRecipe(true, "shape_mold.pipe_small", SHAPE_MOLD_PIPE_SMALL.stackForm,
+            "  h", " M ", "f  ",
+            'M', SHAPE_EMPTY)
+
+        // Shape Mold (Pipe Normal)
+        ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_pipe_normal")
+        ModHandler.addShapedRecipe(true, "shape_mold.pipe_normal", SHAPE_MOLD_PIPE_NORMAL.stackForm,
+            "h f", " M ", "   ",
+            'M', SHAPE_EMPTY)
+
+        // Shape Mold (Pipe Large)
+        ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_pipe_large")
+        ModHandler.addShapedRecipe(true, "shape_mold.pipe_large", SHAPE_MOLD_PIPE_LARGE.stackForm,
+            "   ", " M ", "h f",
+            'M', SHAPE_EMPTY)
+
+        // Shape Mold (Pipe Huge)
+        ModHandler.removeRecipeByName("${GTValues.MODID}:shape_mold_pipe_huge")
+        ModHandler.addShapedRecipe(true, "shape_mold.pipe_huge", SHAPE_MOLD_PIPE_HUGE.stackForm,
+            "   ", " M ", "fh ",
+            'M', SHAPE_EMPTY)
+
+        // Add recipes to additional shape molds, should ensure there are not any conflicts with original extruders.
+
+        // Shape Mold (Screw)
+        ModHandler.addShapedRecipe(true, "shape_mold.screw", SHAPE_MOLD_SCREW.stackForm,
+            " f ", " Mh", "   ",
+            'M', SHAPE_EMPTY)
+
         // Shape Mold (Turbine Blade)
         ModHandler.addShapedRecipe(true, "shape_mold.turbine_blade", SHAPE_MOLD_TURBINE_BLADE.stackForm,
             "   ", "fM ", "  h",
@@ -244,8 +277,7 @@ internal object CraftingRecipeLoader
             "   ", " M ", " hf",
             'M', SHAPE_EMPTY)
 
-        // Add recipes to additional shape extruders, should ensure there are not
-        // any conflicts with original extruders.
+        // Add recipes to additional shape extruders, should ensure there are not any conflicts with original extruders.
 
         // Shape Extruder (Round)
         ModHandler.addShapedRecipe(true, "shape_extruder.round", SHAPE_EXTRUDER_ROUND.stackForm,

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/OreRecipeHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/OreRecipeHandler.kt
@@ -3,23 +3,47 @@ package gregtechlite.gtlitecore.loader.recipe.handler
 import gregtech.api.GTValues.LV
 import gregtech.api.GTValues.VH
 import gregtech.api.recipes.ModHandler
-import gregtech.api.recipes.RecipeMaps
+import gregtech.api.recipes.RecipeMaps.FORGE_HAMMER_RECIPES
+import gregtech.api.recipes.RecipeMaps.MACERATOR_RECIPES
+import gregtech.api.recipes.RecipeMaps.ORE_WASHER_RECIPES
+import gregtech.api.recipes.RecipeMaps.SIFTER_RECIPES
+import gregtech.api.recipes.RecipeMaps.THERMAL_CENTRIFUGE_RECIPES
 import gregtech.api.unification.OreDictUnifier
 import gregtech.api.unification.material.Material
-import gregtech.api.unification.material.Materials
-import gregtech.api.unification.material.info.MaterialFlags
+import gregtech.api.unification.material.Materials.Stone
+import gregtech.api.unification.material.info.MaterialFlags.HIGH_SIFTER_OUTPUT
 import gregtech.api.unification.material.properties.OreProperty
 import gregtech.api.unification.material.properties.PropertyKey
 import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.ore.OrePrefix.crushed
+import gregtech.api.unification.ore.OrePrefix.crushedCentrifuged
+import gregtech.api.unification.ore.OrePrefix.crushedPurified
+import gregtech.api.unification.ore.OrePrefix.dust
+import gregtech.api.unification.ore.OrePrefix.dustPure
+import gregtech.api.unification.ore.OrePrefix.gem
+import gregtech.api.unification.ore.OrePrefix.gemChipped
+import gregtech.api.unification.ore.OrePrefix.gemExquisite
+import gregtech.api.unification.ore.OrePrefix.gemFlawed
+import gregtech.api.unification.ore.OrePrefix.gemFlawless
+import gregtech.api.unification.ore.OrePrefix.ingot
 import gregtech.api.unification.stack.UnificationEntry
-import gregtech.api.util.GTUtility
+import gregtech.api.util.GTUtility.copyFirst
 import gregtech.common.ConfigHolder
-import gregtech.loaders.recipe.handlers.OreRecipeHandler
-import gregtechlite.gtlitecore.api.unification.GTLiteMaterials
-import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix
+import gregtech.loaders.recipe.handlers.OreRecipeHandler as GTOreRecipeHandler
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
-import net.minecraft.item.ItemStack
+import gregtechlite.gtlitecore.api.extension.EUt
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.TectonicPetrotheum
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.ZephyreanAerotheum
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.gemSolitary
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreBlueSchist
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreGreenSchist
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreKimberlite
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreKomatiite
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreLimestone
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreQuartzite
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreShale
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.oreSlate
 
 object OreRecipeHandler
 {
@@ -28,79 +52,73 @@ object OreRecipeHandler
 
     fun init()
     {
-        // Callback original registrate of ore processing handler and post new processing handler from new recipe
-        // handler container.
-        OrePrefix.crushedPurified.addProcessingHandler(PropertyKey.ORE, this::processCrushedPurified)
+        crushedPurified.addProcessingHandler(PropertyKey.ORE, ::processCrushedPurified)
 
-        // -------------------------------------------------------------------------------------------------------------
         if (ConfigHolder.worldgen.allUniqueStoneTypes)
         {
-            GTLiteOrePrefix.oreLimestone.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreKomatiite.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreGreenSchist.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreBlueSchist.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreKimberlite.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreQuartzite.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreSlate.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
-            GTLiteOrePrefix.oreShale.addProcessingHandler(PropertyKey.ORE,
-                OreRecipeHandler::processOre)
+            oreLimestone.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreKomatiite.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreGreenSchist.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreBlueSchist.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreKimberlite.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreQuartzite.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreSlate.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
+            oreShale.addProcessingHandler(PropertyKey.ORE, GTOreRecipeHandler::processOre)
         }
-        OrePrefix.crushed.addProcessingHandler(PropertyKey.ORE, this::processCrushedOre)
+
+        crushed.addProcessingHandler(PropertyKey.ORE, ::processCrushedOre)
     }
 
     private fun processCrushedPurified(purifiedPrefix: OrePrefix, material: Material, property: OreProperty)
     {
-        val crushedCentrifugedStack: ItemStack = OreDictUnifier.get(OrePrefix.crushedCentrifuged, material)
-        val dustStack = OreDictUnifier.get(OrePrefix.dustPure, material)
+        val crushedCentrifugedStack = OreDictUnifier.get(crushedCentrifuged, material)
+        val dustStack = OreDictUnifier.get(dustPure, material)
         val byproductMaterial = property.getOreByProduct(1, material)
-        val byproductStack = OreDictUnifier.get(OrePrefix.dust, byproductMaterial)
+        val byproductStack = OreDictUnifier.get(dust, byproductMaterial)
+
         // Hamming crushedPurifiedX -> dustPureX.
-        RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
+        FORGE_HAMMER_RECIPES.recipeBuilder()
             .input(purifiedPrefix, material)
             .outputs(dustStack)
-            .EUt(VH[LV].toLong())
+            .EUt(VH[LV])
             .duration(10 * TICK)
             .buildAndRegister()
+
         // Macerating crushedPurifiedX -> dustPureX + (dustX: byproduct).
-        RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
+        MACERATOR_RECIPES.recipeBuilder()
             .input(purifiedPrefix, material)
             .outputs(dustStack)
             .chancedOutput(byproductStack, 1400, 850)
             .duration(20 * SECOND)
             .buildAndRegister()
+
         // Hand-hamming crushedPurifiedX -> dustPureX.
         ModHandler.addShapelessRecipe(String.format("purified_ore_to_dust_%s", material), dustStack,
             'h', UnificationEntry(purifiedPrefix, material))
+
         // Thermal centrifuging crushedPurifiedX -> crushedCentrifugedX + (dustX: byproduct).
         if (!crushedCentrifugedStack.isEmpty)
         {
-            RecipeMaps.THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()
+            THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()
                 .input(purifiedPrefix, material)
                 .outputs(crushedCentrifugedStack)
-                .chancedOutput(OrePrefix.dust, byproductMaterial, 3333, 0)
+                .chancedOutput(dust, byproductMaterial, 3333, 0)
                 .buildAndRegister()
         }
+
         // Gem sifting, we merged gemSolitary and sort it at this stage.
-        // We modified sifter recipe map slots at GTLiteRecipeMaps#postRecipeMaps().
         if (material.hasProperty(PropertyKey.GEM))
         {
-            val solitaryStack = OreDictUnifier.get(GTLiteOrePrefix.gemSolitary, material)
-            val exquisiteStack = OreDictUnifier.get(OrePrefix.gemExquisite, material)
-            val flawlessStack = OreDictUnifier.get(OrePrefix.gemFlawless, material)
-            val gemStack = OreDictUnifier.get(OrePrefix.gem, material)
-            val flawedStack = OreDictUnifier.get(OrePrefix.gemFlawed, material)
-            val chippedStack = OreDictUnifier.get(OrePrefix.gemChipped, material)
+            val solitaryStack = OreDictUnifier.get(gemSolitary, material)
+            val exquisiteStack = OreDictUnifier.get(gemExquisite, material)
+            val flawlessStack = OreDictUnifier.get(gemFlawless, material)
+            val gemStack = OreDictUnifier.get(gem, material)
+            val flawedStack = OreDictUnifier.get(gemFlawed, material)
+            val chippedStack = OreDictUnifier.get(gemChipped, material)
 
-            if (material.hasFlag(MaterialFlags.HIGH_SIFTER_OUTPUT))
+            if (material.hasFlag(HIGH_SIFTER_OUTPUT))
             {
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                SIFTER_RECIPES.recipeBuilder()
                     .circuitMeta(1)
                     .input(purifiedPrefix, material)
                     .chancedOutput(solitaryStack, 100, 50)
@@ -110,14 +128,14 @@ object OreRecipeHandler
                     .chancedOutput(flawedStack, 2000, 500)
                     .chancedOutput(chippedStack, 3000, 350)
                     .chancedOutput(dustStack, 2500, 500)
-                    .EUt(VH[LV].toLong())
+                    .EUt(VH[LV])
                     .duration(20 * SECOND)
                     .buildAndRegister()
 
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                SIFTER_RECIPES.recipeBuilder()
                     .circuitMeta(2)
                     .input(purifiedPrefix, material)
-                    .fluidInputs(GTLiteMaterials.ZephyreanAerotheum.getFluid(250))
+                    .fluidInputs(ZephyreanAerotheum.getFluid(250))
                     .chancedOutput(solitaryStack, 200, 100)
                     .chancedOutput(exquisiteStack, 1000, 300)
                     .chancedOutput(flawlessStack, 3000, 400)
@@ -125,13 +143,13 @@ object OreRecipeHandler
                     .chancedOutput(flawedStack, 4000, 1000)
                     .chancedOutput(chippedStack, 6000, 700)
                     .chancedOutput(dustStack, 5000, 1000)
-                    .EUt(VH[LV].toLong())
+                    .EUt(VH[LV])
                     .duration(10 * SECOND)
                     .buildAndRegister()
             }
             else
             {
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                SIFTER_RECIPES.recipeBuilder()
                     .circuitMeta(1)
                     .input(purifiedPrefix, material)
                     .chancedOutput(solitaryStack, 50, 25)
@@ -141,14 +159,14 @@ object OreRecipeHandler
                     .chancedOutput(flawedStack, 2500, 300)
                     .chancedOutput(chippedStack, 3500, 400)
                     .chancedOutput(dustStack, 5000, 750)
-                    .EUt(VH[LV].toLong())
+                    .EUt(VH[LV])
                     .duration(20 * SECOND)
                     .buildAndRegister()
 
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                SIFTER_RECIPES.recipeBuilder()
                     .circuitMeta(2)
                     .input(purifiedPrefix, material)
-                    .fluidInputs(GTLiteMaterials.ZephyreanAerotheum.getFluid(250))
+                    .fluidInputs(ZephyreanAerotheum.getFluid(250))
                     .chancedOutput(solitaryStack, 100, 50)
                     .chancedOutput(exquisiteStack, 600, 200)
                     .chancedOutput(flawlessStack, 2000, 300)
@@ -156,44 +174,41 @@ object OreRecipeHandler
                     .chancedOutput(flawedStack, 5000, 600)
                     .chancedOutput(chippedStack, 7000, 800)
                     .outputs(dustStack)
-                    .EUt(VH[LV].toLong())
+                    .EUt(VH[LV])
                     .duration(10 * SECOND)
                     .buildAndRegister()
             }
         }
+
         processMetalSmelting(purifiedPrefix, material, property)
     }
 
-    /**
-     * Allowed to use Tectonic Petrotheum buff ore washer.
-     */
     private fun processCrushedOre(crushedPrefix: OrePrefix, material: Material, property: OreProperty)
     {
         val byproductMaterial = property.getOreByProduct(0, material)
-        val crushedPurifiedOre = GTUtility.copyFirst(
-            OreDictUnifier.get(OrePrefix.crushedPurified, material),
-            OreDictUnifier.get(OrePrefix.dust, material))
+        val crushedPurifiedOre = copyFirst(OreDictUnifier.get(crushedPurified, material),
+                                                        OreDictUnifier.get(dust, material))
 
-        RecipeMaps.ORE_WASHER_RECIPES.recipeBuilder()
+        ORE_WASHER_RECIPES.recipeBuilder()
             .circuitMeta(3)
             .input(crushedPrefix, material)
-            .fluidInputs(GTLiteMaterials.TectonicPetrotheum.getFluid(100))
+            .fluidInputs(TectonicPetrotheum.getFluid(100))
             .outputs(crushedPurifiedOre)
-            .output(OrePrefix.dust, Materials.Stone)
-            .chancedOutput(OrePrefix.dust, byproductMaterial, 6666, 0)
+            .output(dust, Stone)
+            .chancedOutput(dust, byproductMaterial, 6666, 0)
             .duration(5 * SECOND)
             .buildAndRegister()
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.OreRecipeHandler.processMetalSmelting].
+     * @see gregtech.loaders.recipe.handlers.OreRecipeHandler.processMetalSmelting
      */
     private fun processMetalSmelting(crushedPrefix: OrePrefix, material: Material, property: OreProperty)
     {
         val smeltingResult = property.directSmeltResult ?: material
         if (smeltingResult.hasProperty(PropertyKey.INGOT))
         {
-            val ingotStack: ItemStack = OreDictUnifier.get(OrePrefix.ingot, smeltingResult)
+            val ingotStack = OreDictUnifier.get(ingot, smeltingResult)
             if (!ingotStack.isEmpty && doesMaterialUseNormalFurnace(smeltingResult))
             {
                 ModHandler.addSmeltingRecipe(UnificationEntry(crushedPrefix, material), ingotStack, 0.5f)
@@ -202,7 +217,7 @@ object OreRecipeHandler
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.OreRecipeHandler.doesMaterialUseNormalFurnace].
+     * @see gregtech.loaders.recipe.handlers.OreRecipeHandler.doesMaterialUseNormalFurnace
      */
     private fun doesMaterialUseNormalFurnace(material: Material) = !material.hasProperty(PropertyKey.BLAST)
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/PartsRecipeHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/PartsRecipeHandler.kt
@@ -8,32 +8,75 @@ import gregtech.api.GTValues.ULV
 import gregtech.api.GTValues.VA
 import gregtech.api.GTValues.VH
 import gregtech.api.recipes.ModHandler
-import gregtech.api.recipes.RecipeMaps
+import gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES
+import gregtech.api.recipes.RecipeMaps.CUTTER_RECIPES
+import gregtech.api.recipes.RecipeMaps.EXTRUDER_RECIPES
+import gregtech.api.recipes.RecipeMaps.FLUID_SOLIDFICATION_RECIPES
+import gregtech.api.recipes.RecipeMaps.LATHE_RECIPES
 import gregtech.api.unification.OreDictUnifier
-import gregtech.api.unification.material.MarkerMaterials
+import gregtech.api.unification.material.MarkerMaterials.Color
 import gregtech.api.unification.material.Material
-import gregtech.api.unification.material.Materials
+import gregtech.api.unification.material.Materials.Amethyst
+import gregtech.api.unification.material.Materials.Andradite
+import gregtech.api.unification.material.Materials.Diamond
+import gregtech.api.unification.material.Materials.Emerald
+import gregtech.api.unification.material.Materials.Glass
+import gregtech.api.unification.material.Materials.GreenSapphire
+import gregtech.api.unification.material.Materials.Malachite
+import gregtech.api.unification.material.Materials.Olivine
+import gregtech.api.unification.material.Materials.Pyrope
+import gregtech.api.unification.material.Materials.Ruby
+import gregtech.api.unification.material.Materials.Rutile
+import gregtech.api.unification.material.Materials.Spessartine
+import gregtech.api.unification.material.Materials.Uvarovite
 import gregtech.api.unification.material.info.MaterialFlags
+import gregtech.api.unification.material.info.MaterialFlags.GENERATE_BOLT_SCREW
+import gregtech.api.unification.material.info.MaterialFlags.NO_SMASHING
 import gregtech.api.unification.material.properties.DustProperty
 import gregtech.api.unification.material.properties.GemProperty
 import gregtech.api.unification.material.properties.IngotProperty
 import gregtech.api.unification.material.properties.PropertyKey
 import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.ore.OrePrefix.bolt
+import gregtech.api.unification.ore.OrePrefix.craftingLens
+import gregtech.api.unification.ore.OrePrefix.dust
+import gregtech.api.unification.ore.OrePrefix.dustSmall
+import gregtech.api.unification.ore.OrePrefix.frameGt
+import gregtech.api.unification.ore.OrePrefix.gemExquisite
+import gregtech.api.unification.ore.OrePrefix.ingot
+import gregtech.api.unification.ore.OrePrefix.lens
+import gregtech.api.unification.ore.OrePrefix.plate
+import gregtech.api.unification.ore.OrePrefix.round
+import gregtech.api.unification.ore.OrePrefix.screw
+import gregtech.api.unification.ore.OrePrefix.stick
+import gregtech.api.unification.ore.OrePrefix.toolHeadDrill
+import gregtech.api.unification.ore.OrePrefix.turbineBlade
 import gregtech.api.unification.stack.UnificationEntry
-import gregtech.api.util.DyeUtil
-import gregtech.api.util.GTUtility
+import gregtech.api.util.DyeUtil.determineDyeColor
+import gregtech.api.util.GTUtility.scaleVoltage
 import gregtech.common.ConfigHolder
-import gregtech.common.items.MetaItems.SHAPE_MOLD_BOLT
-import gregtech.common.items.MetaItems.SHAPE_MOLD_RING
 import gregtech.common.items.MetaItems.SHAPE_MOLD_ROD
-import gregtech.common.items.MetaItems.SHAPE_MOLD_ROD_LONG
-import gregtech.common.items.MetaItems.SHAPE_MOLD_ROUND
-import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps
-import gregtechlite.gtlitecore.api.unification.GTLiteMaterials
-import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix
 import gregtechlite.gtlitecore.api.MINUTE
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
+import gregtechlite.gtlitecore.api.extension.EUt
+import gregtechlite.gtlitecore.api.extension.copy
+import gregtechlite.gtlitecore.api.extension.duration
+import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps.POLISHER_RECIPES
+import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps.SLICER_RECIPES
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Albite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Baddeleyite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Celestine
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Cryolite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Fluorite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Heterodiamond
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.HexagonalSiliconNitride
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Jade
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Nephelite
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Tanzanite
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.gemSolitary
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.sheetedFrame
+import gregtechlite.gtlitecore.api.unification.ore.GTLiteOrePrefix.wallGt
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SHAPE_EXTRUDER_DRILL_HEAD
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SHAPE_EXTRUDER_ROUND
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SHAPE_EXTRUDER_TURBINE_BLADE
@@ -42,9 +85,9 @@ import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SHAPE_MOLD_SCREW
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SHAPE_MOLD_TURBINE_BLADE
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SLICER_BLADE_OCTAGONAL
 import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.SLICER_BLADE_STRIPES
-import net.minecraft.item.ItemStack
 import kotlin.math.max
 
+@Suppress("unused")
 object PartsRecipeHandler
 {
 
@@ -52,172 +95,175 @@ object PartsRecipeHandler
 
     fun init()
     {
-        // Callback original registrate of material processing handler and post new processing handler
-        // from new recipe handler container.
-        OrePrefix.stick.addProcessingHandler(PropertyKey.DUST, this::processStick)
-        OrePrefix.lens.addProcessingHandler(PropertyKey.GEM, this::processLens)
-        // ===========================================================================================
-        OrePrefix.stickLong.addProcessingHandler(PropertyKey.DUST, this::processStickLong)
-        OrePrefix.bolt.addProcessingHandler(PropertyKey.DUST, this::processBolt)
-        OrePrefix.screw.addProcessingHandler(PropertyKey.DUST, this::processScrew)
-        OrePrefix.ring.addProcessingHandler(PropertyKey.DUST, this::processRing)
-        OrePrefix.round.addProcessingHandler(PropertyKey.INGOT, this::processRound)
-        OrePrefix.toolHeadDrill.addProcessingHandler(PropertyKey.INGOT, this::processDrillHead)
-        OrePrefix.turbineBlade.addProcessingHandler(PropertyKey.INGOT, this::processTurbineBlade)
-        GTLiteOrePrefix.sheetedFrame.addProcessingHandler(PropertyKey.DUST, this::processSheetedFrame)
-        GTLiteOrePrefix.wallGt.addProcessingHandler(PropertyKey.DUST, this::processWall)
+        stick.addProcessingHandler(PropertyKey.DUST, ::processStick)
+        lens.addProcessingHandler(PropertyKey.GEM, ::processLens)
+
+        screw.addProcessingHandler(PropertyKey.DUST, ::processScrew)
+        round.addProcessingHandler(PropertyKey.INGOT, ::processRound)
+        toolHeadDrill.addProcessingHandler(PropertyKey.INGOT, ::processDrillHead)
+        turbineBlade.addProcessingHandler(PropertyKey.INGOT, ::processTurbineBlade)
+        sheetedFrame.addProcessingHandler(PropertyKey.DUST, ::processSheetedFrame)
+        wallGt.addProcessingHandler(PropertyKey.DUST, ::processWall)
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.PartsRecipeHandler.processStick],
-     * required [magicbook.gtlitecore.mixins.gregtech.MixinPartsRecipeHandler.callbackRegistrate].
+     * @see gregtech.loaders.recipe.handlers.PartsRecipeHandler.processStick
      */
     private fun processStick(stickPrefix: OrePrefix, material: Material, property: DustProperty)
     {
         val workingTier = material.workingTier
-        // Split original predicate (ingot, gem), because we want to add special processing of plastic
-        // stick (this processing required to check [MaterialFlags.NO_SMASHING] tag of material).
+
+        // Split original predicate (ingot, gem), because we want to add special processing of plastic stick (this
+        // processing required to check NO_SMASHING tag of material).
         if (material.hasProperty(PropertyKey.GEM))
         {
-            val builder = RecipeMaps.LATHE_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material) // Delete safety checking of original processing, because this is unused at this time.
-                .EUt(GTUtility.scaleVoltage(VH[LV].toLong(), workingTier))
-                .duration(max(material.mass * 2, 1).toInt())
+            // Delete safety checking of original processing, because this is unused at this time.
+            val builder = LATHE_RECIPES.recipeBuilder()
+                .input(ingot, material)
+                .EUt(scaleVoltage(VH[LV], workingTier))
+                .duration(max(material.mass * 2, 1))
+
             if (ConfigHolder.recipes.harderRods)
             {
                 builder.output(stickPrefix, material)
-                    .output(OrePrefix.dustSmall, material, 2)
+                    .output(dustSmall, material, 2)
             }
             else
             {
-                builder.output(OrePrefix.stick, material, 2)
+                builder.output(stick, material, 2)
             }
+
             builder.buildAndRegister()
         }
 
         if (material.hasProperty(PropertyKey.INGOT))
         {
             // For common hard materials, the processing is same as gem.
-            if (!material.hasFlag(MaterialFlags.NO_SMASHING))
+            if (!material.hasFlag(NO_SMASHING))
             {
-                val builder = RecipeMaps.LATHE_RECIPES.recipeBuilder()
-                    .input(OrePrefix.ingot, material)
-                    .duration(max(material.mass * 2, 1).toInt())
-                    .EUt(GTUtility.scaleVoltage(VH[LV].toLong(), workingTier))
+                val builder = LATHE_RECIPES.recipeBuilder()
+                    .input(ingot, material)
+                    .duration(max(material.mass * 2, 1))
+                    .EUt(scaleVoltage(VH[LV], workingTier))
+
                 if (ConfigHolder.recipes.harderRods)
                 {
                     builder.output(stickPrefix, material)
-                        .output(OrePrefix.dustSmall, material, 2)
+                        .output(dustSmall, material, 2)
                 }
                 else
                 {
                     builder.output(stickPrefix, material, 2)
                 }
+
                 builder.buildAndRegister()
             }
             else // Used slicer to cut soft material with stripes blade.
             {
-                val builder = GTLiteRecipeMaps.SLICER_RECIPES.recipeBuilder()
+                val builder = SLICER_RECIPES.recipeBuilder()
                     .notConsumable(SLICER_BLADE_STRIPES)
-                    .input(OrePrefix.ingot, material)
-                    .duration(max(material.mass * 2, 1).toInt())
-                    .EUt(VH[LV].toLong())
+                    .input(ingot, material)
+                    .duration(max(material.mass * 2, 1))
+                    .EUt(VH[LV])
+
                 if (ConfigHolder.recipes.harderRods)
                 {
-                    builder.output(OrePrefix.stick, material)
-                    builder.output(OrePrefix.dustSmall, material, 2)
+                    builder.output(stick, material)
+                        .output(dustSmall, material, 2)
                 }
                 else
                 {
-                    builder.output(OrePrefix.stick, material, 2)
+                    builder.output(stick, material, 2)
                 }
+
                 builder.buildAndRegister()
             }
         }
-        // Bolt processing is same as ingot predicate, declare it has hard and soft two properties,
-        // hard part used cutting machine, and soft part used slicer with octagonal blade.
-        if (material.hasFlag(MaterialFlags.GENERATE_BOLT_SCREW))
+        // Bolt processing is same as ingot predicate, declare it has hard and soft two properties, hard part used
+        // cutting machine, and soft part used slicer with octagonal blade.
+        if (material.hasFlag(GENERATE_BOLT_SCREW))
         {
-            val boltStack = OreDictUnifier.get(OrePrefix.bolt, material)
-            if (!material.hasFlag(MaterialFlags.NO_SMASHING))
+            val boltStack = OreDictUnifier.get(bolt, material)
+            if (!material.hasFlag(NO_SMASHING))
             {
-                RecipeMaps.CUTTER_RECIPES.recipeBuilder()
+                CUTTER_RECIPES.recipeBuilder()
                     .input(stickPrefix, material)
-                    .outputs(GTUtility.copy(4, boltStack))
-                    .duration(max(material.mass * 2, 1).toInt())
-                .EUt(GTUtility.scaleVoltage(4, workingTier))
-                .buildAndRegister()
+                    .outputs(boltStack.copy(4))
+                    .duration(max(material.mass * 2, 1))
+                    .EUt(scaleVoltage(4, workingTier))
+                    .buildAndRegister()
             }
             else if (!material.hasProperty(PropertyKey.GEM))
             {
-                GTLiteRecipeMaps.SLICER_RECIPES.recipeBuilder()
+                SLICER_RECIPES.recipeBuilder()
                     .notConsumable(SLICER_BLADE_OCTAGONAL)
                     .input(stickPrefix, material)
-                    .outputs(GTUtility.copy(4, boltStack))
-                    .duration(max(material.mass * 2, 1).toInt())
-                    .EUt(GTUtility.scaleVoltage(4, workingTier))
+                    .outputs(boltStack.copy(4))
+                    .duration(max(material.mass * 2, 1))
+                    .EUt(scaleVoltage(4, workingTier))
                     .buildAndRegister()
             }
 
             if (workingTier <= HV)
             {
-                ModHandler.addShapedRecipe(String.format("bolt_saw_%s", material),
-                    GTUtility.copy(2, boltStack),
+                ModHandler.addShapedRecipe(String.format("bolt_saw_%s", material), boltStack.copy(2),
                     "s ", " X",
-                    'X', UnificationEntry(OrePrefix.stick, material))
+                    'X', UnificationEntry(stick, material))
             }
         }
 
         // Add fluid solidification recipes to rod via GTLiteMetaItems#SHAPE_MOLD_ROD.
         if (material.hasFluid())
         {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
+            FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_MOLD_ROD)
                 .fluidInputs(material.getFluid(L / 2))
                 .output(stickPrefix, material)
-                .EUt(GTUtility.scaleVoltage(VA[LV].toLong(), workingTier))
+                .EUt(scaleVoltage(VA[LV], workingTier))
                 .duration(7 * SECOND + 5 * TICK)
                 .buildAndRegister()
         }
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.PartsRecipeHandler.processLens],
-     * required [magicbook.gtlitecore.mixins.gregtech.MixinPartsRecipeHandler.callbackRegistrate].
+     * @see gregtech.loaders.recipe.handlers.PartsRecipeHandler.processLens
      */
     private fun processLens(lensPrefix: OrePrefix, material: Material, property: GemProperty)
     {
         val workingTier = material.workingTier
+
         // plateX -> craftingLensX
-        if (!(OreDictUnifier.get(OrePrefix.plate, material))!!.isEmpty)
+        if (!(OreDictUnifier.get(plate, material))!!.isEmpty)
         {
-            GTLiteRecipeMaps.POLISHER_RECIPES.recipeBuilder()
-                .input(OrePrefix.plate, material)
+            POLISHER_RECIPES.recipeBuilder()
+                .input(plate, material)
                 .output(lensPrefix, material)
-                .output(OrePrefix.dustSmall, material)
-                .EUt(GTUtility.scaleVoltage(VA[MV].toLong(), workingTier))
+                .output(dustSmall, material)
+                .EUt(scaleVoltage(VA[MV], workingTier))
                 .duration(1 * MINUTE)
                 .buildAndRegister()
         }
+
         // gemExquisiteX -> craftingLensX.
-        if (!(OreDictUnifier.get(OrePrefix.gemExquisite, material))!!.isEmpty)
+        if (!(OreDictUnifier.get(gemExquisite, material))!!.isEmpty)
         {
-            GTLiteRecipeMaps.POLISHER_RECIPES.recipeBuilder()
-                .input(OrePrefix.gemExquisite, material)
+            POLISHER_RECIPES.recipeBuilder()
+                .input(gemExquisite, material)
                 .output(lensPrefix, material)
-                .output(OrePrefix.dust, material, 2)
-                .EUt(GTUtility.scaleVoltage(VA[LV].toLong(), workingTier))
+                .output(dust, material, 2)
+                .EUt(scaleVoltage(VA[LV], workingTier))
                 .duration(2 * MINUTE)
                 .buildAndRegister()
         }
+
         // gemSolitaryX -> craftingLensX.
-        if (!(OreDictUnifier.get(GTLiteOrePrefix.gemSolitary, material))!!.isEmpty)
+        if (!(OreDictUnifier.get(gemSolitary, material))!!.isEmpty)
         {
-            GTLiteRecipeMaps.POLISHER_RECIPES.recipeBuilder()
-                .input(GTLiteOrePrefix.gemSolitary, material)
+            POLISHER_RECIPES.recipeBuilder()
+                .input(gemSolitary, material)
                 .output(lensPrefix, material, 2)
-                .output(OrePrefix.dust, material, 4)
-                .EUt(GTUtility.scaleVoltage(VA[MV].toLong(), workingTier))
+                .output(dust, material, 4)
+                .EUt(scaleVoltage(VA[MV], workingTier))
                 .duration(1 * MINUTE)
                 .buildAndRegister()
         }
@@ -226,267 +272,126 @@ object PartsRecipeHandler
         val lensStack = OreDictUnifier.get(lensPrefix, material)
         when (material)
         {
-            // Original gem colored lens modifications.
-            Materials.Diamond -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.LightBlue)
-            }
-            Materials.Ruby -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Red)
-            }
-            Materials.Emerald -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Green)
-            }
-            Materials.Glass -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens.name() + material.toCamelCaseString())
-            }
-            Materials.Uvarovite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Lime)
-            }
-            Materials.Malachite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Green)
-            }
-            Materials.Andradite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Brown)
-            }
-            Materials.GreenSapphire -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Lime)
-            }
-            Materials.Pyrope -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Purple)
-            }
-            Materials.Rutile -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Pink)
-            }
-            Materials.Spessartine -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Red)
-            }
-            Materials.Olivine -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Lime)
-            }
-            Materials.Amethyst -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Purple)
-            }
-            // Addition gem colored lens in gtlitecore.
-            GTLiteMaterials.Tanzanite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Purple)
-            }
-            GTLiteMaterials.Albite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Pink)
-            }
-            GTLiteMaterials.Fluorite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Green)
-            }
-            GTLiteMaterials.Celestine -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Cyan)
-            }
-            GTLiteMaterials.Baddeleyite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Cyan)
-            }
-            GTLiteMaterials.Nephelite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Red)
-            }
-            GTLiteMaterials.Cryolite -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.LightBlue)
-            }
-            GTLiteMaterials.Jade -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Green)
-            }
-            GTLiteMaterials.Heterodiamond -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Purple)
-            }
-            GTLiteMaterials.HexagonalSiliconNitride -> {
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens,
-                    MarkerMaterials.Color.Purple)
-            }
+            // GTCEu colored lens modifications.
+            Diamond -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.LightBlue)
+            Ruby -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Red)
+            Emerald -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Green)
+            Glass -> OreDictUnifier.registerOre(lensStack, craftingLens.name() + material.toCamelCaseString())
+            Uvarovite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Lime)
+            Malachite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Green)
+            Andradite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Brown)
+            GreenSapphire -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Lime)
+            Pyrope -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Purple)
+            Rutile -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Pink)
+            Spessartine -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Red)
+            Olivine -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Lime)
+            Amethyst -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Purple)
+
+            // Mod colored lens modifications.
+            Tanzanite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Purple)
+            Albite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Pink)
+            Fluorite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Green)
+            Celestine -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Cyan)
+            Baddeleyite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Cyan)
+            Nephelite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Red)
+            Cryolite -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.LightBlue)
+            Jade -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Green)
+            Heterodiamond -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Purple)
+            HexagonalSiliconNitride -> OreDictUnifier.registerOre(lensStack, craftingLens, Color.Purple)
+
+            // Default behaviour for determining lens color, left for CrT.
             else -> {
-                // Default behaviour for determining lens color, left for addons and CraftTweaker.
-                val dyeColor = DyeUtil.determineDyeColor(material.materialRGB)
-                val colorMaterial = MarkerMaterials.Color.COLORS[dyeColor]
-                OreDictUnifier.registerOre(lensStack, OrePrefix.craftingLens, colorMaterial)
+
+                val dyeColor = determineDyeColor(material.materialRGB)
+                val colorMaterial = Color.COLORS[dyeColor]
+                OreDictUnifier.registerOre(lensStack, craftingLens, colorMaterial)
             }
         }
     }
 
-    /**
-     * Add fluid solidification processing via [SHAPE_MOLD_ROD_LONG].
-     */
-    private fun processStickLong(stickLongPrefix: OrePrefix, material: Material, property: DustProperty)
-    {
-        val workingTier = material.workingTier
-        if (material.hasFluid())
-        {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
-                .notConsumable(SHAPE_MOLD_ROD_LONG)
-                .fluidInputs(material.getFluid(L))
-                .output(stickLongPrefix, material)
-                .EUt(GTUtility.scaleVoltage(max(VA[MV].toLong(), 16 * getVoltageMultiplier(material)), workingTier))
-                .duration(15 * SECOND)
-                .buildAndRegister()
-        }
-    }
-
-    /**
-     * Add fluid solidification processing via [SHAPE_MOLD_BOLT].
-     */
-    private fun processBolt(boltPrefix: OrePrefix, material: Material, property: DustProperty)
-    {
-        val workingTier = material.workingTier
-        if (material.hasFluid())
-        {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
-                .notConsumable(SHAPE_MOLD_BOLT)
-                .fluidInputs(material.getFluid(L / 8))
-                .output(boltPrefix, material)
-                .EUt(GTUtility.scaleVoltage(VA[LV].toLong(), workingTier))
-                .duration(2 * SECOND + 5 * TICK)
-                .buildAndRegister()
-        }
-    }
-
-    /**
-     * Add fluid solidification processing via [SHAPE_MOLD_SCREW].
-     */
     private fun processScrew(screwPrefix: OrePrefix, material: Material, property: DustProperty)
     {
         val workingTier = material.workingTier
         if (material.hasFluid())
         {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
+            FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_MOLD_SCREW)
                 .fluidInputs(material.getFluid(L / 8))
                 .output(screwPrefix, material)
-                .EUt(GTUtility.scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
+                .EUt(scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
                 .duration(2 * SECOND + 5 * TICK)
                 .buildAndRegister()
         }
     }
 
-    /**
-     * Add fluid solidification processing via [SHAPE_MOLD_RING].
-     */
-    private fun processRing(ringPrefix: OrePrefix, material: Material, property: DustProperty)
-    {
-        val workingTier = material.workingTier
-        if (material.hasFluid())
-        {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
-                .notConsumable(SHAPE_MOLD_RING)
-                .fluidInputs(material.getFluid(L / 4))
-                .output(ringPrefix, material)
-                .EUt(GTUtility.scaleVoltage(VA[LV].toLong(), workingTier))
-                .duration(5 * SECOND)
-                .buildAndRegister()
-        }
-    }
-
-    /**
-     * Add fluid solidification and extruding processing via [SHAPE_MOLD_ROUND]
-     * and [SHAPE_EXTRUDER_ROUND].
-     */
     private fun processRound(roundPrefix: OrePrefix, material: Material, property: IngotProperty)
     {
         val workingTier = material.workingTier
-        if (material.hasFluid())
+
+        if (!(OreDictUnifier.get(ingot, material).isEmpty))
         {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
-                .notConsumable(SHAPE_MOLD_ROUND)
-                .fluidInputs(material.getFluid(L / 8))
-                .output(roundPrefix, material)
-                .EUt(GTUtility.scaleVoltage(VA[LV].toLong(), workingTier))
-                .duration(2 * SECOND + 5 * TICK)
-                .buildAndRegister()
-        }
-        if (!(OreDictUnifier.get(OrePrefix.ingot, material) as? ItemStack)!!.isEmpty)
-        {
-            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+            EXTRUDER_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_EXTRUDER_ROUND)
-                .input(OrePrefix.ingot, material)
+                .input(ingot, material)
                 .output(roundPrefix, material, 4)
-                .EUt(GTUtility.scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
+                .EUt(scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
                 .duration(2 * SECOND)
                 .buildAndRegister()
         }
-        else // TODO Should there needs a extra checking of dustStack not null?
+        else
         {
-            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+            EXTRUDER_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_EXTRUDER_ROUND)
-                .input(OrePrefix.dust, material)
+                .input(dust, material)
                 .output(roundPrefix, material, 4)
-                .EUt(GTUtility.scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
+                .EUt(scaleVoltage(max(VA[MV].toLong(), 4 * getVoltageMultiplier(material)), workingTier))
                 .duration(2 * SECOND)
                 .buildAndRegister()
         }
     }
 
-    /**
-     * Add fluid solidification and extruding processing via [SHAPE_MOLD_DRILL_HEAD]
-     * and [SHAPE_EXTRUDER_DRILL_HEAD].
-     */
     private fun processDrillHead(drillHeadPrefix: OrePrefix, material: Material, property: IngotProperty)
     {
         val workingTier = material.workingTier
         if (material.hasFluid())
         {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
+            FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_MOLD_DRILL_HEAD)
                 .fluidInputs(material.getFluid(L * 4)) // Cost less material than hand-crafting recipes.
                 .output(drillHeadPrefix, material)
-                .EUt(GTUtility.scaleVoltage(VA[MV].toLong(), workingTier))
+                .EUt(scaleVoltage(VA[MV].toLong(), workingTier))
                 .duration(5 * SECOND)
                 .buildAndRegister()
         }
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+
+        EXTRUDER_RECIPES.recipeBuilder()
             .notConsumable(SHAPE_EXTRUDER_DRILL_HEAD)
-            .input(OrePrefix.ingot, material, 4) // Cost less material than hand-crafting recipes.
+            .input(ingot, material, 4) // Cost less material than hand-crafting recipes.
             .output(drillHeadPrefix, material, 1)
-            .EUt(GTUtility.scaleVoltage(VA[MV].toLong(), workingTier))
+            .EUt(scaleVoltage(VA[MV].toLong(), workingTier))
             .duration(5 * SECOND)
             .buildAndRegister()
     }
 
-    /**
-     * Add fluid solidification and extruding processing via [SHAPE_MOLD_TURBINE_BLADE]
-     * and [SHAPE_EXTRUDER_TURBINE_BLADE].
-     */
     private fun processTurbineBlade(turbineBladePrefix: OrePrefix, material: Material, property: IngotProperty)
     {
         val workingTier = material.workingTier
         if (material.hasFluid())
         {
-            RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
+            FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                 .notConsumable(SHAPE_MOLD_TURBINE_BLADE)
                 .fluidInputs(material.getFluid(L * 6))
                 .output(turbineBladePrefix, material)
-                .EUt(GTUtility.scaleVoltage(max(VA[MV].toLong(), 6 * getVoltageMultiplier(material)), workingTier))
+                .EUt(scaleVoltage(max(VA[MV].toLong(), 6 * getVoltageMultiplier(material)), workingTier))
                 .duration(20 * SECOND)
                 .buildAndRegister()
         }
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+
+        EXTRUDER_RECIPES.recipeBuilder()
             .notConsumable(SHAPE_EXTRUDER_TURBINE_BLADE)
-            .input(OrePrefix.ingot, material, 6)
+            .input(ingot, material, 6)
             .output(turbineBladePrefix, material)
-            .EUt(GTUtility.scaleVoltage(VA[MV].toLong(), workingTier))
+            .EUt(scaleVoltage(VA[MV].toLong(), workingTier))
             .duration(20 * SECOND)
             .buildAndRegister()
     }
@@ -496,17 +401,18 @@ object PartsRecipeHandler
 
         if (!material.hasFlag(MaterialFlags.GENERATE_FRAME))
             return
+
         ModHandler.addShapedRecipe(String.format("%s_sheeted_frame", material), OreDictUnifier.get(sheetedFramePrefix, material, 12),
             "PFP", "PhP", "PFP",
-            'P', UnificationEntry(OrePrefix.plate, material),
-            'F', UnificationEntry(OrePrefix.frameGt, material))
+            'P', UnificationEntry(plate, material),
+            'F', UnificationEntry(frameGt, material))
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+        ASSEMBLER_RECIPES.recipeBuilder()
             .circuitMeta(10)
-            .input(OrePrefix.plate, material, 3)
-            .input(OrePrefix.frameGt, material, 1)
+            .input(plate, material, 3)
+            .input(frameGt, material, 1)
             .output(sheetedFramePrefix, material, 6)
-            .EUt(VA[ULV].toLong())
+            .EUt(VA[ULV])
             .duration(2 * SECOND + 5 * TICK)
             .buildAndRegister()
 
@@ -516,22 +422,25 @@ object PartsRecipeHandler
     {
         if (!material.hasFlag(MaterialFlags.GENERATE_PLATE) || !material.hasFlag(MaterialFlags.GENERATE_BOLT_SCREW))
             return
+
         ModHandler.addShapedRecipe(String.format("%s_wall_gt", material), OreDictUnifier.get(wallGtPrefix, material, 6),
             "hPS", "P P", "SPd",
-            'P', UnificationEntry(OrePrefix.plate, material),
-            'S', UnificationEntry(OrePrefix.screw, material))
+            'P', UnificationEntry(plate, material),
+            'S', UnificationEntry(screw, material))
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+        ASSEMBLER_RECIPES.recipeBuilder()
             .circuitMeta(11)
-            .input(OrePrefix.plate, material, 2)
-            .input(OrePrefix.screw, material, 1)
+            .input(plate, material, 2)
+            .input(screw, material, 1)
             .output(wallGtPrefix, material, 3)
-            .EUt(VA[ULV].toLong())
+            .EUt(VA[ULV])
             .duration(2 * SECOND + 5 * TICK)
             .buildAndRegister()
     }
 
     private fun getVoltageMultiplier(material: Material): Long = if (material.blastTemperature >= 2800) VA[LV].toLong() else VA[ULV].toLong()
+
+    private fun scaleVoltage(voltage: Int, workingTier: Int) = scaleVoltage(voltage.toLong(), workingTier)
 
     // @formatter:on
 

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/ToolRecipeHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/ToolRecipeHandler.kt
@@ -2,20 +2,36 @@ package gregtechlite.gtlitecore.loader.recipe.handler
 
 import gregtech.api.items.toolitem.IGTTool
 import gregtech.api.recipes.ModHandler
-import gregtech.api.unification.material.MarkerMaterials
+import gregtech.api.unification.material.MarkerMaterials.Color
 import gregtech.api.unification.material.Material
-import gregtech.api.unification.material.Materials
-import gregtech.api.unification.material.info.MaterialFlags
+import gregtech.api.unification.material.Materials.Steel
+import gregtech.api.unification.material.Materials.Wood
+import gregtech.api.unification.material.info.MaterialFlags.GENERATE_PLATE
+import gregtech.api.unification.material.info.MaterialFlags.GENERATE_ROD
+import gregtech.api.unification.material.info.MaterialFlags.GENERATE_SMALL_GEAR
+import gregtech.api.unification.material.info.MaterialFlags.GENERATE_SPRING_SMALL
 import gregtech.api.unification.material.properties.PropertyKey
 import gregtech.api.unification.material.properties.ToolProperty
 import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.ore.OrePrefix.dye
+import gregtech.api.unification.ore.OrePrefix.gearSmall
+import gregtech.api.unification.ore.OrePrefix.ingot
+import gregtech.api.unification.ore.OrePrefix.plate
+import gregtech.api.unification.ore.OrePrefix.springSmall
+import gregtech.api.unification.ore.OrePrefix.stick
 import gregtech.api.unification.stack.UnificationEntry
-import gregtech.common.items.ToolItems
+import gregtech.common.items.ToolItems.PLUNGER
+import gregtech.common.items.ToolItems.SOFT_MALLET
 import gregtechlite.gtlitecore.api.unification.material.properties.GTLiteToolPropertyAdder
-import gregtechlite.gtlitecore.common.item.GTLiteToolItems
+import gregtechlite.gtlitecore.common.item.GTLiteToolItems.CLUB
+import gregtechlite.gtlitecore.common.item.GTLiteToolItems.COMBINATION_WRENCH
+import gregtechlite.gtlitecore.common.item.GTLiteToolItems.FLINT_AND_STEEL
+import gregtechlite.gtlitecore.common.item.GTLiteToolItems.ROLLING_PIN
+import gregtechlite.gtlitecore.common.item.GTLiteToolItems.UNIVERSAL_SPADE
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 
+@Suppress("unused")
 object ToolRecipeHandler
 {
 
@@ -23,7 +39,7 @@ object ToolRecipeHandler
 
     fun init()
     {
-        OrePrefix.ingot.addProcessingHandler(PropertyKey.TOOL, this::processTool)
+        ingot.addProcessingHandler(PropertyKey.TOOL, ::processTool)
     }
 
     fun registerCustomToolRecipes()
@@ -36,48 +52,48 @@ object ToolRecipeHandler
         if (material.hasProperty(PropertyKey.INGOT))
         {
 
-            if (material.hasFlags(MaterialFlags.GENERATE_PLATE))
+            if (material.hasFlag(GENERATE_PLATE))
             {
                 // Combination Wrench
-                addToolRecipe(material, GTLiteToolItems.COMBINATION_WRENCH, true,
+                addToolRecipe(material, COMBINATION_WRENCH, true,
                     "PhP", "IPI", "fP ",
-                    'I', UnificationEntry(OrePrefix.ingot, material),
-                    'P', UnificationEntry(OrePrefix.plate, material))
+                    'I', UnificationEntry(ingot, material),
+                    'P', UnificationEntry(plate, material))
             }
 
-            if (material.hasFlag(MaterialFlags.GENERATE_ROD))
+            if (material.hasFlag(GENERATE_ROD))
             {
                 // Rolling Pin
-                addToolRecipe(material, GTLiteToolItems.ROLLING_PIN, true,
+                addToolRecipe(material, ROLLING_PIN, true,
                     "  R", " I ", "R f",
-                    'R', UnificationEntry(OrePrefix.stick, material),
-                    'I', UnificationEntry(OrePrefix.ingot, material))
+                    'R', UnificationEntry(stick, material),
+                    'I', UnificationEntry(ingot, material))
 
                 // Club
-                addToolRecipe(material, GTLiteToolItems.CLUB, true,
+                addToolRecipe(material, CLUB, true,
                     "hII", "III", "RIf",
-                    'I', UnificationEntry(OrePrefix.ingot, material),
-                    'R', UnificationEntry(OrePrefix.stick, material))
+                    'I', UnificationEntry(ingot, material),
+                    'R', UnificationEntry(stick, material))
             }
 
-            if (material.hasFlags(MaterialFlags.GENERATE_PLATE) && material.hasFlags(MaterialFlags.GENERATE_ROD))
+            if (material.hasFlags(GENERATE_PLATE, GENERATE_ROD))
             {
                 // Universal Spade
-                addToolRecipe(material, GTLiteToolItems.UNIVERSAL_SPADE, true,
+                addToolRecipe(material, UNIVERSAL_SPADE, true,
                     "hPP", "DRP", "RDf",
-                    'P', UnificationEntry(OrePrefix.plate, material),
-                    'R', UnificationEntry(OrePrefix.stick, material),
-                    'D', UnificationEntry(OrePrefix.dye, MarkerMaterials.Color.Blue))
+                    'P', UnificationEntry(plate, material),
+                    'R', UnificationEntry(stick, material),
+                    'D', UnificationEntry(dye, Color.Blue))
             }
 
-            if (material.hasFlags(MaterialFlags.GENERATE_SPRING_SMALL) && material.hasFlags(MaterialFlags.GENERATE_SMALL_GEAR)
-                && material != Materials.Steel) // Do not generate Steel Flint And Steel because the vanilla Flint And Steel is Steel yet.
+            // Do not generate Steel Flint And Steel because the vanilla Flint And Steel is Steel yet.
+            if (material.hasFlags(GENERATE_SPRING_SMALL, GENERATE_SMALL_GEAR) && material != Steel)
             {
                 // Flint And Steel
-                addToolRecipe(material, GTLiteToolItems.FLINT_AND_STEEL, false,
+                addToolRecipe(material, FLINT_AND_STEEL, false,
                     " G ", " F ", " S ",
-                    'G', UnificationEntry(OrePrefix.gearSmall, material),
-                    'S', UnificationEntry(OrePrefix.springSmall, material),
+                    'G', UnificationEntry(gearSmall, material),
+                    'S', UnificationEntry(springSmall, material),
                     'F', ItemStack(Items.FLINT))
             }
 
@@ -87,18 +103,18 @@ object ToolRecipeHandler
     private fun registerSoftToolRecipes()
     {
         val softMaterials = GTLiteToolPropertyAdder.softMaterials
-        val stick = UnificationEntry(OrePrefix.stick, Materials.Wood)
+        val stick = UnificationEntry(stick, Wood)
 
         for (mat in softMaterials)
         {
             val material = mat.first
-            addToolRecipe(material, ToolItems.SOFT_MALLET, true,
+            addToolRecipe(material, SOFT_MALLET, true,
                 "II ", "IIS", "II ",
-                'I', UnificationEntry(OrePrefix.ingot, material),
+                'I', UnificationEntry(ingot, material),
                 'S', stick)
-            addToolRecipe(material, ToolItems.PLUNGER, true,
+            addToolRecipe(material, PLUNGER, true,
                 "xPP", " SP", "S f",
-                'P', UnificationEntry(OrePrefix.plate, material),
+                'P', UnificationEntry(plate, material),
                 'S', stick)
         }
     }

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireCombinationHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireCombinationHandler.kt
@@ -1,54 +1,65 @@
 package gregtechlite.gtlitecore.loader.recipe.handler
 
-import com.google.common.collect.ImmutableMap
 import gregtech.api.GTValues.M
 import gregtech.api.GTValues.ULV
 import gregtech.api.GTValues.VA
 import gregtech.api.recipes.ModHandler
-import gregtech.api.recipes.RecipeMaps
+import gregtech.api.recipes.RecipeMaps.PACKER_RECIPES
 import gregtech.api.unification.OreDictUnifier
 import gregtech.api.unification.material.Material
-import gregtech.api.unification.material.Materials
+import gregtech.api.unification.material.Materials.Rubber
 import gregtech.api.unification.material.properties.PropertyKey
 import gregtech.api.unification.material.properties.WireProperties
 import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.ore.OrePrefix.cableGtDouble
+import gregtech.api.unification.ore.OrePrefix.cableGtHex
+import gregtech.api.unification.ore.OrePrefix.cableGtOctal
+import gregtech.api.unification.ore.OrePrefix.cableGtQuadruple
+import gregtech.api.unification.ore.OrePrefix.cableGtSingle
+import gregtech.api.unification.ore.OrePrefix.plate
+import gregtech.api.unification.ore.OrePrefix.wireGtDouble
+import gregtech.api.unification.ore.OrePrefix.wireGtHex
+import gregtech.api.unification.ore.OrePrefix.wireGtOctal
+import gregtech.api.unification.ore.OrePrefix.wireGtQuadruple
+import gregtech.api.unification.ore.OrePrefix.wireGtSingle
 import gregtech.api.unification.stack.UnificationEntry
 import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps.LOOM_RECIPES
 import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.TICK
-import org.apache.commons.lang3.ArrayUtils
+import gregtechlite.gtlitecore.api.extension.EUt
 import kotlin.math.pow
 
-// Callback original registrate of wire combination processing handler and post new
-// processing handler from this recipe handler container.
+@Suppress("unused")
 object WireCombinationHandler
 {
 
     // @formatter:off
 
-    private val WIRE_DOUBLING_ORDER = arrayOf(OrePrefix.wireGtSingle,
-                                              OrePrefix.wireGtDouble,
-                                              OrePrefix.wireGtQuadruple,
-                                              OrePrefix.wireGtOctal,
-                                              OrePrefix.wireGtHex)
+    private val WIRE_DOUBLING_ORDER = arrayOf(wireGtSingle,
+                                              wireGtDouble,
+                                              wireGtQuadruple,
+                                              wireGtOctal,
+                                              wireGtHex)
 
-    private val cableToWireMap = ImmutableMap.of(OrePrefix.cableGtSingle, OrePrefix.wireGtSingle,
-                                                 OrePrefix.cableGtDouble, OrePrefix.wireGtDouble,
-                                                 OrePrefix.cableGtQuadruple, OrePrefix.wireGtQuadruple,
-                                                 OrePrefix.cableGtOctal, OrePrefix.wireGtOctal,
-                                                 OrePrefix.cableGtHex, OrePrefix.wireGtHex)
+    private val cableToWireMap = mapOf(cableGtSingle to wireGtSingle,
+                                       cableGtDouble to wireGtDouble,
+                                       cableGtQuadruple to wireGtQuadruple,
+                                       cableGtOctal to wireGtOctal,
+                                       cableGtHex to wireGtHex)
 
     fun init()
     {
-        OrePrefix.wireGtSingle.addProcessingHandler(PropertyKey.WIRE, this::processWireCompression)
+        wireGtSingle.addProcessingHandler(PropertyKey.WIRE, ::processWireCompression)
+
         for (wirePrefix in WIRE_DOUBLING_ORDER)
-            wirePrefix.addProcessingHandler(PropertyKey.WIRE, this::generateWireCombiningRecipe)
+            wirePrefix.addProcessingHandler(PropertyKey.WIRE, ::generateWireCombiningRecipe)
+
         for (cablePrefix in cableToWireMap.keys)
-            cablePrefix.addProcessingHandler(PropertyKey.WIRE, this::processCableStripping)
+            cablePrefix.addProcessingHandler(PropertyKey.WIRE, ::processCableStripping)
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.WireCombiningHandler.processWireCompression].
+     * @see gregtech.loaders.recipe.handlers.WireCombiningHandler.processWireCompression
      */
     private fun processWireCompression(wirePrefix: OrePrefix, material: Material, properties: WireProperties)
     {
@@ -65,6 +76,7 @@ object WireCombinationHandler
                     .buildAndRegister()
             }
         }
+
         for (i in 1 until 5)
         {
             LOOM_RECIPES.recipeBuilder()
@@ -79,11 +91,11 @@ object WireCombinationHandler
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.WireCombiningHandler.generateWireCombiningRecipe].
+     * @see gregtech.loaders.recipe.handlers.WireCombiningHandler.generateWireCombiningRecipe
      */
     private fun generateWireCombiningRecipe(wirePrefix: OrePrefix, material: Material, property: WireProperties)
     {
-        val wireIndex = ArrayUtils.indexOf(WIRE_DOUBLING_ORDER, wirePrefix)
+        val wireIndex = WIRE_DOUBLING_ORDER.indexOf(wirePrefix)
         if (wireIndex < WIRE_DOUBLING_ORDER.size - 1)
         {
             ModHandler.addShapelessRecipe(String.format("%s_wire_%s_doubling", material, wirePrefix),
@@ -91,12 +103,14 @@ object WireCombinationHandler
                 UnificationEntry(wirePrefix, material),
                 UnificationEntry(wirePrefix, material))
         }
+
         if (wireIndex > 0)
         {
             ModHandler.addShapelessRecipe(String.format("%s_wire_%s_splitting", material, wirePrefix),
                 OreDictUnifier.get(WIRE_DOUBLING_ORDER[wireIndex - 1], material, 2),
                 UnificationEntry(wirePrefix, material))
         }
+
         if (wireIndex < 3)
         {
             ModHandler.addShapelessRecipe(String.format("%s_wire_%s_quadrupling", material, wirePrefix),
@@ -109,15 +123,15 @@ object WireCombinationHandler
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.WireCombiningHandler.processCableStripping].
+     * @see gregtech.loaders.recipe.handlers.WireCombiningHandler.processCableStripping
      */
     private fun processCableStripping(prefix: OrePrefix, material: Material, property: WireProperties)
     {
-        RecipeMaps.PACKER_RECIPES.recipeBuilder()
+        PACKER_RECIPES.recipeBuilder()
             .input(prefix, material)
             .output(cableToWireMap[prefix], material)
-            .output(OrePrefix.plate, Materials.Rubber, (prefix.secondaryMaterials[0].amount / M).toInt())
-            .EUt(VA[ULV].toLong())
+            .output(plate, Rubber, (prefix.secondaryMaterials[0].amount / M).toInt())
+            .EUt(VA[ULV])
             .duration(5 * SECOND)
             .buildAndRegister()
     }

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireRecipeHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireRecipeHandler.kt
@@ -36,7 +36,7 @@ import gregtechlite.gtlitecore.api.SECOND
 import gregtechlite.gtlitecore.api.extension.EUt
 import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps.LAMINATOR_RECIPES
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CosmicFabric
-import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Omnium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.DimensionallyShiftedSuperfluid
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Polyetheretherketone
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolyphosphonitrileFluoroRubber
 import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolytetramethyleneGlycolRubber
@@ -215,7 +215,7 @@ object WireRecipeHandler
                 .input(foil, Zylon, insulationAmount)
                 .input(POLYMER_INSULATOR_FOIL, insulationAmount)
                 .fluidInputs(CosmicFabric.getFluid(L * insulationAmount / 2))
-                .fluidInputs(Omnium.getFluid(L * insulationAmount / 2))
+                .fluidInputs(DimensionallyShiftedSuperfluid.getFluid(1000 * insulationAmount / 2))
                 .output(cablePrefix, material)
                 .EUt(VA[ULV])
                 .duration(5 * SECOND)

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireRecipeHandler.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/handler/WireRecipeHandler.kt
@@ -1,62 +1,84 @@
 package gregtechlite.gtlitecore.loader.recipe.handler
 
-import com.google.common.collect.ImmutableMap
 import gregtech.api.GTValues.EV
 import gregtech.api.GTValues.L
 import gregtech.api.GTValues.LV
 import gregtech.api.GTValues.LuV
 import gregtech.api.GTValues.M
+import gregtech.api.GTValues.MAX
 import gregtech.api.GTValues.OpV
 import gregtech.api.GTValues.UEV
 import gregtech.api.GTValues.ULV
 import gregtech.api.GTValues.UV
 import gregtech.api.GTValues.VA
 import gregtech.api.unification.material.Material
-import gregtech.api.unification.material.Materials
+import gregtech.api.unification.material.Materials.PolyphenyleneSulfide
+import gregtech.api.unification.material.Materials.PolyvinylChloride
+import gregtech.api.unification.material.Materials.Rubber
 import gregtech.api.unification.material.Materials.SiliconeRubber
+import gregtech.api.unification.material.Materials.StyreneButadieneRubber
 import gregtech.api.unification.material.properties.PropertyKey
 import gregtech.api.unification.material.properties.WireProperties
 import gregtech.api.unification.ore.OrePrefix
+import gregtech.api.unification.ore.OrePrefix.cableGtDouble
+import gregtech.api.unification.ore.OrePrefix.cableGtHex
+import gregtech.api.unification.ore.OrePrefix.cableGtOctal
+import gregtech.api.unification.ore.OrePrefix.cableGtQuadruple
+import gregtech.api.unification.ore.OrePrefix.cableGtSingle
+import gregtech.api.unification.ore.OrePrefix.foil
+import gregtech.api.unification.ore.OrePrefix.wireGtDouble
+import gregtech.api.unification.ore.OrePrefix.wireGtHex
+import gregtech.api.unification.ore.OrePrefix.wireGtOctal
+import gregtech.api.unification.ore.OrePrefix.wireGtQuadruple
+import gregtech.api.unification.ore.OrePrefix.wireGtSingle
 import gregtech.api.util.GTUtility
-import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps
-import gregtechlite.gtlitecore.api.unification.GTLiteMaterials
 import gregtechlite.gtlitecore.api.SECOND
+import gregtechlite.gtlitecore.api.extension.EUt
+import gregtechlite.gtlitecore.api.recipe.GTLiteRecipeMaps.LAMINATOR_RECIPES
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.CosmicFabric
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Omnium
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Polyetheretherketone
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolyphosphonitrileFluoroRubber
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.PolytetramethyleneGlycolRubber
+import gregtechlite.gtlitecore.api.unification.GTLiteMaterials.Zylon
+import gregtechlite.gtlitecore.common.item.GTLiteMetaItems.POLYMER_INSULATOR_FOIL
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.isAccessible
+import gregtech.loaders.recipe.handlers.WireRecipeHandler as GTWireRecipeHandler
 
-// Callback original registrate of wire processing handler and post new
-// processing handler from this recipe handler container.
 object WireRecipeHandler
 {
 
     // @formatter:off
-    private val INSULATION_AMOUNT = ImmutableMap.of(OrePrefix.cableGtSingle, 1,
-                                                    OrePrefix.cableGtDouble, 1,
-                                                    OrePrefix.cableGtQuadruple, 2,
-                                                    OrePrefix.cableGtOctal, 3,
-                                                    OrePrefix.cableGtHex, 5)
+
+    private val INSULATION_AMOUNT = mapOf(cableGtSingle to 1,
+                                          cableGtDouble to 1,
+                                          cableGtQuadruple to 2,
+                                          cableGtOctal to 3,
+                                          cableGtHex to 5)
 
     fun init()
     {
-        OrePrefix.wireGtSingle.addProcessingHandler(PropertyKey.WIRE, this::generateCableCovering)
-        OrePrefix.wireGtDouble.addProcessingHandler(PropertyKey.WIRE, this::generateCableCovering)
-        OrePrefix.wireGtQuadruple.addProcessingHandler(PropertyKey.WIRE, this::generateCableCovering)
-        OrePrefix.wireGtOctal.addProcessingHandler(PropertyKey.WIRE, this::generateCableCovering)
-        OrePrefix.wireGtHex.addProcessingHandler(PropertyKey.WIRE, this::generateCableCovering)
+        wireGtSingle.addProcessingHandler(PropertyKey.WIRE, ::generateCableCovering)
+        wireGtDouble.addProcessingHandler(PropertyKey.WIRE, ::generateCableCovering)
+        wireGtQuadruple.addProcessingHandler(PropertyKey.WIRE, ::generateCableCovering)
+        wireGtOctal.addProcessingHandler(PropertyKey.WIRE, ::generateCableCovering)
+        wireGtHex.addProcessingHandler(PropertyKey.WIRE, ::generateCableCovering)
     }
 
     /**
-     * Transformed from [gregtech.loaders.recipe.handlers.WireRecipeHandler.generateCableCovering].
+     * @see gregtech.loaders.recipe.handlers.WireRecipeHandler.generateCableCovering
      */
     private fun generateCableCovering(wirePrefix: OrePrefix, material: Material, properties: WireProperties)
     {
-        // Do Kt Reflect to make original class's generateManualRecipe() function public.
-        val targetMethod = gregtech.loaders.recipe.handlers.WireRecipeHandler::class
-                .declaredFunctions.find { it.name == "generateManualRecipe" }
-                    ?: throw IllegalArgumentException("Method 'generateManualRecipe()' is not found in target class [gregtech.loaders.recipe.handlers.WireRecipeHandler]")
-        targetMethod.isAccessible = true
+        // Let common generation method be accessible and prepare to call for below recipe generations.
+        val generateManualRecipe = GTWireRecipeHandler::class
+            .declaredFunctions.find { it.name == "generateManualRecipe" }
+            ?: throw IllegalArgumentException("Method 'generateManualRecipe' is not found in target class")
 
-        // Superconductors have no cables, so exit early lazy.
+        generateManualRecipe.isAccessible = true
+
+        // All superconductors does not have cable forms, so skip them.
         if (properties.isSuperconductor)
             return
 
@@ -67,99 +89,139 @@ object WireRecipeHandler
 
         // Generate hand-crafting recipes for ULV and LV cables.
         if (voltageTier <= LV)
-            targetMethod.call(wirePrefix, material, cablePrefix, cableAmount)
+            generateManualRecipe.call(wirePrefix, material, cablePrefix, cableAmount)
+
         // Rubber recipe (for ULV-EV cables)
         if (voltageTier <= EV)
         {
-            val builder = GTLiteRecipeMaps.LAMINATOR_RECIPES.recipeBuilder()
+            val builder = LAMINATOR_RECIPES.recipeBuilder()
                 .input(wirePrefix, material)
-                .fluidInputs(Materials.Rubber.getFluid(L * insulationAmount))
+                .fluidInputs(Rubber.getFluid(L * insulationAmount))
                 .output(cablePrefix, material)
-                .EUt(VA[ULV].toLong())
+                .EUt(VA[ULV])
                 .duration(5 * SECOND)
+
             // Apply PVC foil for EV cables.
             if (voltageTier == EV)
-                builder.input(OrePrefix.foil, Materials.PolyvinylChloride, insulationAmount)
+                builder.input(foil, PolyvinylChloride, insulationAmount)
+
             builder.buildAndRegister()
         }
+
         // Synthetic Rubber recipe (for EV-UV cables).
         if (voltageTier <= UV)
         {
             // Silicone Rubber recipes.
-            var builder = GTLiteRecipeMaps.LAMINATOR_RECIPES.recipeBuilder()
+            var builder = LAMINATOR_RECIPES.recipeBuilder()
                 .input(wirePrefix, material)
                 .output(cablePrefix, material)
-                .EUt(VA[ULV].toLong())
+                .EUt(VA[ULV])
                 .duration(5 * SECOND)
+
             // Apply PVC foil for EV or above cables.
             if (voltageTier >= EV)
-                builder.input(OrePrefix.foil, Materials.PolyvinylChloride, insulationAmount)
+                builder.input(foil, PolyvinylChloride, insulationAmount)
+
             // Apply PPS foil for LuV or above cables.
             if (voltageTier >= LuV)
-                builder.input(OrePrefix.foil, Materials.PolyphenyleneSulfide, insulationAmount)
+                builder.input(foil, PolyphenyleneSulfide, insulationAmount)
+
             builder.fluidInputs(SiliconeRubber.getFluid(L * insulationAmount / 2))
                 .buildAndRegister()
 
             // Styrene Butadiene Rubber recipes.
-            builder = GTLiteRecipeMaps.LAMINATOR_RECIPES.recipeBuilder()
+            builder = LAMINATOR_RECIPES.recipeBuilder()
                 .input(wirePrefix, material)
                 .output(cablePrefix, material)
-                .EUt(VA[ULV].toLong())
+                .EUt(VA[ULV])
                 .duration(5 * SECOND)
+
             // Apply PVC foil for EV or above cables.
             if (voltageTier >= EV)
-                builder.input(OrePrefix.foil, Materials.PolyvinylChloride, insulationAmount)
+                builder.input(foil, PolyvinylChloride, insulationAmount)
+
             // Apply PPS foil for LuV or above cables.
             if (voltageTier >= LuV)
-                builder.input(OrePrefix.foil, Materials.PolyphenyleneSulfide, insulationAmount)
-            builder.fluidInputs(Materials.StyreneButadieneRubber.getFluid(L * insulationAmount / 4))
+                builder.input(foil, PolyphenyleneSulfide, insulationAmount)
+
+            builder.fluidInputs(StyreneButadieneRubber.getFluid(L * insulationAmount / 4))
                 .buildAndRegister()
         }
+
         // Advanced Synthetic Rubber recipe (for UHV-OpV cables)
         if (voltageTier <= OpV)
         {
             // PTMEG Rubber recipes.
-            var builder = GTLiteRecipeMaps.LAMINATOR_RECIPES.recipeBuilder()
+            var builder = LAMINATOR_RECIPES.recipeBuilder()
                 .input(wirePrefix, material)
                 .output(cablePrefix, material)
-                .EUt(VA[ULV].toLong())
+                .EUt(VA[ULV])
                 .duration(5 * SECOND)
+
             // Apply PVC foil for EV or above cables.
             if (voltageTier >= EV)
-                builder.input(OrePrefix.foil, Materials.PolyvinylChloride, insulationAmount)
+                builder.input(foil, PolyvinylChloride, insulationAmount)
+
             // Apply PPS foil for LuV or above cables.
             if (voltageTier >= LuV)
-                builder.input(OrePrefix.foil, Materials.PolyphenyleneSulfide, insulationAmount)
+                builder.input(foil, PolyphenyleneSulfide, insulationAmount)
+
             // Apply PEEK foil for UV or above cables.
             if (voltageTier >= UV)
-                builder.input(OrePrefix.foil, GTLiteMaterials.Polyetheretherketone, insulationAmount)
+                builder.input(foil, Polyetheretherketone, insulationAmount)
+
             // Apply Zylon foil for UEV or above cables.
             if (voltageTier >= UEV)
-                builder.input(OrePrefix.foil, GTLiteMaterials.Zylon, insulationAmount)
-            builder.fluidInputs(GTLiteMaterials.PolytetramethyleneGlycolRubber.getFluid(L * insulationAmount / 2))
+                builder.input(foil, Zylon, insulationAmount)
+
+            builder.fluidInputs(PolytetramethyleneGlycolRubber.getFluid(L * insulationAmount / 2))
                 .buildAndRegister()
 
             // PPF Rubber recipes.
-            builder = GTLiteRecipeMaps.LAMINATOR_RECIPES.recipeBuilder()
+            builder = LAMINATOR_RECIPES.recipeBuilder()
                 .input(wirePrefix, material)
                 .output(cablePrefix, material)
-                .EUt(VA[ULV].toLong())
+                .EUt(VA[ULV])
                 .duration(5 * SECOND)
+
             // Apply PVC foil for EV or above cables.
             if (voltageTier >= EV)
-                builder.input(OrePrefix.foil, Materials.PolyvinylChloride, insulationAmount)
+                builder.input(foil, PolyvinylChloride, insulationAmount)
+
             // Apply PPS foil for LuV or above cables.
             if (voltageTier >= LuV)
-                builder.input(OrePrefix.foil, Materials.PolyphenyleneSulfide, insulationAmount)
+                builder.input(foil, PolyphenyleneSulfide, insulationAmount)
+
             // Apply PEEK foil for UV or above cables.
             if (voltageTier >= UV)
-                builder.input(OrePrefix.foil, GTLiteMaterials.Polyetheretherketone, insulationAmount)
+                builder.input(foil, Polyetheretherketone, insulationAmount)
+
             // Apply Zylon foil for UEV or above cables.
             if (voltageTier >= UEV)
-                builder.input(OrePrefix.foil, GTLiteMaterials.Zylon, insulationAmount)
-            builder.fluidInputs(GTLiteMaterials.PolyphosphonitrileFluoroRubber.getFluid(L * insulationAmount / 4))
+                builder.input(foil, Zylon, insulationAmount)
+
+            builder.fluidInputs(PolyphosphonitrileFluoroRubber.getFluid(L * insulationAmount / 4))
                 .buildAndRegister()
         }
+
+        // Final recipes for the endgame (for MAX cables).
+        if (voltageTier == MAX)
+        {
+            LAMINATOR_RECIPES.recipeBuilder()
+                .input(wirePrefix, material)
+                .input(foil, PolyvinylChloride, insulationAmount)
+                .input(foil, PolyphenyleneSulfide, insulationAmount)
+                .input(foil, Polyetheretherketone, insulationAmount)
+                .input(foil, Zylon, insulationAmount)
+                .input(POLYMER_INSULATOR_FOIL, insulationAmount)
+                .fluidInputs(CosmicFabric.getFluid(L * insulationAmount / 2))
+                .fluidInputs(Omnium.getFluid(L * insulationAmount / 2))
+                .output(cablePrefix, material)
+                .EUt(VA[ULV])
+                .duration(5 * SECOND)
+                .buildAndRegister()
+        }
+
     }
 
     // @formatter:on


### PR DESCRIPTION
This PR clean up all recipe handlers, deleted some fluid solidifier recipes which be duplicated because GTCEu added some new molds.

Also added MAX-tier wireGtX and cableGtX  recipes for the handler.