### PR TITLE
chore: Update Retro Futura Gradle to the latest 1.X version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ betterQuestingUnofficial = "5875712" # 4.2.6
 
 # Plugins
 ideaExt = "1.1.7"
-retrofuturaGradle = "1.3.27"
+retrofuturaGradle = "1.4.9"
 curseGradle = "1.4.0"
 dokka = "1.9.10"
 shadow = "7.1.2"


### PR DESCRIPTION
GTNH Team delete the old package from GTNH maven, upgrade it to the latest 1.X version