### PR TITLE
fix: Let Ethane output amount be correct in Hydro-Cracked Ethylene distillation

### DIFF
--- a/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/chain/OilsChain.kt
+++ b/src/main/kotlin/gregtechlite/gtlitecore/loader/recipe/chain/OilsChain.kt
@@ -157,7 +157,7 @@ internal object OilsChain
         DISTILLATION_RECIPES.addRecipe {
             fluidInputs(HydroCrackedEthylene.getFluid(1000))
             fluidOutputs(Carbon5Fraction.getFluid(200))
-            fluidOutputs(Ethane.getFluid(8000)) // C2H6
+            fluidOutputs(Ethane.getFluid(800)) // C2H6
             EUt(VA[MV])
             duration(6 * SECOND)
         }


### PR DESCRIPTION
Due [**Modpack Issue #38**](https://github.com/GregTechLite/GregTech-Lite-Modpack/issues/38), this is just a little typo when I wrote these recipes :(