### PR TITLE
fix: Disable ender pearl dust extraction & remove unnecessary solitary gems

### DIFF
--- a/src/main/kotlin/gregtechlite/gtlitecore/api/unification/ore/GTLiteOrePrefix.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/api/unification/ore/GTLiteOrePrefix.kt
@@ -2,9 +2,16 @@ package gregtechlite.gtlitecore.api.unification.ore
 
 import gregtech.api.GTValues.M
 import gregtech.api.unification.material.Material
+import gregtech.api.unification.material.Materials.Charcoal
+import gregtech.api.unification.material.Materials.EnderEye
+import gregtech.api.unification.material.Materials.EnderPearl
+import gregtech.api.unification.material.Materials.Flint
 import gregtech.api.unification.material.Materials.Graphite
+import gregtech.api.unification.material.Materials.Lapotron
+import gregtech.api.unification.material.Materials.NetherStar
 import gregtech.api.unification.material.Materials.Quartzite
 import gregtech.api.unification.material.Materials.Steel
+import gregtech.api.unification.material.Materials.Sugar
 import gregtech.api.unification.material.info.MaterialFlags.GENERATE_BOLT_SCREW
 import gregtech.api.unification.material.info.MaterialFlags.GENERATE_FRAME
 import gregtech.api.unification.material.info.MaterialFlags.GENERATE_PLATE
@@ -322,6 +329,14 @@ object GTLiteOrePrefix
         fuelRodEnrichedDepleted.setIgnored(Graphite)
 
         fuelRodHighDensityDepleted.setIgnored(Graphite)
+
+        gemSolitary.setIgnored(Charcoal)
+        gemSolitary.setIgnored(EnderPearl)
+        gemSolitary.setIgnored(EnderEye)
+        gemSolitary.setIgnored(Flint)
+        gemSolitary.setIgnored(Lapotron)
+        gemSolitary.setIgnored(NetherStar)
+        gemSolitary.setIgnored(Sugar)
 
         // endregion
     }

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/machine/ExtractorRecipes.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/machine/ExtractorRecipes.kt
@@ -1,0 +1,23 @@
+package gregtechlite.gtlitecore.loader.recipe.machine
+
+import gregtech.api.recipes.GTRecipeHandler
+import gregtech.api.recipes.RecipeMaps.EXTRACTOR_RECIPES
+import gregtech.api.unification.OreDictUnifier
+import gregtech.api.unification.material.Materials.EnderPearl
+import gregtech.api.unification.ore.OrePrefix.dust
+
+internal object ExtractorRecipes
+{
+
+    // @formatter:off
+
+    fun init()
+    {
+        // Remove duplicated endear pearl dust extraction.
+        GTRecipeHandler.removeRecipesByInputs(EXTRACTOR_RECIPES,
+            OreDictUnifier.get(dust, EnderPearl))
+    }
+
+    // @formatter:on
+
+}

--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/machine/MachineRecipeList.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/machine/MachineRecipeList.kt
@@ -19,6 +19,7 @@ internal object MachineRecipeList
         CutterRecipes.init()
         DistilleryRecipes.init()
         ElectricBlastFurnaceRecipes.init()
+        ExtractorRecipes.init()
         ExtruderRecipes.init()
         FluidSolidifierRecipes.init()
         FormingPressRecipes.init()


### PR DESCRIPTION
This PR disabled the extractor recycling recipe of *Ender Pearl dust*, and remove all unnecessary solitary gem generation for meta items, consists of:
- Charcoal
- Ender Pearl
- Ender Eye
- Flint
- Lapotron
- Nether Star
- Sugar