### PR TITLE
fix: Make drain cover be workable with correct neighbor block

### DIFF
--- a/src/main/kotlin/gregtechlite/gtlitecore/common/cover/behavior/CoverDrain.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/common/cover/behavior/CoverDrain.kt
@@ -49,7 +49,7 @@ class CoverDrain(definition: CoverDefinition,
         val fluidHandler =
             tileEntityHere?.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, attachedSide) ?: return
 
-        if (neighborBlock == Blocks.WATER.defaultState || neighborBlock == Blocks.FLOWING_WATER.defaultState)
+        if (neighborBlock.block == Blocks.WATER || neighborBlock.block == Blocks.FLOWING_WATER)
         {
             fluidHandler.fill(this.waterStack.copy(), true)
         }


### PR DESCRIPTION
这里似乎多了一个opposite，导致正常配置不工作，某种看起来很奇怪的配置反而可以工作